### PR TITLE
fix: 인터렉션 컴포넌트 수정 및 storybook 설정 

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -10,6 +10,9 @@ const preview: Preview = {
         date: /Date$/i,
       },
     },
+    backgrounds: {
+      default: 'dark',
+    },
   },
 };
 

--- a/src/components/common/Badge.stories.tsx
+++ b/src/components/common/Badge.stories.tsx
@@ -15,11 +15,7 @@ const meta: Meta<typeof Badge> = {
 
 export default meta;
 
-type Story = StoryObj<{
-  text: string;
-  backgroundColor: string;
-  textColor: string;
-}>;
+type Story = StoryObj<typeof Badge>;
 
 export const Primary: Story = {
   args: {

--- a/src/components/common/Badge.stories.tsx
+++ b/src/components/common/Badge.stories.tsx
@@ -17,10 +17,29 @@ export default meta;
 
 type Story = StoryObj<typeof Badge>;
 
-export const Primary: Story = {
+export const Default: Story = {
   args: {
     children: '레이블',
     backgroundColor: 'bg-feedback-trans-information-dark',
     textColor: 'text-feedback-information-dark',
+  },
+};
+
+export const Primary: Story = {
+  name: 'Badge',
+  render: () => {
+    return (
+      <div className='gap-xs flex'>
+        <Badge backgroundColor='bg-fill-assistive-dark' textColor='text-object-normal-dark'>
+          레이블1
+        </Badge>
+        <Badge
+          backgroundColor='bg-feedback-trans-information-dark'
+          textColor='text-feedback-information-dark'
+        >
+          레이블2
+        </Badge>
+      </div>
+    );
   },
 };

--- a/src/components/common/Badge.stories.tsx
+++ b/src/components/common/Badge.stories.tsx
@@ -7,7 +7,7 @@ const meta: Meta<typeof Badge> = {
   component: Badge,
   tags: ['autodocs'],
   argTypes: {
-    text: { control: 'text', description: 'Badge에 들어갈 텍스트' },
+    children: { control: 'text', description: 'Badge에 들어갈 텍스트' },
     backgroundColor: { control: 'color', description: '배경색' },
     textColor: { control: 'color', description: '폰트 색상' },
   },
@@ -19,7 +19,7 @@ type Story = StoryObj<typeof Badge>;
 
 export const Primary: Story = {
   args: {
-    text: '레이블',
+    children: '레이블',
     backgroundColor: 'bg-feedback-trans-information-dark',
     textColor: 'text-feedback-information-dark',
   },

--- a/src/components/common/Badge.tsx
+++ b/src/components/common/Badge.tsx
@@ -1,16 +1,18 @@
+import { ReactNode } from 'react';
+
 import Label from './Label';
 
 interface BadgeProps {
-  text: string;
+  children: ReactNode;
   backgroundColor: string;
   textColor: string;
 }
 
-function Badge({ text, backgroundColor, textColor }: BadgeProps) {
+function Badge({ children, backgroundColor, textColor }: BadgeProps) {
   return (
     <div className={`radius-2xs ${backgroundColor} inline-block px-(--gap-xs) py-(--gap-5xs)`}>
       <Label hierarchy='stronger' weight='normal' textColor={textColor}>
-        {text}
+        {children}
       </Label>
     </div>
   );

--- a/src/components/common/Badge.tsx
+++ b/src/components/common/Badge.tsx
@@ -9,7 +9,9 @@ interface BadgeProps {
 function Badge({ text, backgroundColor, textColor }: BadgeProps) {
   return (
     <div className={`radius-2xs ${backgroundColor} inline-block px-(--gap-xs) py-(--gap-5xs)`}>
-      <Label hierarchy='stronger' weight='normal' text={text} textColor={textColor} />
+      <Label hierarchy='stronger' weight='normal' textColor={textColor}>
+        {text}
+      </Label>
     </div>
   );
 }

--- a/src/components/common/Interaction.stories.tsx
+++ b/src/components/common/Interaction.stories.tsx
@@ -45,36 +45,48 @@ export default meta;
 
 type Story = StoryObj<typeof Interaction>;
 
-export const BackgroundColor: Story = {
+export const Default: Story = {
   args: {
     children: (
       <button
-        className={`radius-circle bg-accent-normal-dark border-border-hero-dark text-object-hero-dark h-[44px] px-(--gap-lg) py-(--gap-2xs)`}
+        className={`radius-circle border-border-hero-dark text-object-hero-dark h-[44px] px-(--gap-lg) py-(--gap-2xs)`}
       >
-        배경색 있는 요소
+        Button
       </button>
     ),
-
     variant: 'brand',
     density: 'bold',
-    childHasBg: true,
+    childHasBg: false,
     childRadius: 'radius-circle',
   },
 };
 
-export const NoBackgroundColor: Story = {
-  args: {
-    children: (
-      <button
-        className={`radius-lg text-object-neutral-dark border-border-hero-dark h-[44px] border px-(--gap-lg) py-(--gap-2xs)`}
-      >
-        배경색 없는 요소
-      </button>
-    ),
+export const BackgroundColor: Story = {
+  name: 'HasBackgroundColor',
+  render: () => {
+    return (
+      <Interaction variant='brand' density='bold' childHasBg={true} childRadius='radius-circle'>
+        <button
+          className={`radius-circle bg-accent-normal-dark border-border-hero-dark text-object-hero-dark h-[44px] px-(--gap-lg) py-(--gap-2xs)`}
+        >
+          배경색 있는 요소
+        </button>
+      </Interaction>
+    );
+  },
+};
 
-    variant: 'default',
-    density: 'subtle',
-    childHasBg: false,
-    childRadius: 'radius-lg',
+export const NoBackgroundColor: Story = {
+  name: 'NoBackgroundColor',
+  render: () => {
+    return (
+      <Interaction variant='default' density='subtle' childHasBg={false} childRadius='radius-lg'>
+        <button
+          className={`radius-lg text-object-neutral-dark border-border-hero-dark h-[44px] border px-(--gap-lg) py-(--gap-2xs)`}
+        >
+          배경색 없는 요소
+        </button>
+      </Interaction>
+    );
   },
 };

--- a/src/components/common/Interaction.stories.tsx
+++ b/src/components/common/Interaction.stories.tsx
@@ -8,7 +8,8 @@ const meta: Meta<typeof Interaction> = {
   tags: ['autodocs'],
   argTypes: {
     children: {
-      description: '인터렉션 효과가 필요한 컴포넌트입니다. 해당 요소를 Interaction으로 감쌉니다.',
+      description:
+        '인터렉션 효과가 필요한 컴포넌트입니다. 해당 요소를 Interaction으로 감쌉니다. <br>',
     },
     variant: {
       control: 'radio',
@@ -19,24 +20,6 @@ const meta: Meta<typeof Interaction> = {
       control: 'radio',
       description: '피그마에 정의된 density 속성입니다.',
       options: ['bold', 'normal', 'subtle'],
-    },
-    childHasBg: {
-      control: 'boolean',
-      description: '자식 요소에 배경색이 있다면 true, 없다면 false를 넘겨줍니다.',
-    },
-    childRadius: {
-      control: 'select',
-      description: 'Interaction으로 감싸는 자식요소의 radius와 동일해야합니다.',
-      options: [
-        'radius-4xs',
-        'radius-3xs',
-        'radius-2xs',
-        'radius-xs',
-        'radius-sm',
-        'radius-md',
-        'radius-lg',
-        'radius-circle',
-      ],
     },
   },
 };
@@ -56,8 +39,6 @@ export const Default: Story = {
     ),
     variant: 'brand',
     density: 'bold',
-    childHasBg: false,
-    childRadius: 'radius-circle',
   },
 };
 
@@ -65,7 +46,7 @@ export const BackgroundColor: Story = {
   name: 'HasBackgroundColor',
   render: () => {
     return (
-      <Interaction variant='brand' density='bold' childHasBg={true} childRadius='radius-circle'>
+      <Interaction variant='brand' density='bold'>
         <button
           className={`radius-circle bg-accent-normal-dark border-border-hero-dark text-object-hero-dark h-[44px] px-(--gap-lg) py-(--gap-2xs)`}
         >
@@ -80,7 +61,7 @@ export const NoBackgroundColor: Story = {
   name: 'NoBackgroundColor',
   render: () => {
     return (
-      <Interaction variant='default' density='subtle' childHasBg={false} childRadius='radius-lg'>
+      <Interaction variant='default' density='subtle'>
         <button
           className={`radius-lg text-object-neutral-dark border-border-hero-dark h-[44px] border px-(--gap-lg) py-(--gap-2xs)`}
         >

--- a/src/components/common/Interaction.stories.tsx
+++ b/src/components/common/Interaction.stories.tsx
@@ -22,6 +22,7 @@ const meta: Meta<typeof Interaction> = {
     },
     childHasBg: {
       control: 'boolean',
+      description: '자식 요소에 배경색이 있다면 true, 없다면 false를 넘겨줍니다.',
     },
     childRadius: {
       control: 'select',

--- a/src/components/common/Interaction.stories.tsx
+++ b/src/components/common/Interaction.stories.tsx
@@ -11,17 +11,20 @@ const meta: Meta<typeof Interaction> = {
       description: '인터렉션 효과가 필요한 컴포넌트입니다. 해당 요소를 Interaction으로 감쌉니다.',
     },
     variant: {
-      control: { type: 'radio' },
+      control: 'radio',
       description: '피그마에 정의된 variant 속성입니다.',
       options: ['default', 'brand'],
     },
     density: {
-      control: { type: 'radio' },
+      control: 'radio',
       description: '피그마에 정의된 density 속성입니다.',
       options: ['bold', 'normal', 'subtle'],
     },
-    radius: {
-      control: { type: 'select' },
+    childHasBg: {
+      control: 'boolean',
+    },
+    childRadius: {
+      control: 'select',
       description: 'Interaction으로 감싸는 자식요소의 radius와 동일해야합니다.',
       options: [
         'radius-4xs',
@@ -41,18 +44,36 @@ export default meta;
 
 type Story = StoryObj<typeof Interaction>;
 
-// Default - Normal
-export const Default: Story = {
+export const BackgroundColor: Story = {
   args: {
     children: (
       <button
-        className={`radius-circle h-[44px] border border-blue-200 px-(--gap-lg) py-(--gap-2xs) text-black`}
+        className={`radius-circle bg-accent-normal-dark border-border-hero-dark text-object-hero-dark h-[44px] px-(--gap-lg) py-(--gap-2xs)`}
       >
-        레이블
+        배경색 있는 요소
       </button>
     ),
+
+    variant: 'brand',
+    density: 'bold',
+    childHasBg: true,
+    childRadius: 'radius-circle',
+  },
+};
+
+export const NoBackgroundColor: Story = {
+  args: {
+    children: (
+      <button
+        className={`radius-lg text-object-neutral-dark border-border-hero-dark h-[44px] border px-(--gap-lg) py-(--gap-2xs)`}
+      >
+        배경색 없는 요소
+      </button>
+    ),
+
     variant: 'default',
-    density: 'normal',
-    radius: 'radius-circle',
+    density: 'subtle',
+    childHasBg: false,
+    childRadius: 'radius-lg',
   },
 };

--- a/src/components/common/Interaction.tsx
+++ b/src/components/common/Interaction.tsx
@@ -1,3 +1,5 @@
+import { ReactNode } from 'react';
+
 import { Density, interactionStyle, Variant } from '@/styles/interactionStyle';
 
 type Radius =
@@ -11,7 +13,7 @@ type Radius =
   | 'radius-circle';
 
 interface InteractionProps {
-  children: React.ReactNode;
+  children: ReactNode;
   variant: Variant;
   density: Density;
   childHasBg: boolean;

--- a/src/components/common/Interaction.tsx
+++ b/src/components/common/Interaction.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from 'react';
+import { ReactElement } from 'react';
 
 import { Density, interactionStyle, Variant } from '@/styles/interactionStyle';
 
@@ -13,17 +13,21 @@ type Radius =
   | 'radius-circle';
 
 interface InteractionProps {
-  children: ReactNode;
+  children: ReactElement<HTMLElement>;
   variant: Variant;
   density: Density;
-  childHasBg: boolean;
-  childRadius?: Radius;
 }
 
-function Interaction({ children, variant, density, childHasBg, childRadius }: InteractionProps) {
+function Interaction({ children, variant, density }: InteractionProps) {
   const bgColor = interactionStyle.variant[variant].density[density].bgColor;
   const opacity = interactionStyle.variant[variant].density[density].opacity;
   const bgRgba = interactionStyle.variant[variant].density[density].bgRgba;
+
+  const classNames = children.props.className.split(' ');
+  const childHasBg = classNames.filter(classname => classname.includes('bg-'))[0];
+  const childRadius = classNames.filter(classname => classname.includes('radius'))[0] as
+    | Radius
+    | undefined;
 
   return (
     <div>

--- a/src/components/common/Interaction.tsx
+++ b/src/components/common/Interaction.tsx
@@ -14,17 +14,19 @@ interface InteractionProps {
   children: React.ReactNode;
   variant: Variant;
   density: Density;
-  radius?: Radius;
+  childHasBg: boolean;
+  childRadius?: Radius;
 }
 
-function Interaction({ children, variant, density, radius }: InteractionProps) {
-  const background = interactionStyle.variant[variant].density[density].bgColor;
+function Interaction({ children, variant, density, childHasBg, childRadius }: InteractionProps) {
+  const bgColor = interactionStyle.variant[variant].density[density].bgColor;
   const opacity = interactionStyle.variant[variant].density[density].opacity;
+  const bgRgba = interactionStyle.variant[variant].density[density].bgRgba;
 
   return (
     <div>
       <div
-        className={`${background} ${opacity} ${radius || ''} *:focus-visible:outline-interactive-focus-dark *:focus-visible:hover:opacity-visible inline-block *:focus-visible:outline-4`}
+        className={`${childHasBg ? bgColor : bgRgba} ${childHasBg ? opacity : ''} ${childRadius || ''} *:focus-visible:outline-interactive-focus-dark *:focus-visible:hover:opacity-visible inline-block *:focus-visible:outline-4`}
       >
         {children}
       </div>

--- a/src/components/common/Label.stories.tsx
+++ b/src/components/common/Label.stories.tsx
@@ -9,16 +9,17 @@ const meta: Meta<typeof Label> = {
   component: Label,
   tags: ['autodocs'],
   argTypes: {
-    weight: {
-      control: 'radio',
-      options: ['normal', 'bold'],
+    children: {
+      control: 'text',
+      description: 'Label에 들어갈 텍스트입니다.',
     },
     hierarchy: {
       control: 'radio',
       options: ['stronger', 'strong', 'normal', 'weak'],
     },
-    text: {
-      control: 'text',
+    weight: {
+      control: 'radio',
+      options: ['normal', 'bold'],
     },
     textColor: {
       control: 'color',
@@ -34,19 +35,19 @@ const meta: Meta<typeof Label> = {
 export default meta;
 
 type Story = StoryObj<{
+  children: React.ReactNode;
   hierarchy: Hierarchy;
   weight: Weight;
-  text: string;
   textColor: string;
   isRequired?: boolean;
 }>;
 
 export const Primary: Story = {
   args: {
+    children: '레이블',
+    hierarchy: 'stronger',
     weight: 'normal',
-    hierarchy: 'weak',
-    textColor: '#000',
-    text: '레이블',
+    textColor: 'text-object-neutral-dark',
     isRequired: true,
   },
 };

--- a/src/components/common/Label.stories.tsx
+++ b/src/components/common/Label.stories.tsx
@@ -2,8 +2,6 @@ import { Meta, StoryObj } from '@storybook/react';
 
 import Label from './Label';
 
-import { Hierarchy, Weight } from '@/styles/labelStyle';
-
 const meta: Meta<typeof Label> = {
   title: 'Components/Label',
   component: Label,
@@ -34,13 +32,7 @@ const meta: Meta<typeof Label> = {
 
 export default meta;
 
-type Story = StoryObj<{
-  children: React.ReactNode;
-  hierarchy: Hierarchy;
-  weight: Weight;
-  textColor: string;
-  isRequired?: boolean;
-}>;
+type Story = StoryObj<typeof Label>;
 
 export const Primary: Story = {
   args: {

--- a/src/components/common/Label.stories.tsx
+++ b/src/components/common/Label.stories.tsx
@@ -34,12 +34,55 @@ export default meta;
 
 type Story = StoryObj<typeof Label>;
 
-export const Primary: Story = {
+export const Default: Story = {
   args: {
     children: '레이블',
     hierarchy: 'stronger',
     weight: 'normal',
     textColor: 'text-object-neutral-dark',
     isRequired: true,
+  },
+};
+
+export const Labels: Story = {
+  render: () => {
+    return (
+      <div className='gap-lg flex'>
+        <div>
+          <Label
+            hierarchy='stronger'
+            weight='normal'
+            textColor='text-object-neutral-dark'
+            isRequired={true}
+          >
+            레이블
+          </Label>
+          <Label
+            hierarchy='strong'
+            weight='normal'
+            textColor='text-object-neutral-dark'
+            isRequired={false}
+          >
+            레이블
+          </Label>
+          <Label
+            hierarchy='normal'
+            weight='normal'
+            textColor='text-object-neutral-dark'
+            isRequired={true}
+          >
+            레이블
+          </Label>
+          <Label
+            hierarchy='weak'
+            weight='normal'
+            textColor='text-object-neutral-dark'
+            isRequired={false}
+          >
+            레이블
+          </Label>
+        </div>
+      </div>
+    );
   },
 };

--- a/src/components/common/Label.tsx
+++ b/src/components/common/Label.tsx
@@ -1,7 +1,9 @@
+import { ReactNode } from 'react';
+
 import { Hierarchy, labelStyle, Weight } from '@/styles/labelStyle';
 
 interface LabelProps {
-  children: React.ReactNode;
+  children: ReactNode;
   hierarchy: Hierarchy;
   weight: Weight;
   textColor: string;

--- a/src/components/common/Label.tsx
+++ b/src/components/common/Label.tsx
@@ -1,20 +1,20 @@
 import { Hierarchy, labelStyle, Weight } from '@/styles/labelStyle';
 
 interface LabelProps {
+  children: React.ReactNode;
   hierarchy: Hierarchy;
   weight: Weight;
-  text: string;
   textColor: string;
   isRequired?: boolean;
 }
 
-function Label({ weight, hierarchy, text, textColor, isRequired }: LabelProps) {
+function Label({ children, weight, hierarchy, textColor, isRequired }: LabelProps) {
   const typo = labelStyle.weight[weight].hierarchy[hierarchy].typo;
   const lineHeight = labelStyle.weight[weight].hierarchy[hierarchy].lineHeight;
 
   return (
     <div className={`${typo} ${lineHeight} gap-5xs flex`}>
-      <span className={`${textColor} whitespace-nowrap`}>{text}</span>
+      <span className={`${textColor} whitespace-nowrap`}>{children}</span>
       {isRequired && <span className='text-feedback-notification-dark'>*</span>}
     </div>
   );

--- a/src/styles/interactionStyle.ts
+++ b/src/styles/interactionStyle.ts
@@ -8,6 +8,7 @@ interface InteractionStyleType {
         [key in Density]: {
           bgColor: string;
           opacity: string;
+          bgRgba: string;
         };
       };
     };
@@ -22,16 +23,19 @@ export const interactionStyle: InteractionStyleType = {
           bgColor:
             'hover:bg-object-hero-dark focus-visible:bg-object-hero-dark active:bg-object-hero-dark',
           opacity: '*:hover:opacity-88 *:active:opacity-88',
+          bgRgba: 'hover:bg-[rgba(255,255,255,0.12)] active:bg-[rgba(255,255,255,0.12)]',
         },
         normal: {
           bgColor:
             'hover:bg-object-normal-dark focus-visible:bg-object-normal-dark  active:bg-object-normal-dark',
           opacity: '*:hover:opacity-92 *:active:opacity-92',
+          bgRgba: 'hover:bg-[rgba(212,211,222,0.08)] active:bg-[rgba(212,211,222,0.08)]',
         },
         subtle: {
           bgColor:
             'hover:bg-object-neutral-dark focus-visible:bg-object-neutral-dark  active:bg-object-neutral-dark ',
           opacity: '*:hover:opacity-95 *:active:opacity-95',
+          bgRgba: 'hover:bg-[rgba(247,245,255,0.033)] active:bg-[rgba(247,245,255,0.033)]',
         },
       },
     },
@@ -41,16 +45,19 @@ export const interactionStyle: InteractionStyleType = {
           bgColor:
             'hover:bg-accent-hero-dark focus-visible:bg-accent-hero-dark  active:bg-accent-hero-dark',
           opacity: '*:hover:opacity-88 *:active:opacity-88',
+          bgRgba: 'hover:bg-[rgba(145,147,255,0.12)] active:bg-[rgba(145,147,255,0.12)]',
         },
         normal: {
           bgColor:
             'hover:bg-accent-normal-dark focus-visible:bg-accent-normal-dark  active:bg-accent-normal-dark',
           opacity: '*:hover:opacity-92 *:active:opacity-92',
+          bgRgba: 'hover:bg-[rgba(113,115,255,0.08)] active:bg-[rgba(113,115,255,0.08) ]',
         },
         subtle: {
           bgColor:
-            'hover:bg-accent-neutral-dark focus-visible:bg-accent-neutral-dark  active:bg-accent-neutral-dark',
+            'hover:bg-accent-neutral-dark focus-visible:bg-accent-neutral-dark active:bg-accent-neutral-dark',
           opacity: '*:hover:opacity-95 *:active:opacity-95',
+          bgRgba: 'hover:bg-[rgba(87,88,227,0.05)] active:bg-[rgba(87,88,227,0.05)]',
         },
       },
     },

--- a/src/styles/tokens/typography.css
+++ b/src/styles/tokens/typography.css
@@ -105,7 +105,7 @@
   }
 
   .label-bold-xs {
-    @apply text-size-2xs font-2xl tracking-narrow leading-normal;
+    @apply text-size-xs font-2xl tracking-narrow leading-normal;
   }
 
   .label-bold-sm {


### PR DESCRIPTION
## 💡 작업 내용

- [x] 인터렉션 컴포넌트 수정
- [x] Label 컴포넌트 수정 
- [x] ++) Badge 컴포넌트 수정
- [x] Badge 컴포넌트 수정된 Label 반영
- [x] 스토리북 배경 기본 값 dark로 설정

## 💡 자세한 설명

### 1️⃣ 인터렉션 수정 
이전 인터렉션에서 자식요소의 배경색 존재 여부를 고려하지 않고 구현하여 
배경색이 없을 경우 인터렉션의 투명도 값이 제대로 계산되지 않는 문제가 있어 해결하였습니다. 

```ts
interface InteractionProps {
  children: React.ReactNode;
  variant: Variant;
  density: Density;
  childHasBg: boolean; // 추가
  childRadius?: Radius; // radius -> childRadius로 이름 변경
}
```
- Props로 `childHasBg` 가 추가되었습니다. 
- 기존 `radius` 에서 `childRadius` 로 이름이 변경되었습니다.

배경색이 있을 경우, 자식요소의 opacity를 조절하지만
배경색이 없을 경우, 인터렉션의 raga 값을 조절합니다. 
(opacity 대신 raba로 사용한 이유는 opacity로 할 경우 자식요소에도 함께 적용되어 텍스트가 안보입니다.)

🚨 **추가로, Interaction의 `focus-visible` 효과가 적용되기 위해서 
자식요소는 기본 블록 태그가 아닌 상호작용이 가능한 태그여야합니다.**  
ex) button, input, a, textarea, select ..

### 2️⃣ Label 
Label에 들어가는 텍스트를 `text` Prop에서 children 으로 수정되었습니다!
이렇게 하면 Label을 사용하는 컴포넌트에서 좀 더 텍스트에 대해 가독성이 좋다 생각하여 변경했습니다. 

++) Badge도 text prop에서 children으로 변경되었습니다 

### 3️⃣ 스토리북 설정
스토리북 배경색 기본값을 dark로 지정했습니다. 
현재 젝트 홈페이지는 다크모드를 기본값이므로
컴포넌트 디자인이 다크모드에 맞춰져 있어 dark로 지정합니다. 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #21 
