### PR TITLE
feat: Select 컴포넌트 구현

### DIFF
--- a/src/components/common/select/Select.stories.tsx
+++ b/src/components/common/select/Select.stories.tsx
@@ -49,3 +49,20 @@ export const SelectStory: Story = {
     </div>
   ),
 };
+
+export const SelectWithDefaultValueStory: Story = {
+  name: 'Select with Default Value',
+  render: () => (
+    <div className='w-[26.25rem]'>
+      <Select
+        items={[
+          { label: '프론트엔드 개발자' },
+          { label: '백엔드 개발자' },
+          { label: '프로젝트 매니저' },
+          { label: '프로덕트 디자이너' },
+        ]}
+        defaultValue='백엔드 개발자'
+      />
+    </div>
+  ),
+};

--- a/src/components/common/select/Select.stories.tsx
+++ b/src/components/common/select/Select.stories.tsx
@@ -37,13 +37,15 @@ export const DefaultStory: Story = {
 export const SelectStory: Story = {
   name: 'Select',
   render: () => (
-    <Select
-      items={[
-        { label: '프론트엔드 개발자' },
-        { label: '백엔드 개발자' },
-        { label: '프로젝트 매니저', disabled: true },
-        { label: '프로덕트 디자이너' },
-      ]}
-    />
+    <div className='w-[26.25rem]'>
+      <Select
+        items={[
+          { label: '프론트엔드 개발자' },
+          { label: '백엔드 개발자' },
+          { label: '프로젝트 매니저', disabled: true },
+          { label: '프로덕트 디자이너' },
+        ]}
+      />
+    </div>
   ),
 };

--- a/src/components/common/select/Select.stories.tsx
+++ b/src/components/common/select/Select.stories.tsx
@@ -7,9 +7,9 @@ const meta: Meta<typeof Select> = {
   component: Select,
   argTypes: {
     items: {
-      control: 'array',
+      control: 'object',
       description:
-        '선택 옵션 이름을 배열 형태로 입력합니다. 배열의 요소에는 label 명이 들어갑니다.',
+        '선택 옵션 객체 배열입니다. 각 객체는 label과 선택적으로 disabled 속성을 가집니다.',
     },
     onChange: {
       action: 'changed',
@@ -17,7 +17,12 @@ const meta: Meta<typeof Select> = {
     },
   },
   args: {
-    items: ['Option 1', 'Option 2', 'Option 3'],
+    items: [
+      { label: '프론트엔드 개발자' },
+      { label: '백엔드 개발자' },
+      { label: '프로젝트 매니저' },
+      { label: '프로덕트 디자이너' },
+    ],
   },
 };
 
@@ -33,7 +38,12 @@ export const SelectStory: Story = {
   name: 'Select',
   render: () => (
     <Select
-      items={['프론트엔드 개발자', '백엔드 개발자', '프로젝트 매니저', '프로덕트 디자이너']}
+      items={[
+        { label: '프론트엔드 개발자' },
+        { label: '백엔드 개발자' },
+        { label: '프로젝트 매니저', disabled: true },
+        { label: '프로덕트 디자이너' },
+      ]}
     />
   ),
 };

--- a/src/components/common/select/Select.stories.tsx
+++ b/src/components/common/select/Select.stories.tsx
@@ -1,0 +1,39 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import { Select } from './Select';
+
+const meta: Meta<typeof Select> = {
+  title: 'Components/Select',
+  component: Select,
+  argTypes: {
+    items: {
+      control: 'array',
+      description:
+        '선택 옵션 이름을 배열 형태로 입력합니다. 배열의 요소에는 label 명이 들어갑니다.',
+    },
+    onChange: {
+      action: 'changed',
+      description: '아이템 선택 시 호출되는 콜백입니다.',
+    },
+  },
+  args: {
+    items: ['Option 1', 'Option 2', 'Option 3'],
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof Select>;
+
+export const DefaultStory: Story = {
+  name: 'Default Select',
+};
+
+export const SelectStory: Story = {
+  name: 'Select',
+  render: () => (
+    <Select
+      items={['프론트엔드 개발자', '백엔드 개발자', '프로젝트 매니저', '프로덕트 디자이너']}
+    />
+  ),
+};

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -7,14 +7,14 @@ import Interaction from '@/components/common/interaction/Interaction';
 interface SelectItemProps extends ComponentPropsWithoutRef<'button'> {
   label: string;
   isSelected: boolean;
-  onClick: (label: string) => void;
+  clickHandler: (label: string) => void;
   children?: ReactNode;
 }
 
 export const SelectItem = ({
   label,
   isSelected,
-  onClick,
+  clickHandler,
   disabled = false,
   children,
   ...restProps
@@ -34,7 +34,7 @@ export const SelectItem = ({
     >
       <button
         type='button'
-        onClick={() => !disabled && onClick(label)}
+        onClick={() => !disabled && clickHandler(label)}
         disabled={!!disabled}
         className={buttonClass}
         {...restProps}
@@ -72,7 +72,7 @@ export const Select = ({ items, onChange }: SelectProps) => {
           key={label}
           label={label}
           isSelected={selectedValue === label}
-          onClick={handleItemClick}
+          clickHandler={handleItemClick}
           disabled={disabled}
         >
           {selectedValue === label && (

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -53,11 +53,12 @@ interface SelectOption {
 
 interface SelectProps {
   items: SelectOption[];
+  defaultValue?: string | null;
   onChange?: (label: string | null) => void;
 }
 
-export const Select = ({ items, onChange }: SelectProps) => {
-  const [selectedValue, setSelectedValue] = useState<string | null>(null);
+export const Select = ({ items, defaultValue = null, onChange }: SelectProps) => {
+  const [selectedValue, setSelectedValue] = useState<string | null>(defaultValue);
 
   const handleItemClick = (label: string) => {
     const newValue = selectedValue === label ? null : label;

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -1,0 +1,56 @@
+import { ReactNode, useState } from 'react';
+
+import Icon from '@/components/common/icon/Icon';
+
+interface SelectItemProps {
+  label: string;
+  isSelected: boolean;
+  onClick: (label: string) => void;
+  children?: ReactNode;
+}
+
+export const SelectItem = ({ label, isSelected, onClick, children }: SelectItemProps) => {
+  return (
+    <div
+      onClick={() => onClick(label)}
+      className={`radius-xs opacity-visible flex cursor-pointer items-start justify-between p-(--gap-sm) ${
+        isSelected ? 'text-object-hero-dark' : 'text-object-neutral-dark'
+      }`}
+    >
+      <span className='body-lg self-stretch'>{label}</span>
+      {children}
+    </div>
+  );
+};
+
+interface SelectProps {
+  items: string[];
+  onChange?: (label: string | null) => void;
+}
+
+export const Select = ({ items, onChange }: SelectProps) => {
+  const [selectedValue, setSelectedValue] = useState<string | null>(null);
+
+  const handleItemClick = (label: string) => {
+    const newValue = selectedValue === label ? null : label;
+    setSelectedValue(newValue);
+    onChange?.(newValue);
+  };
+
+  return (
+    <div className='gap-5xs radius-md border-border-trans-assistive-dark bg-surface-embossed-dark opacity-visible shadow-overlay flex w-[20rem] flex-col p-(--gap-2xs)'>
+      {items.map(item => (
+        <SelectItem
+          key={item}
+          label={item}
+          isSelected={selectedValue === item}
+          onClick={handleItemClick}
+        >
+          {selectedValue === item && (
+            <Icon name='check' size='lg' fillColor='fill-object-hero-dark' />
+          )}
+        </SelectItem>
+      ))}
+    </div>
+  );
+};

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -12,7 +12,12 @@ interface SelectItemProps {
 
 export const SelectItem = ({ label, isSelected, onClick, children }: SelectItemProps) => {
   return (
-    <Interaction variant='default' density='normal' isInversed={false}>
+    <Interaction
+      variant='default'
+      density='normal'
+      isInversed={false}
+      className='peer hover:duration-faster hover:ease-(--motion-fluent)'
+    >
       <button
         onClick={() => onClick(label)}
         className={`peer radius-xs opacity-visible flex w-full cursor-pointer items-start justify-between p-(--gap-sm) ${

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -1,16 +1,15 @@
 import clsx from 'clsx';
-import { ReactNode, useState } from 'react';
+import { ComponentPropsWithoutRef, ReactNode, useState } from 'react';
 
 import Icon from '@/components/common/icon/Icon';
 import Interaction from '@/components/common/interaction/Interaction';
 
-type SelectItemProps = {
+interface SelectItemProps extends ComponentPropsWithoutRef<'button'> {
   label: string;
   isSelected: boolean;
   onClick: (label: string) => void;
-  disabled?: boolean;
   children?: ReactNode;
-};
+}
 
 export const SelectItem = ({
   label,
@@ -18,9 +17,10 @@ export const SelectItem = ({
   onClick,
   disabled = false,
   children,
+  ...rest
 }: SelectItemProps) => {
   const buttonClass = clsx('peer radius-xs flex w-full items-start justify-between p-(--gap-sm)', {
-    'text-object-disabled-dark cursor-not-allowed pointer-events-none': disabled,
+    'text-object-disabled-dark cursor-not-allowed pointer-events-none': !!disabled,
     'text-object-hero-dark cursor-pointer pointer-events-auto': !disabled && isSelected,
     'text-object-neutral-dark cursor-pointer pointer-events-auto': !disabled && !isSelected,
   });
@@ -33,9 +33,11 @@ export const SelectItem = ({
       className='peer-hover:duration-faster peer-hover:ease-(--motion-fluent)'
     >
       <button
+        type='button'
         onClick={() => !disabled && onClick(label)}
         disabled={!!disabled}
         className={buttonClass}
+        {...rest}
       >
         <span className='body-lg self-stretch'>{label}</span>
         {children}
@@ -44,10 +46,10 @@ export const SelectItem = ({
   );
 };
 
-type SelectOption = {
+interface SelectOption {
   label: string;
   disabled?: boolean;
-};
+}
 
 interface SelectProps {
   items: SelectOption[];

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -1,16 +1,30 @@
+import clsx from 'clsx';
 import { ReactNode, useState } from 'react';
 
 import Icon from '@/components/common/icon/Icon';
 import Interaction from '@/components/common/interaction/Interaction';
 
-interface SelectItemProps {
+type SelectItemProps = {
   label: string;
   isSelected: boolean;
   onClick: (label: string) => void;
+  disabled?: boolean;
   children?: ReactNode;
-}
+};
 
-export const SelectItem = ({ label, isSelected, onClick, children }: SelectItemProps) => {
+export const SelectItem = ({
+  label,
+  isSelected,
+  onClick,
+  disabled = false,
+  children,
+}: SelectItemProps) => {
+  const buttonClass = clsx('peer radius-xs flex w-full items-start justify-between p-(--gap-sm)', {
+    'text-object-disabled-dark cursor-not-allowed pointer-events-none': disabled,
+    'text-object-hero-dark cursor-pointer pointer-events-auto': !disabled && isSelected,
+    'text-object-neutral-dark cursor-pointer pointer-events-auto': !disabled && !isSelected,
+  });
+
   return (
     <Interaction
       variant='default'
@@ -19,10 +33,9 @@ export const SelectItem = ({ label, isSelected, onClick, children }: SelectItemP
       className='peer hover:duration-faster hover:ease-(--motion-fluent)'
     >
       <button
-        onClick={() => onClick(label)}
-        className={`peer radius-xs opacity-visible flex w-full cursor-pointer items-start justify-between p-(--gap-sm) ${
-          isSelected ? 'text-object-hero-dark' : 'text-object-neutral-dark'
-        }`}
+        onClick={() => !disabled && onClick(label)}
+        disabled={!!disabled}
+        className={buttonClass}
       >
         <span className='body-lg self-stretch'>{label}</span>
         {children}
@@ -31,8 +44,13 @@ export const SelectItem = ({ label, isSelected, onClick, children }: SelectItemP
   );
 };
 
+type SelectOption = {
+  label: string;
+  disabled?: boolean;
+};
+
 interface SelectProps {
-  items: string[];
+  items: SelectOption[];
   onChange?: (label: string | null) => void;
 }
 
@@ -47,14 +65,15 @@ export const Select = ({ items, onChange }: SelectProps) => {
 
   return (
     <div className='gap-5xs radius-md border-border-trans-assistive-dark bg-surface-embossed-dark opacity-visible shadow-overlay flex w-[20rem] flex-col border p-(--gap-2xs)'>
-      {items.map(item => (
+      {items.map(({ label, disabled }) => (
         <SelectItem
-          key={item}
-          label={item}
-          isSelected={selectedValue === item}
+          key={label}
+          label={label}
+          isSelected={selectedValue === label}
           onClick={handleItemClick}
+          disabled={disabled}
         >
-          {selectedValue === item && (
+          {selectedValue === label && (
             <Icon name='check' size='lg' fillColor='fill-object-hero-dark' />
           )}
         </SelectItem>

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -1,6 +1,7 @@
 import { ReactNode, useState } from 'react';
 
 import Icon from '@/components/common/icon/Icon';
+import Interaction from '@/components/common/interaction/Interaction';
 
 interface SelectItemProps {
   label: string;
@@ -11,15 +12,17 @@ interface SelectItemProps {
 
 export const SelectItem = ({ label, isSelected, onClick, children }: SelectItemProps) => {
   return (
-    <div
-      onClick={() => onClick(label)}
-      className={`radius-xs opacity-visible flex cursor-pointer items-start justify-between p-(--gap-sm) ${
-        isSelected ? 'text-object-hero-dark' : 'text-object-neutral-dark'
-      }`}
-    >
-      <span className='body-lg self-stretch'>{label}</span>
-      {children}
-    </div>
+    <Interaction variant='default' density='normal' isInversed={false}>
+      <button
+        onClick={() => onClick(label)}
+        className={`peer radius-xs opacity-visible flex w-full cursor-pointer items-start justify-between p-(--gap-sm) ${
+          isSelected ? 'text-object-hero-dark' : 'text-object-neutral-dark'
+        }`}
+      >
+        <span className='body-lg self-stretch'>{label}</span>
+        {children}
+      </button>
+    </Interaction>
   );
 };
 
@@ -38,7 +41,7 @@ export const Select = ({ items, onChange }: SelectProps) => {
   };
 
   return (
-    <div className='gap-5xs radius-md border-border-trans-assistive-dark bg-surface-embossed-dark opacity-visible shadow-overlay flex w-[20rem] flex-col p-(--gap-2xs)'>
+    <div className='gap-5xs radius-md border-border-trans-assistive-dark bg-surface-embossed-dark opacity-visible shadow-overlay flex w-[20rem] flex-col border p-(--gap-2xs)'>
       {items.map(item => (
         <SelectItem
           key={item}

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -66,7 +66,7 @@ export const Select = ({ items, onChange }: SelectProps) => {
   };
 
   return (
-    <div className='gap-5xs radius-md border-border-trans-assistive-dark bg-surface-embossed-dark opacity-visible shadow-overlay flex w-[20rem] flex-col border p-(--gap-2xs)'>
+    <div className='gap-5xs radius-md border-border-trans-assistive-dark bg-surface-embossed-dark opacity-visible shadow-overlay flex w-full flex-col border p-(--gap-2xs)'>
       {items.map(({ label, disabled }) => (
         <SelectItem
           key={label}

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -30,7 +30,7 @@ export const SelectItem = ({
       variant='default'
       density='normal'
       isInversed={false}
-      className='peer hover:duration-faster hover:ease-(--motion-fluent)'
+      className='peer-hover:duration-faster peer-hover:ease-(--motion-fluent)'
     >
       <button
         onClick={() => !disabled && onClick(label)}

--- a/src/components/common/select/Select.tsx
+++ b/src/components/common/select/Select.tsx
@@ -17,7 +17,7 @@ export const SelectItem = ({
   onClick,
   disabled = false,
   children,
-  ...rest
+  ...restProps
 }: SelectItemProps) => {
   const buttonClass = clsx('peer radius-xs flex w-full items-start justify-between p-(--gap-sm)', {
     'text-object-disabled-dark cursor-not-allowed pointer-events-none': !!disabled,
@@ -37,7 +37,7 @@ export const SelectItem = ({
         onClick={() => !disabled && onClick(label)}
         disabled={!!disabled}
         className={buttonClass}
-        {...rest}
+        {...restProps}
       >
         <span className='body-lg self-stretch'>{label}</span>
         {children}

--- a/src/components/common/tab/Tab.tsx
+++ b/src/components/common/tab/Tab.tsx
@@ -1,4 +1,4 @@
-import React, { createContext, useState, useContext, ReactNode } from 'react';
+import { createContext, useState, useContext, ReactNode } from 'react';
 
 import Interaction from '@/components/common/interaction/Interaction.tsx';
 import { TabProps } from '@/components/common/tab/Tab.types.ts';


### PR DESCRIPTION
## 💡 작업 내용

- [x] Select 컴포넌트 구현

## 💡 자세한 설명

### ✅ 컴포넌트 관련
- Select의 경우 복잡한 구조를 가지고 있거나, 추가적인 렌더링 처리가 불필요해 보여 Tab의 경우와는 다르게 Compound Component Pattern은 사용하지 않았습니다.

- SelectItem의 children의 경우 clicked 되었을 때 우측에 오는 Icon 컴포넌트가 오는 공간입니다. 확장성 있는 방식을 위해 `children?: ReactNode;` 처리를 하였습니다.

- 실제로 컴포넌트에서 사용하는 인터페이스만 interface 형태를 사용하였고, 내부적인 요소들은 type으로 선언했습니다.

- `handleItemClick` 에서 이미 선택된 항목을 다시 클릭 시 클릭이 해제되도록 처리했습니다. 또한 onChange 콜백이 존재한다면 이를 이후 호출합니다. 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
Interaction에 duration과 motion 주입 시 
```typescript
    <Interaction
      variant='default'
      density='normal'
      isInversed={false}
      className='peer-hover:duration-faster peer-hover:ease-(--motion-fluent)'
    >
```
로 표현되는데, 적용은 잘 되는거 같네요. 이러한 방식이 합당한지 궁금합니다.

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #28 
