### PR TITLE
feat: 탭 컴포넌트 구현

### DIFF
--- a/src/components/common/tab/Tab.stories.tsx
+++ b/src/components/common/tab/Tab.stories.tsx
@@ -57,3 +57,23 @@ export const TabStory: Story = {
     </Tab>
   ),
 };
+
+export const CategoryTabStory: Story = {
+  name: 'Category Tab',
+  render: args => (
+    <Tab defaultActiveTabId={0} {...args}>
+      <TabHeader>
+        <TabItem id={0} label='프로젝트' />
+        <TabItem id={1} label='해커톤' />
+      </TabHeader>
+      <div>
+        <TabPanel id={0}>
+          <div>프로젝트 콘텐츠</div>
+        </TabPanel>
+        <TabPanel id={1}>
+          <div>해커톤 콘텐츠</div>
+        </TabPanel>
+      </div>
+    </Tab>
+  ),
+};

--- a/src/components/common/tab/Tab.stories.tsx
+++ b/src/components/common/tab/Tab.stories.tsx
@@ -16,8 +16,8 @@ const meta: Meta<typeof Tabs> = {
   },
   argTypes: {
     defaultActiveTabId: {
-      control: 'text',
-      description: '초기 활성 탭의 id를 설정합니다. string 형태입니다.',
+      control: { type: 'number' },
+      description: '초기 활성 탭의 id를 설정합니다. number 형태이며, 0부터 시작합니다.',
     },
     onTabChange: {
       action: '탭 변경됨',
@@ -33,24 +33,24 @@ type Story = StoryObj<typeof Tabs>;
 export const TabStory: Story = {
   name: 'Tab',
   render: args => (
-    <Tab defaultActiveTabId='1' {...args}>
+    <Tab defaultActiveTabId={0} {...args}>
       <TabHeader>
-        <TabItem id='1' label='프론트엔드 개발자' />
-        <TabItem id='2' label='백엔드 개발자' />
-        <TabItem id='3' label='프로젝트 매니저' />
-        <TabItem id='4' label='프로덕트 디자이너' />
+        <TabItem id={0} label='프론트엔드 개발자' />
+        <TabItem id={1} label='백엔드 개발자' />
+        <TabItem id={2} label='프로젝트 매니저' />
+        <TabItem id={3} label='프로덕트 디자이너' />
       </TabHeader>
       <div>
-        <TabPanel id='1'>
+        <TabPanel id={0}>
           <div>프론트엔드 개발자 콘텐츠</div>
         </TabPanel>
-        <TabPanel id='2'>
+        <TabPanel id={1}>
           <div>백엔드 개발자 콘텐츠</div>
         </TabPanel>
-        <TabPanel id='3'>
+        <TabPanel id={2}>
           <div>프로젝트 매니저 콘텐츠</div>
         </TabPanel>
-        <TabPanel id='4'>
+        <TabPanel id={3}>
           <div>프로덕트 디자이너 콘텐츠</div>
         </TabPanel>
       </div>

--- a/src/components/common/tab/Tab.stories.tsx
+++ b/src/components/common/tab/Tab.stories.tsx
@@ -1,15 +1,23 @@
 import type { Meta, StoryObj } from '@storybook/react';
 import React from 'react';
 
-import { Tab, TabItem } from './Tab';
+import { Tab, TabHeader, TabItem, TabPanel } from './Tab';
 
-const meta: Meta<typeof Tab> = {
+const meta: Meta<typeof Tabs> = {
   title: 'Components/Tab',
   component: Tab,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'Tab 컴포넌트는  탭 헤더(TabHeader 및 TabItem)와 탭 콘텐츠(TabPanel)를 자유롭게 구성할 수 있습니다. Context API를 사용합니다.',
+      },
+    },
+  },
   argTypes: {
     defaultActiveTabId: {
       control: 'text',
-      description: '기본 활성 탭의 id를 설정합니다. 전달하지 않으면 첫 번째 탭이 활성화됩니다.',
+      description: '초기 활성 탭의 id를 설정합니다. string 형태입니다.',
     },
     onTabChange: {
       action: '탭 변경됨',
@@ -20,16 +28,32 @@ const meta: Meta<typeof Tab> = {
 
 export default meta;
 
-type Story = StoryObj<typeof Tab>;
+type Story = StoryObj<typeof Tabs>;
 
 export const TabStory: Story = {
   name: 'Tab',
-  render: () => (
-    <Tab>
-      <TabItem id='1' label='프론트엔드 개발자' />
-      <TabItem id='2' label='백엔드 개발자' />
-      <TabItem id='3' label='프로젝트 매니저' />
-      <TabItem id='4' label='프로덕트 디자이너' />
+  render: args => (
+    <Tab defaultActiveTabId='1' {...args}>
+      <TabHeader>
+        <TabItem id='1' label='프론트엔드 개발자' />
+        <TabItem id='2' label='백엔드 개발자' />
+        <TabItem id='3' label='프로젝트 매니저' />
+        <TabItem id='4' label='프로덕트 디자이너' />
+      </TabHeader>
+      <div>
+        <TabPanel id='1'>
+          <div>프론트엔드 개발자 콘텐츠</div>
+        </TabPanel>
+        <TabPanel id='2'>
+          <div>백엔드 개발자 콘텐츠</div>
+        </TabPanel>
+        <TabPanel id='3'>
+          <div>프로젝트 매니저 콘텐츠</div>
+        </TabPanel>
+        <TabPanel id='4'>
+          <div>프로덕트 디자이너 콘텐츠</div>
+        </TabPanel>
+      </div>
     </Tab>
   ),
 };

--- a/src/components/common/tab/Tab.stories.tsx
+++ b/src/components/common/tab/Tab.stories.tsx
@@ -1,0 +1,35 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+
+import { Tab, TabItem } from './Tab';
+
+const meta: Meta<typeof Tab> = {
+  title: 'Components/Tab',
+  component: Tab,
+  argTypes: {
+    defaultActiveTabId: {
+      control: 'text',
+      description: '기본 활성 탭의 id를 설정합니다. 전달하지 않으면 첫 번째 탭이 활성화됩니다.',
+    },
+    onTabChange: {
+      action: '탭 변경됨',
+      description: '탭 변경 시 호출되는 콜백 함수입니다.',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Tab>;
+
+export const TabStory: Story = {
+  name: 'Tab',
+  render: () => (
+    <Tab>
+      <TabItem id='1' label='프론트엔드 개발자' />
+      <TabItem id='2' label='백엔드 개발자' />
+      <TabItem id='3' label='프로젝트 매니저' />
+      <TabItem id='4' label='프로덕트 디자이너' />
+    </Tab>
+  ),
+};

--- a/src/components/common/tab/Tab.tsx
+++ b/src/components/common/tab/Tab.tsx
@@ -1,5 +1,7 @@
 import React, { useState, cloneElement, ReactElement } from 'react';
 
+import Interaction from '@/components/common/interaction/Interaction.tsx';
+
 interface TabItemProps {
   id: string;
   label: string;
@@ -9,7 +11,7 @@ interface TabItemProps {
 
 export const TabItem = ({ label, isActive, onClick }: TabItemProps) => {
   return (
-    <div>
+    <Interaction variant='default' density='subtle' isInversed='false'>
       <button
         onClick={onClick}
         className={`peer gap- py-(--gap-3xs)4xs label-bold-lg inline-flex items-center justify-center px-(--gap-md) text-center ${
@@ -20,7 +22,7 @@ export const TabItem = ({ label, isActive, onClick }: TabItemProps) => {
       >
         {label}
       </button>
-    </div>
+    </Interaction>
   );
 };
 

--- a/src/components/common/tab/Tab.tsx
+++ b/src/components/common/tab/Tab.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useState, useContext, ReactNode } from 'react';
 
 import Interaction from '@/components/common/interaction/Interaction.tsx';
-import { TabsProps } from '@/components/common/tab/Tab.types.ts';
+import { TabProps } from '@/components/common/tab/Tab.types.ts';
 
 type TabContextType = {
   activeTabId: string;
@@ -64,7 +64,7 @@ export const TabPanel = ({ id, children }: TabPanelProps) => {
   return activeTabId === id ? <div className='tab-panel'>{children}</div> : null;
 };
 
-export const Tabs = ({ children, defaultActiveTabId, onTabChange }: TabsProps) => {
+export const Tab = ({ children, defaultActiveTabId, onTabChange }: TabProps) => {
   const [activeTabId, setActiveTabId] = useState<string>(defaultActiveTabId ?? '');
 
   const handleTabClick = (id: string) => {

--- a/src/components/common/tab/Tab.tsx
+++ b/src/components/common/tab/Tab.tsx
@@ -24,7 +24,7 @@ type TabHeaderProps = {
 
 export const TabHeader = ({ children }: TabHeaderProps) => {
   return (
-    <div className='tab-header stroke-normal border-border-alternative-dark flex w-[37.3125rem] items-center'>
+    <div className='tab-header stroke-normal border-border-alternative-dark flex w-full items-center'>
       {children}
     </div>
   );

--- a/src/components/common/tab/Tab.tsx
+++ b/src/components/common/tab/Tab.tsx
@@ -24,7 +24,10 @@ type TabHeaderProps = {
 
 export const TabHeader = ({ children }: TabHeaderProps) => {
   return (
-    <div className='tab-header stroke-normal border-border-alternative-dark flex w-full items-center'>
+    <div
+      aria-label='탭 헤더'
+      className='stroke-normal border-border-alternative-dark flex w-full items-center'
+    >
       {children}
     </div>
   );
@@ -61,7 +64,7 @@ type TabPanelProps = {
 
 export const TabPanel = ({ id, children }: TabPanelProps) => {
   const { activeTabId } = useTabContext();
-  return activeTabId === id ? <div className='tab-panel'>{children}</div> : null;
+  return activeTabId === id ? <div aria-label='탭 패널'>{children}</div> : null;
 };
 
 export const Tab = ({ children, defaultActiveTabId, onTabChange }: TabProps) => {
@@ -76,7 +79,9 @@ export const Tab = ({ children, defaultActiveTabId, onTabChange }: TabProps) => 
 
   return (
     <TabContext.Provider value={{ activeTabId, onTabClick: handleTabClick }}>
-      <div className='tabs-container flex flex-col'>{children}</div>
+      <div aria-label='탭' className='flex flex-col'>
+        {children}
+      </div>
     </TabContext.Provider>
   );
 };

--- a/src/components/common/tab/Tab.tsx
+++ b/src/components/common/tab/Tab.tsx
@@ -1,0 +1,58 @@
+import React, { useState, cloneElement, ReactElement } from 'react';
+
+interface TabItemProps {
+  id: string;
+  label: string;
+  isActive?: boolean;
+  onClick?: () => void;
+}
+
+export const TabItem = ({ label, isActive, onClick }: TabItemProps) => {
+  return (
+    <div>
+      <button
+        onClick={onClick}
+        className={`peer gap- py-(--gap-3xs)4xs label-bold-lg inline-flex items-center justify-center px-(--gap-md) text-center ${
+          isActive
+            ? 'text-object-hero-dark stroke-bold border-accent-normal-dark'
+            : 'text-object-alternative-dark'
+        }`}
+      >
+        {label}
+      </button>
+    </div>
+  );
+};
+
+interface TabProps {
+  children: ReactElement<TabItemProps> | ReactElement<TabItemProps>[];
+  defaultActiveTabId?: string;
+  onTabChange?: (activeTabId: string) => void;
+}
+
+export const Tab = ({ children, defaultActiveTabId, onTabChange }: TabProps) => {
+  const tabItems = Array.isArray(children) ? children : [children];
+
+  const initialActiveId = defaultActiveTabId ?? tabItems[0].props.id;
+  const [activeTabId, setActiveTabId] = useState(initialActiveId);
+
+  const handleTabClick = (id: string) => {
+    setActiveTabId(id);
+    if (onTabChange) {
+      onTabChange(id);
+    }
+  };
+
+  const TabItems = tabItems.map(item =>
+    cloneElement(item, {
+      isActive: item.props.id === activeTabId,
+      onClick: () => handleTabClick(item.props.id),
+    }),
+  );
+
+  return (
+    <div className='tab-container stroke-normal border-border-alternative-dark flex w-[37.3125rem]'>
+      {TabItems}
+    </div>
+  );
+};

--- a/src/components/common/tab/Tab.tsx
+++ b/src/components/common/tab/Tab.tsx
@@ -4,8 +4,8 @@ import Interaction from '@/components/common/interaction/Interaction.tsx';
 import { TabProps } from '@/components/common/tab/Tab.types.ts';
 
 type TabContextType = {
-  activeTabId: string;
-  onTabClick: (id: string) => void;
+  activeTabId: number;
+  onTabClick: (id: number) => void;
 };
 
 const TabContext = createContext<TabContextType | undefined>(undefined);
@@ -31,7 +31,7 @@ export const TabHeader = ({ children }: TabHeaderProps) => {
 };
 
 type TabItemProps = {
-  id: string;
+  id: number;
   label: string;
 };
 
@@ -55,7 +55,7 @@ export const TabItem = ({ id, label }: TabItemProps) => {
 };
 
 type TabPanelProps = {
-  id: string;
+  id: number;
   children: ReactNode;
 };
 
@@ -65,9 +65,9 @@ export const TabPanel = ({ id, children }: TabPanelProps) => {
 };
 
 export const Tab = ({ children, defaultActiveTabId, onTabChange }: TabProps) => {
-  const [activeTabId, setActiveTabId] = useState<string>(defaultActiveTabId ?? '');
+  const [activeTabId, setActiveTabId] = useState<number>(defaultActiveTabId ?? 0);
 
-  const handleTabClick = (id: string) => {
+  const handleTabClick = (id: number) => {
     setActiveTabId(id);
     if (onTabChange) {
       onTabChange(id);

--- a/src/components/common/tab/Tab.tsx
+++ b/src/components/common/tab/Tab.tsx
@@ -16,7 +16,7 @@ export const TabItem = ({ label, isActive, onClick }: TabItemProps) => {
         onClick={onClick}
         className={`peer gap- py-(--gap-3xs)4xs label-bold-lg inline-flex items-center justify-center px-(--gap-md) text-center ${
           isActive
-            ? 'text-object-hero-dark stroke-bold border-accent-normal-dark'
+            ? 'text-object-hero-dark stroke-bold border-accent-normal-dark relative z-10 -mb-px'
             : 'text-object-alternative-dark'
         }`}
       >

--- a/src/components/common/tab/Tab.types.ts
+++ b/src/components/common/tab/Tab.types.ts
@@ -1,0 +1,7 @@
+import { ReactNode } from 'react';
+
+export interface TabsProps {
+  children: ReactNode;
+  defaultActiveTabId?: string;
+  onTabChange?: (activeTabId: string) => void;
+}

--- a/src/components/common/tab/Tab.types.ts
+++ b/src/components/common/tab/Tab.types.ts
@@ -2,6 +2,6 @@ import { ReactNode } from 'react';
 
 export interface TabProps {
   children: ReactNode;
-  defaultActiveTabId?: string;
-  onTabChange?: (activeTabId: string) => void;
+  defaultActiveTabId?: number;
+  onTabChange?: (activeTabId: number) => void;
 }

--- a/src/components/common/tab/Tab.types.ts
+++ b/src/components/common/tab/Tab.types.ts
@@ -1,6 +1,6 @@
 import { ReactNode } from 'react';
 
-export interface TabsProps {
+export interface TabProps {
   children: ReactNode;
   defaultActiveTabId?: string;
   onTabChange?: (activeTabId: string) => void;


### PR DESCRIPTION
## 💡 작업 내용

- [x] TabItem 컴포넌트 구현
- [x] Tab 컴포넌트 구현

## 💡 자세한 설명
처음 구현했던 구조를 한번 갈아엎는 과정에서.... 약간의 시간이 소요되었습니다! 😂 

### ✅ Compound (Component) Pattern 사용
- 전체 Tab 의 경우에는 Tab 컴포넌트를 props로 가지는 것이 아닌 children의 속성을 `TabItem` 으로 좁혀서 선언하였습니다.
- 필요에 따라서 기본 선택 속성인 `defaultActiveTabId` 을 옵셔널로 선언하였고, 해당 props이 없다면 첫번째 TabItem으로 선택되도록 처리했습니다.

```typescript
const tabItems = Array.isArray(children) ? children : [children];
```
는 children이 하나 일 때의 경우를 상정한 것입니다.

### ✅ cloneElement 시의 흐름
`TabItems`의 isActive와 onClick의 경우 부모인 Tab에서 TabItem에게 해당 값을 직접 주입하여 사용합니다.

다시 말해, Tab 내부에 TabItems의 경우 해당 props이 의존적이며, 독립적으로 사용될 경우 자체적인 props이 됩니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항
- 추가 발견한 문제 : 디자인에서와 실제 적용되는 typo의 미세한 차이로 인해, 스토리북에서 Tab Header의 끝부분이 미세하게 비어있는 문제가 발생하였습니다. 해당 부분을 이슈로 남겨놓을지, 해당 부분까지 수정을 해야할지 고민되네요.

## ✅  추가 구현 사항
(02.15 추가됨)
- Context API 방식을 활용해, Tab 컴포넌트는 string 형태의 id를 이용하여 Tab Header 부분과 해당 항목에 속하는 내용물인 Tab Panel을 조작할 수 있도록 수정했습니다.

- 실질적으로 사용하는 Tab 컴포넌트의 인터페이스는 Tab.types.ts 로 분리하였습니다.

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [ ] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #27 
