### PR TITLE
feat: Title, Callout, Hero 컴포넌트 구현 

### DIFF
--- a/src/components/common/Label.tsx
+++ b/src/components/common/Label.tsx
@@ -10,10 +10,9 @@ interface LabelProps {
 
 function Label({ weight, hierarchy, text, textColor, isRequired }: LabelProps) {
   const typo = labelStyle.weight[weight].hierarchy[hierarchy].typo;
-  const lineHeight = labelStyle.weight[weight].hierarchy[hierarchy].lineHeight;
 
   return (
-    <div className={`${typo} ${lineHeight} gap-5xs flex`}>
+    <div className={`${typo} gap-5xs flex`}>
       <span className={`${textColor} whitespace-nowrap`}>{text}</span>
       {isRequired && <span className='text-feedback-notification-dark'>*</span>}
     </div>

--- a/src/components/common/Label.tsx
+++ b/src/components/common/Label.tsx
@@ -15,7 +15,7 @@ function Label({ children, weight, hierarchy, textColor, isRequired }: LabelProp
 
   return (
     <div className={`${typo} gap-5xs flex`}>
-      <span className={`${textColor} whitespace-nowrap`}>{text}</span>
+      <span className={`${textColor} whitespace-nowrap`}>{children}</span>
       {isRequired && <span className='text-feedback-notification-dark'>*</span>}
     </div>
   );

--- a/src/components/common/Title.stories.tsx
+++ b/src/components/common/Title.stories.tsx
@@ -1,0 +1,36 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import Title from './Title';
+
+import { Hierarchy } from '@/styles/labelStyle';
+
+const meta: Meta<typeof Title> = {
+  title: 'Components/Title',
+  component: Title,
+  tags: ['autodocs'],
+  argTypes: {
+    children: {
+      control: 'text',
+      description: 'Title에 들어갈 텍스트입니다.',
+    },
+    hierarchy: {
+      control: 'radio',
+      options: ['stronger', 'strong', 'normal', 'weak'],
+      description: 'Title의 계층을 나타냅니다.',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<{
+  children: React.ReactNode;
+  hierarchy: Hierarchy;
+}>;
+
+export const Primary: Story = {
+  args: {
+    children: '타이틀',
+    hierarchy: 'stronger',
+  },
+};

--- a/src/components/common/Title.stories.tsx
+++ b/src/components/common/Title.stories.tsx
@@ -23,10 +23,7 @@ const meta: Meta<typeof Title> = {
 
 export default meta;
 
-type Story = StoryObj<{
-  children: React.ReactNode;
-  hierarchy: Hierarchy;
-}>;
+type Story = StoryObj<typeof Title>;
 
 export const Primary: Story = {
   args: {

--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -10,9 +10,8 @@ interface TitleProps {
 
 function Title({ children, hierarchy }: TitleProps) {
   const typo = titleStyle.hierarchy[hierarchy].typo;
-  const lineHeight = titleStyle.hierarchy[hierarchy].lineHeight;
 
-  return <div className={`${typo} ${lineHeight} text-object-hero-dark`}>{children}</div>;
+  return <div className={`${typo} text-object-hero-dark`}>{children}</div>;
 }
 
 export default Title;

--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -1,8 +1,10 @@
+import { ReactNode } from 'react';
+
 import { Hierarchy } from '@/styles/labelStyle';
 import { titleStyle } from '@/styles/titleStyle';
 
 interface TitleProps {
-  children: React.ReactNode;
+  children: ReactNode;
   hierarchy: Hierarchy;
 }
 

--- a/src/components/common/Title.tsx
+++ b/src/components/common/Title.tsx
@@ -1,0 +1,16 @@
+import { Hierarchy } from '@/styles/labelStyle';
+import { titleStyle } from '@/styles/titleStyle';
+
+interface TitleProps {
+  children: React.ReactNode;
+  hierarchy: Hierarchy;
+}
+
+function Title({ children, hierarchy }: TitleProps) {
+  const typo = titleStyle.hierarchy[hierarchy].typo;
+  const lineHeight = titleStyle.hierarchy[hierarchy].lineHeight;
+
+  return <div className={`${typo} ${lineHeight} text-object-hero-dark`}>{children}</div>;
+}
+
+export default Title;

--- a/src/components/common/callout/CalloutInformation.stories.tsx
+++ b/src/components/common/callout/CalloutInformation.stories.tsx
@@ -1,0 +1,29 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import CalloutInformation from './CalloutInformation';
+
+const meta: Meta<typeof CalloutInformation> = {
+  title: 'Components/Callout/CalloutInformation',
+  component: CalloutInformation,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+    },
+    labels: {
+      control: 'object',
+      description: '문자열 배열입니다.',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CalloutInformation>;
+
+export const Primary: Story = {
+  args: {
+    title: '콜아웃 레이블',
+    labels: ['레이블', '레이블'],
+  },
+};

--- a/src/components/common/callout/CalloutInformation.tsx
+++ b/src/components/common/callout/CalloutInformation.tsx
@@ -8,14 +8,13 @@ interface CalloutProps {
 function CalloutInformation({ title, labels }: CalloutProps) {
   return (
     <div className='bg-surface-deep-dark border-border-assistive-dark gap-xs radius-xs flex items-center border px-(--gap-lg) py-(--gap-xs)'>
-      <Label hierarchy='stronger' weight='bold' text={title} textColor='text-object-hero-dark' />
+      <Label hierarchy='stronger' weight='bold' textColor='text-object-hero-dark'>
+        {title}
+      </Label>
       {labels.map(label => (
-        <Label
-          hierarchy='normal'
-          weight='normal'
-          text={label}
-          textColor='text-object-neutral-dark'
-        />
+        <Label hierarchy='normal' weight='normal' textColor='text-object-neutral-dark'>
+          {label}
+        </Label>
       ))}
     </div>
   );

--- a/src/components/common/callout/CalloutInformation.tsx
+++ b/src/components/common/callout/CalloutInformation.tsx
@@ -1,0 +1,24 @@
+import Label from '../Label';
+
+interface CalloutProps {
+  title: string;
+  labels: string[];
+}
+
+function CalloutInformation({ title, labels }: CalloutProps) {
+  return (
+    <div className='bg-surface-deep-dark border-border-assistive-dark gap-xs radius-xs flex items-center border px-(--gap-lg) py-(--gap-xs)'>
+      <Label hierarchy='stronger' weight='bold' text={title} textColor='text-object-hero-dark' />
+      {labels.map(label => (
+        <Label
+          hierarchy='normal'
+          weight='normal'
+          text={label}
+          textColor='text-object-neutral-dark'
+        />
+      ))}
+    </div>
+  );
+}
+
+export default CalloutInformation;

--- a/src/components/common/callout/CalloutNumerical.stories.tsx
+++ b/src/components/common/callout/CalloutNumerical.stories.tsx
@@ -1,0 +1,28 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import CalloutNumerical from './CalloutNumerical';
+
+const meta: Meta<typeof CalloutNumerical> = {
+  title: 'Components/Callout/CalloutNumerical',
+  component: CalloutNumerical,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+    },
+    labelText: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CalloutNumerical>;
+
+export const Primary: Story = {
+  args: {
+    title: '콜아웃 레이블',
+    labelText: '레이블',
+  },
+};

--- a/src/components/common/callout/CalloutNumerical.tsx
+++ b/src/components/common/callout/CalloutNumerical.tsx
@@ -1,0 +1,23 @@
+import Label from '../Label';
+import Title from '../Title';
+
+interface CalloutProps {
+  title: string;
+  labelText: string;
+}
+
+function CalloutNumerical({ title, labelText }: CalloutProps) {
+  return (
+    <div className='bg-surface-deep-dark border-border-assistive-dark gap-md radius-sm flex flex-col items-center border px-(--gap-4xl) py-(--gap-3xl)'>
+      <Title hierarchy='stronger'>{title}</Title>
+      <Label
+        hierarchy='normal'
+        weight='bold'
+        text={labelText}
+        textColor='text-object-neutral-dark'
+      ></Label>
+    </div>
+  );
+}
+
+export default CalloutNumerical;

--- a/src/components/common/callout/CalloutNumerical.tsx
+++ b/src/components/common/callout/CalloutNumerical.tsx
@@ -10,12 +10,9 @@ function CalloutNumerical({ title, labelText }: CalloutProps) {
   return (
     <div className='bg-surface-deep-dark border-border-assistive-dark gap-md radius-sm flex flex-col items-center border px-(--gap-4xl) py-(--gap-3xl)'>
       <Title hierarchy='stronger'>{title}</Title>
-      <Label
-        hierarchy='normal'
-        weight='bold'
-        text={labelText}
-        textColor='text-object-neutral-dark'
-      ></Label>
+      <Label hierarchy='normal' weight='bold' textColor='text-object-neutral-dark'>
+        {labelText}
+      </Label>
     </div>
   );
 }

--- a/src/components/common/callout/Hero.stories.tsx
+++ b/src/components/common/callout/Hero.stories.tsx
@@ -1,0 +1,32 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import Hero from './Hero';
+
+const meta: Meta<typeof Hero> = {
+  title: 'Components/Hero/Hero',
+  component: Hero,
+  tags: ['autodocs'],
+  argTypes: {
+    title: {
+      control: 'text',
+    },
+    badgeText: {
+      control: 'text',
+    },
+    content: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Hero>;
+
+export const Primary: Story = {
+  args: {
+    title: '히어로 타이틀',
+    badgeText: '레이블',
+    content: '히어로 내용',
+  },
+};

--- a/src/components/common/callout/Hero.tsx
+++ b/src/components/common/callout/Hero.tsx
@@ -12,11 +12,9 @@ function Hero({ title, badgeText, content }: HeroProps) {
     <div className='gap-xl radius-xs border-border-assistive-dark bg-surface-deep-dark flex flex-col border px-(--gap-3xl) py-(--gap-2xl)'>
       <div className='gap-sm flex'>
         <Title hierarchy='normal'>{title}</Title>
-        <Badge
-          text={badgeText}
-          backgroundColor='bg-fill-assistive-dark'
-          textColor='text-object-normal-dark'
-        />
+        <Badge backgroundColor='bg-fill-assistive-dark' textColor='text-object-normal-dark'>
+          {badgeText}
+        </Badge>
       </div>
       <p className='text-object-normal-dark body-lg'>{content}</p>
     </div>

--- a/src/components/common/callout/Hero.tsx
+++ b/src/components/common/callout/Hero.tsx
@@ -1,0 +1,26 @@
+import Badge from '../Badge';
+import Title from '../Title';
+
+export interface HeroProps {
+  title: string;
+  badgeText: string;
+  content: string;
+}
+
+function Hero({ title, badgeText, content }: HeroProps) {
+  return (
+    <div className='gap-xl radius-xs border-border-assistive-dark bg-surface-deep-dark flex flex-col border px-(--gap-3xl) py-(--gap-2xl)'>
+      <div className='gap-sm flex'>
+        <Title hierarchy='normal'>{title}</Title>
+        <Badge
+          text={badgeText}
+          backgroundColor='bg-fill-assistive-dark'
+          textColor='text-object-normal-dark'
+        />
+      </div>
+      <p className='text-object-normal-dark body-lg'>{content}</p>
+    </div>
+  );
+}
+
+export default Hero;

--- a/src/components/common/callout/HeroIndex.stories.tsx
+++ b/src/components/common/callout/HeroIndex.stories.tsx
@@ -1,0 +1,36 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import HeroIndex from './HeroIndex';
+
+const meta: Meta<typeof HeroIndex> = {
+  title: 'Components/Hero/HeroIndex',
+  component: HeroIndex,
+  tags: ['autodocs'],
+  argTypes: {
+    index: {
+      control: 'number',
+    },
+    title: {
+      control: 'text',
+    },
+    badgeText: {
+      control: 'text',
+    },
+    content: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof HeroIndex>;
+
+export const Primary: Story = {
+  args: {
+    index: 1,
+    title: '히어로 타이틀',
+    badgeText: '레이블',
+    content: '히어로 내용',
+  },
+};

--- a/src/components/common/callout/HeroIndex.tsx
+++ b/src/components/common/callout/HeroIndex.tsx
@@ -15,11 +15,9 @@ function HeroIndex({ index, title, badgeText, content }: HeroIndexProps) {
       <div className='gap-xs flex flex-col'>
         <div className='gap-sm flex'>
           <Title hierarchy='normal'>{title}</Title>
-          <Badge
-            text={badgeText}
-            backgroundColor='bg-fill-assistive-dark'
-            textColor='text-object-normal-dark'
-          />
+          <Badge backgroundColor='bg-fill-assistive-dark' textColor='text-object-normal-dark'>
+            {badgeText}
+          </Badge>
         </div>
         <p className='text-object-normal-dark body-lg'>{content}</p>
       </div>

--- a/src/components/common/callout/HeroIndex.tsx
+++ b/src/components/common/callout/HeroIndex.tsx
@@ -9,7 +9,9 @@ interface HeroIndexProps extends HeroProps {
 function HeroIndex({ index, title, badgeText, content }: HeroIndexProps) {
   return (
     <div className='radius-xs border-border-assistive-dark bg-surface-deep-dark gap-4xl flex items-center border px-(--gap-3xl) py-(--gap-2xl)'>
-      <Title hierarchy='stronger'>{index}</Title>
+      <div className='min-w-[33px] text-center'>
+        <Title hierarchy='stronger'>{index}</Title>
+      </div>
       <div className='gap-xs flex flex-col'>
         <div className='gap-sm flex'>
           <Title hierarchy='normal'>{title}</Title>

--- a/src/components/common/callout/HeroIndex.tsx
+++ b/src/components/common/callout/HeroIndex.tsx
@@ -1,0 +1,28 @@
+import Badge from '../Badge';
+import Title from '../Title';
+import { HeroProps } from './Hero';
+
+interface HeroIndexProps extends HeroProps {
+  index: number;
+}
+
+function HeroIndex({ index, title, badgeText, content }: HeroIndexProps) {
+  return (
+    <div className='radius-xs border-border-assistive-dark bg-surface-deep-dark gap-4xl flex items-center border px-(--gap-3xl) py-(--gap-2xl)'>
+      <Title hierarchy='stronger'>{index}</Title>
+      <div className='gap-xs flex flex-col'>
+        <div className='gap-sm flex'>
+          <Title hierarchy='normal'>{title}</Title>
+          <Badge
+            text={badgeText}
+            backgroundColor='bg-fill-assistive-dark'
+            textColor='text-object-normal-dark'
+          />
+        </div>
+        <p className='text-object-normal-dark body-lg'>{content}</p>
+      </div>
+    </div>
+  );
+}
+
+export default HeroIndex;

--- a/src/styles/labelStyle.ts
+++ b/src/styles/labelStyle.ts
@@ -7,7 +7,6 @@ interface LabelStyleType {
       hierarchy: {
         [key in Hierarchy]: {
           typo: string;
-          lineHeight: string;
         };
       };
     };
@@ -20,19 +19,15 @@ export const labelStyle: LabelStyleType = {
       hierarchy: {
         stronger: {
           typo: 'label-lg',
-          lineHeight: 'leading-[27px]',
         },
         strong: {
           typo: 'label-md',
-          lineHeight: 'leading-[24px]',
         },
         normal: {
           typo: 'label-sm',
-          lineHeight: 'leading-[22.5px]',
         },
         weak: {
           typo: 'label-xs',
-          lineHeight: 'leading-[21px]',
         },
       },
     },
@@ -40,19 +35,15 @@ export const labelStyle: LabelStyleType = {
       hierarchy: {
         stronger: {
           typo: 'label-bold-lg',
-          lineHeight: 'leading-[27px]',
         },
         strong: {
           typo: 'label-bold-md',
-          lineHeight: 'leading-[24px]',
         },
         normal: {
           typo: 'label-bold-sm',
-          lineHeight: 'leading-[22.5px]',
         },
         weak: {
           typo: 'label-bold-xs',
-          lineHeight: 'leading-[21px]',
         },
       },
     },

--- a/src/styles/titleStyle.ts
+++ b/src/styles/titleStyle.ts
@@ -1,0 +1,31 @@
+import { Hierarchy } from './labelStyle';
+
+interface TitleStyleType {
+  hierarchy: {
+    [key in Hierarchy]: {
+      typo: string;
+      lineHeight: string;
+    };
+  };
+}
+
+export const titleStyle: TitleStyleType = {
+  hierarchy: {
+    stronger: {
+      typo: 'title-04',
+      lineHeight: 'leading-[56px]',
+    },
+    strong: {
+      typo: 'title-03',
+      lineHeight: 'leading-[44.8px]',
+    },
+    normal: {
+      typo: 'title-02',
+      lineHeight: 'leading-[35px]',
+    },
+    weak: {
+      typo: 'title-01',
+      lineHeight: 'leading-[28px]',
+    },
+  },
+};

--- a/src/styles/titleStyle.ts
+++ b/src/styles/titleStyle.ts
@@ -4,7 +4,6 @@ interface TitleStyleType {
   hierarchy: {
     [key in Hierarchy]: {
       typo: string;
-      lineHeight: string;
     };
   };
 }
@@ -13,19 +12,15 @@ export const titleStyle: TitleStyleType = {
   hierarchy: {
     stronger: {
       typo: 'title-04',
-      lineHeight: 'leading-[56px]',
     },
     strong: {
       typo: 'title-03',
-      lineHeight: 'leading-[44.8px]',
     },
     normal: {
       typo: 'title-02',
-      lineHeight: 'leading-[35px]',
     },
     weak: {
       typo: 'title-01',
-      lineHeight: 'leading-[28px]',
     },
   },
 };

--- a/src/styles/tokens/scheme.css
+++ b/src/styles/tokens/scheme.css
@@ -26,14 +26,14 @@
   --gap-12xl: 9rem;
 
   /* radius */
-  --radius-4xs: 0.25rem;
-  --radius-3xs: 0.375rem;
-  --radius-2xs: 0.5rem;
-  --radius-xs: 0.625rem;
-  --radius-sm: 0.75rem;
-  --radius-md: 1rem;
-  --radius-lg: 1.5rem;
-  --radius-circle: calc(infinity * 1px);
+  --border-radius-4xs: 0.25rem;
+  --border-radius-3xs: 0.375rem;
+  --border-radius-2xs: 0.5rem;
+  --border-radius-xs: 0.625rem;
+  --border-radius-sm: 0.75rem;
+  --border-radius-md: 1rem;
+  --border-radius-lg: 1.5rem;
+  --border-radius-circle: calc(infinity * 1px);
 
   /* stroke */
   --stroke-normal: 0.0625rem;
@@ -51,7 +51,7 @@
 }
 
 @utility radius-* {
-  border-radius: --value(--radius- *);
+  border-radius: --value(--border-radius- *);
 }
 
 @utility stroke-* {


### PR DESCRIPTION
## 💡 작업 내용

- [x] Title 컴포넌트 구현
- [x] Callout 컴포넌트 구현 (2가지)
- [x] Hero 컴포넌트 구현 (2가지)
- [x] 오버라이딩안되는 border-radius 토큰  문제 해결

## 💡 자세한 설명

### 1️⃣ 공통 컴포넌트 구현

![image](https://github.com/user-attachments/assets/940fccec-86d0-4add-a634-d08f4a8ec8bb)

Title, Callout, Hero 컴포넌트를 구현했습니다. 
컴포넌트 수는 5가지지만 간단한 구조라서 구현도 간단하게 진행했습니다!
자세한 props 내용은 스토리북 확인해주시면 될 것 같습니다ㅎㅎ

### 2️⃣ scheme radius 토큰 
구현을 하다가 tailwind와 동일한 이름을 사용하는 radius가 오버라이딩이 되지 않는 걸 발견했습니다.
css 변수명 자체를 그냥 tailwind의 네임스페이스와 다르게 수정해서 해결했습니다. 
@utility 에 정의한 `radius-*` 형태는 건들지 않아서 기존 형식 그대로 사용해도 문제 없습니다!

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
PR을 연달아 계속 올리고 있는데 스프린트가 곧 끝나서 조금 달리겠습니다..! 💪🙏🙌 
컴포넌트 폴더가 스토리북도 같이 작성하다보니까 금방 많아졌는데 
스토리북은 따로 폴더 만들어서 분리하는게 좋을 것 같단 생각이 살짝 드는데 원준님 의견은 어떠신지 궁금합니다ㅎㅎ
그리고 혹시 preview에 autodocs 추가하신다고 하셨는데 추가하게되면 스토리북 개별 파일에는 생략해도 되는건가요?

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #19 
