### PR TITLE
feat: SnackBar 컴포넌트 구현

### DIFF
--- a/src/components/common/button/BlockButton.stories.tsx
+++ b/src/components/common/button/BlockButton.stories.tsx
@@ -41,7 +41,7 @@ export default meta;
 type Story = StoryObj<typeof BlockButton>;
 
 export const DefaultStory: Story = {
-  name: 'Default Button',
+  name: 'Default BlockButton',
   render: args => (
     <div className='story-container'>
       <div className='story-inner-container'>
@@ -54,7 +54,7 @@ export const DefaultStory: Story = {
 };
 
 export const ButtonStory: Story = {
-  name: 'Button',
+  name: 'BlockButton',
   render: () => (
     <div className='story-container'>
       <div className='story-inner-container'>
@@ -81,7 +81,7 @@ export const ButtonStory: Story = {
 };
 
 export const IconButtonStory: Story = {
-  name: 'Icon Button',
+  name: 'Icon BlockButton',
   render: () => (
     <div className='story-container'>
       <div className='story-inner-container'>

--- a/src/components/common/button/BlockButton.stories.tsx
+++ b/src/components/common/button/BlockButton.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import BlockButton from './BlockButton';
 
+import Icon from '@/components/common/icon/Icon';
+
 const meta: Meta<typeof BlockButton> = {
   title: 'Components/BlockButton',
   component: BlockButton,
@@ -21,12 +23,35 @@ const meta: Meta<typeof BlockButton> = {
       options: ['accent', 'primary', 'secondary', 'tertiary'],
       description: '버튼의 색상이 분기되는 위계 요소입니다.',
     },
+    disabled: {
+      control: { type: 'boolean' },
+      description: '버튼 비활성화 여부입니다.',
+    },
+  },
+  args: {
+    size: 'lg',
+    style: 'solid',
+    hierarchy: 'accent',
+    disabled: false,
   },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof BlockButton>;
+
+export const DefaultStory: Story = {
+  name: 'Default Button',
+  render: args => (
+    <div className='story-container'>
+      <div className='story-inner-container'>
+        <div className='story-inner-row-container'>
+          <BlockButton {...args}>레이블</BlockButton>
+        </div>
+      </div>
+    </div>
+  ),
+};
 
 export const ButtonStory: Story = {
   name: 'Button',
@@ -46,6 +71,9 @@ export const ButtonStory: Story = {
           <BlockButton size='lg' style='solid' hierarchy='tertiary'>
             레이블
           </BlockButton>
+          <BlockButton size='lg' style='solid' hierarchy='accent' disabled={true}>
+            레이블
+          </BlockButton>
         </div>
       </div>
     </div>
@@ -62,8 +90,12 @@ export const IconButtonStory: Story = {
             size='lg'
             style='solid'
             hierarchy='accent'
-            leftIcon={<span>→</span>}
-            rightIcon={<span>→</span>}
+            leftIcon={
+              <Icon name='check' size='md' fillColor='fill-object-static-inverse-hero-dark' />
+            }
+            rightIcon={
+              <Icon name='check' size='md' fillColor='fill-object-static-inverse-hero-dark' />
+            }
           >
             레이블
           </BlockButton>
@@ -71,8 +103,8 @@ export const IconButtonStory: Story = {
             size='lg'
             style='solid'
             hierarchy='primary'
-            leftIcon={<span>→</span>}
-            rightIcon={<span>→</span>}
+            leftIcon={<Icon name='check' size='md' fillColor='fill-object-inverse-hero-dark' />}
+            rightIcon={<Icon name='check' size='md' fillColor='fill-object-inverse-hero-dark' />}
           >
             레이블
           </BlockButton>
@@ -80,8 +112,12 @@ export const IconButtonStory: Story = {
             size='lg'
             style='solid'
             hierarchy='secondary'
-            leftIcon={<span>→</span>}
-            rightIcon={<span>→</span>}
+            leftIcon={
+              <Icon name='check' size='md' fillColor='fill-object-static-inverse-hero-dark' />
+            }
+            rightIcon={
+              <Icon name='check' size='md' fillColor='fill-object-static-inverse-hero-dark' />
+            }
           >
             레이블
           </BlockButton>
@@ -89,8 +125,8 @@ export const IconButtonStory: Story = {
             size='lg'
             style='solid'
             hierarchy='tertiary'
-            leftIcon={<span>→</span>}
-            rightIcon={<span>→</span>}
+            leftIcon={<Icon name='check' size='md' fillColor='fill-object-neutral-dark' />}
+            rightIcon={<Icon name='check' size='md' fillColor='fill-object-neutral-dark' />}
           >
             레이블
           </BlockButton>

--- a/src/components/common/button/BlockButton.stories.tsx
+++ b/src/components/common/button/BlockButton.stories.tsx
@@ -130,6 +130,16 @@ export const IconButtonStory: Story = {
           >
             레이블
           </BlockButton>
+          <BlockButton
+            size='lg'
+            style='solid'
+            hierarchy='accent'
+            leftIcon={<Icon name='check' size='md' fillColor='fill-accent-trans-hero-dark' />}
+            rightIcon={<Icon name='check' size='md' fillColor='fill-accent-trans-hero-dark' />}
+            disabled={true}
+          >
+            레이블
+          </BlockButton>
         </div>
       </div>
     </div>

--- a/src/components/common/button/BlockButton.tsx
+++ b/src/components/common/button/BlockButton.tsx
@@ -21,7 +21,7 @@ export interface BlockButtonProps extends ComponentPropsWithoutRef<'button'> {
 
 export const BlockButton = forwardRef<HTMLButtonElement, BlockButtonProps>(
   ({ children, leftIcon, rightIcon, size, style, hierarchy, className, ...props }, ref) => {
-    const baseClasses = 'inline-flex flex-row justify-center items-center gap-4xs';
+    const baseClasses = 'peer inline-flex flex-row justify-center items-center gap-4xs';
 
     const combinedClasses = clsx(
       baseClasses,

--- a/src/components/common/button/BlockButton.tsx
+++ b/src/components/common/button/BlockButton.tsx
@@ -30,11 +30,18 @@ export const BlockButton = forwardRef<HTMLButtonElement, BlockButtonProps>(
       className,
     );
 
-    const { variant: interactionVariant, density: interactionDensity } =
-      blockButtonInteractionMap[style][hierarchy];
+    const {
+      variant: interactionVariant,
+      density: interactionDensity,
+      isInversed: isInteractionInversed,
+    } = blockButtonInteractionMap[style][hierarchy];
 
     return (
-      <Interaction variant={interactionVariant} density={interactionDensity}>
+      <Interaction
+        variant={interactionVariant}
+        density={interactionDensity}
+        isInversed={isInteractionInversed}
+      >
         <button ref={ref} className={combinedClasses} {...props}>
           {leftIcon && leftIcon}
           {children}

--- a/src/components/common/button/BlockButton.tsx
+++ b/src/components/common/button/BlockButton.tsx
@@ -50,6 +50,7 @@ export const BlockButton = forwardRef<HTMLButtonElement, BlockButtonProps>(
         variant={interactionVariant}
         density={interactionDensity}
         isInversed={isInteractionInversed}
+        className='peer-hover:duration-faster peer-hover:ease-(--motion-fluent)'
       >
         <button ref={ref} className={combinedClasses} disabled={!!disabled} {...props}>
           {leftIcon && leftIcon}

--- a/src/components/common/button/BlockButton.tsx
+++ b/src/components/common/button/BlockButton.tsx
@@ -20,14 +20,23 @@ export interface BlockButtonProps extends ComponentPropsWithoutRef<'button'> {
 }
 
 export const BlockButton = forwardRef<HTMLButtonElement, BlockButtonProps>(
-  ({ children, leftIcon, rightIcon, size, style, hierarchy, className, ...props }, ref) => {
+  (
+    { children, leftIcon, rightIcon, size, style, hierarchy, className, disabled, ...props },
+    ref,
+  ) => {
     const baseClasses = 'peer inline-flex flex-row justify-center items-center gap-4xs';
 
     const combinedClasses = clsx(
       baseClasses,
       blockButtonStyle.size[size],
-      blockButtonStyle.variant[style][hierarchy],
+      disabled
+        ? blockButtonStyle.disabled?.[style][hierarchy]
+        : blockButtonStyle.variant[style][hierarchy],
       className,
+      {
+        'cursor-not-allowed pointer-events-none': disabled,
+        'cursor-pointer pointer-events-auto': !disabled,
+      },
     );
 
     const {
@@ -42,7 +51,7 @@ export const BlockButton = forwardRef<HTMLButtonElement, BlockButtonProps>(
         density={interactionDensity}
         isInversed={isInteractionInversed}
       >
-        <button ref={ref} className={combinedClasses} {...props}>
+        <button ref={ref} className={combinedClasses} disabled={!!disabled} {...props}>
           {leftIcon && leftIcon}
           {children}
           {rightIcon && rightIcon}

--- a/src/components/common/button/LabelButton.stories.tsx
+++ b/src/components/common/button/LabelButton.stories.tsx
@@ -2,6 +2,8 @@ import type { Meta, StoryObj } from '@storybook/react';
 
 import LabelButton from './LabelButton';
 
+import Icon from '@/components/common/icon/Icon';
+
 const meta: Meta<typeof LabelButton> = {
   title: 'Components/LabelButton',
   component: LabelButton,
@@ -16,12 +18,34 @@ const meta: Meta<typeof LabelButton> = {
       options: ['accent', 'primary', 'secondary', 'tertiary'],
       description: '버튼의 색상이 분기되는 위계 요소입니다.',
     },
+    disabled: {
+      control: { type: 'boolean' },
+      description: '버튼 비활성화 여부입니다.',
+    },
+  },
+  args: {
+    size: 'lg',
+    hierarchy: 'accent',
+    disabled: false,
   },
 };
 
 export default meta;
 
 type Story = StoryObj<typeof LabelButton>;
+
+export const DefaultStory: Story = {
+  name: 'Default LabelButton',
+  render: args => (
+    <div className='story-container'>
+      <div className='story-inner-container'>
+        <div className='story-inner-row-container'>
+          <LabelButton {...args}>레이블</LabelButton>
+        </div>
+      </div>
+    </div>
+  ),
+};
 
 export const ButtonStory: Story = {
   name: 'Button',
@@ -41,6 +65,9 @@ export const ButtonStory: Story = {
           <LabelButton size='lg' hierarchy='tertiary'>
             레이블
           </LabelButton>
+          <LabelButton size='lg' hierarchy='accent' disabled={true}>
+            레이블
+          </LabelButton>
         </div>
       </div>
     </div>
@@ -48,40 +75,47 @@ export const ButtonStory: Story = {
 };
 
 export const IconButtonStory: Story = {
-  name: 'Icon Button',
-  render: () => (
+  name: 'Icon LabelButton',
+  render: args => (
     <div className='story-container'>
       <div className='story-inner-container'>
         <div className='story-inner-row-container'>
           <LabelButton
-            size='lg'
-            hierarchy='accent'
-            leftIcon={<span>→</span>}
-            rightIcon={<span>→</span>}
+            {...args}
+            leftIcon={<Icon name='check' size='md' fillColor='fill-accent-hero-dark' />}
+            rightIcon={<Icon name='check' size='md' fillColor='fill-accent-hero-dark' />}
           >
             레이블
           </LabelButton>
           <LabelButton
-            size='lg'
+            {...args}
             hierarchy='primary'
-            leftIcon={<span>→</span>}
-            rightIcon={<span>→</span>}
+            leftIcon={<Icon name='check' size='md' fillColor='fill-object-hero-dark' />}
+            rightIcon={<Icon name='check' size='md' fillColor='fill-object-hero-dark' />}
           >
             레이블
           </LabelButton>
           <LabelButton
-            size='lg'
+            {...args}
             hierarchy='secondary'
-            leftIcon={<span>→</span>}
-            rightIcon={<span>→</span>}
+            leftIcon={<Icon name='check' size='md' fillColor='fill-object-neutral-dark' />}
+            rightIcon={<Icon name='check' size='md' fillColor='fill-object-neutral-dark' />}
           >
             레이블
           </LabelButton>
           <LabelButton
-            size='lg'
+            {...args}
             hierarchy='tertiary'
-            leftIcon={<span>→</span>}
-            rightIcon={<span>→</span>}
+            leftIcon={<Icon name='check' size='md' fillColor='fill-object-alternative-dark' />}
+            rightIcon={<Icon name='check' size='md' fillColor='fill-object-alternative-dark' />}
+          >
+            레이블
+          </LabelButton>
+          <LabelButton
+            {...args}
+            leftIcon={<Icon name='check' size='md' fillColor='fill-accent-trans-hero-dark' />}
+            rightIcon={<Icon name='check' size='md' fillColor='fill-accent-trans-hero-dark' />}
+            disabled={true}
           >
             레이블
           </LabelButton>

--- a/src/components/common/button/LabelButton.stories.tsx
+++ b/src/components/common/button/LabelButton.stories.tsx
@@ -48,7 +48,7 @@ export const DefaultStory: Story = {
 };
 
 export const ButtonStory: Story = {
-  name: 'Button',
+  name: 'LabelButton',
   render: () => (
     <div className='story-container'>
       <div className='story-inner-container'>

--- a/src/components/common/button/LabelButton.stories.tsx
+++ b/src/components/common/button/LabelButton.stories.tsx
@@ -124,3 +124,33 @@ export const IconButtonStory: Story = {
     </div>
   ),
 };
+
+export const IconOnlyStory: Story = {
+  name: 'Icon Only LabelButton',
+  render: () => (
+    <div className='story-container'>
+      <div className='story-inner-container'>
+        <div className='story-inner-row-container'>
+          <LabelButton
+            size='large'
+            hierarchy='secondary'
+            leftIcon={<Icon name='clear' size='md' fillColor='fill-accent-hero-dark' />}
+          />
+          <LabelButton
+            size='large'
+            hierarchy='secondary'
+            rightIcon={<Icon name='clear' size='md' fillColor='fill-object-hero-dark' />}
+          />
+
+          <LabelButton
+            size='large'
+            hierarchy='secondary'
+            leftIcon={<Icon name='clear' size='md' fillColor='fill-object-neutral-dark' />}
+            rightIcon={<Icon name='clear' size='md' fillColor='fill-object-neutral-dark' />}
+            disabled={true}
+          />
+        </div>
+      </div>
+    </div>
+  ),
+};

--- a/src/components/common/button/LabelButton.tsx
+++ b/src/components/common/button/LabelButton.tsx
@@ -45,6 +45,7 @@ export const LabelButton = forwardRef<HTMLButtonElement, LabelButtonProps>(
         density={interactionDensity}
         isInversed={isInteractionInversed}
         className='peer-hover:duration-faster peer-hover:ease-(--motion-fluent)'
+        scale='scale-x-118 scale-y-129'
       >
         <button ref={ref} className={combinedClasses} disabled={!!disabled} {...props}>
           {leftIcon && leftIcon}

--- a/src/components/common/button/LabelButton.tsx
+++ b/src/components/common/button/LabelButton.tsx
@@ -33,11 +33,18 @@ export const LabelButton = forwardRef<HTMLButtonElement, LabelButtonProps>(
       className,
     );
 
-    const { variant: interactionVariant, density: interactionDensity } =
-      labelButtonInteractionMap[hierarchy];
+    const {
+      variant: interactionVariant,
+      density: interactionDensity,
+      isInversed: isInteractionInversed,
+    } = labelButtonInteractionMap[hierarchy];
 
     return (
-      <Interaction variant={interactionVariant} density={interactionDensity}>
+      <Interaction
+        variant={interactionVariant}
+        density={interactionDensity}
+        isInversed={isInteractionInversed}
+      >
         <button ref={ref} className={combinedClasses} disabled={!!disabled} {...props}>
           {leftIcon && leftIcon}
           {children}

--- a/src/components/common/button/LabelButton.tsx
+++ b/src/components/common/button/LabelButton.tsx
@@ -7,7 +7,6 @@ import {
   Size,
   Hierarchy,
   labelButtonInteractionMap,
-  labelButtonOutlineOffsetMap,
 } from '@/styles/labelButtonStyle';
 
 export interface LabelButtonProps extends ComponentPropsWithoutRef<'button'> {
@@ -37,14 +36,8 @@ export const LabelButton = forwardRef<HTMLButtonElement, LabelButtonProps>(
     const { variant: interactionVariant, density: interactionDensity } =
       labelButtonInteractionMap[hierarchy];
 
-    const outlineOffset = labelButtonOutlineOffsetMap[size];
-
     return (
-      <Interaction
-        variant={interactionVariant}
-        density={interactionDensity}
-        outlineOffset={outlineOffset}
-      >
+      <Interaction variant={interactionVariant} density={interactionDensity}>
         <button ref={ref} className={combinedClasses} disabled={!!disabled} {...props}>
           {leftIcon && leftIcon}
           {children}

--- a/src/components/common/button/LabelButton.tsx
+++ b/src/components/common/button/LabelButton.tsx
@@ -19,14 +19,18 @@ export interface LabelButtonProps extends ComponentPropsWithoutRef<'button'> {
 }
 
 export const LabelButton = forwardRef<HTMLButtonElement, LabelButtonProps>(
-  ({ children, leftIcon, rightIcon, size, hierarchy, className, ...props }, ref) => {
+  ({ children, leftIcon, rightIcon, size, hierarchy, className, disabled, ...props }, ref) => {
     const baseClasses =
       'inline-flex flex-row py-0 px-0 justify-center items-center gap-4xs radius-xs';
 
     const combinedClasses = clsx(
       baseClasses,
       labelButtonStyle.size[size],
-      labelButtonStyle.hierarchy[hierarchy],
+      disabled ? labelButtonStyle.disabled?.[hierarchy] : labelButtonStyle.hierarchy[hierarchy],
+      {
+        'cursor-not-allowed pointer-events-none': disabled,
+        'cursor-pointer pointer-events-auto': !disabled,
+      },
       className,
     );
 
@@ -41,7 +45,7 @@ export const LabelButton = forwardRef<HTMLButtonElement, LabelButtonProps>(
         density={interactionDensity}
         outlineOffset={outlineOffset}
       >
-        <button ref={ref} className={combinedClasses} {...props}>
+        <button ref={ref} className={combinedClasses} disabled={!!disabled} {...props}>
           {leftIcon && leftIcon}
           {children}
           {rightIcon && rightIcon}

--- a/src/components/common/button/LabelButton.tsx
+++ b/src/components/common/button/LabelButton.tsx
@@ -10,7 +10,7 @@ import {
 } from '@/styles/labelButtonStyle';
 
 export interface LabelButtonProps extends ComponentPropsWithoutRef<'button'> {
-  children: ReactNode;
+  children?: ReactNode;
   leftIcon?: ReactNode;
   rightIcon?: ReactNode;
   size: Size;

--- a/src/components/common/button/LabelButton.tsx
+++ b/src/components/common/button/LabelButton.tsx
@@ -44,6 +44,7 @@ export const LabelButton = forwardRef<HTMLButtonElement, LabelButtonProps>(
         variant={interactionVariant}
         density={interactionDensity}
         isInversed={isInteractionInversed}
+        className='peer-hover:duration-faster peer-hover:ease-(--motion-fluent)'
       >
         <button ref={ref} className={combinedClasses} disabled={!!disabled} {...props}>
           {leftIcon && leftIcon}

--- a/src/components/common/button/LabelButton.tsx
+++ b/src/components/common/button/LabelButton.tsx
@@ -20,7 +20,7 @@ export interface LabelButtonProps extends ComponentPropsWithoutRef<'button'> {
 export const LabelButton = forwardRef<HTMLButtonElement, LabelButtonProps>(
   ({ children, leftIcon, rightIcon, size, hierarchy, className, disabled, ...props }, ref) => {
     const baseClasses =
-      'inline-flex flex-row py-0 px-0 justify-center items-center gap-4xs radius-xs';
+      'peer inline-flex flex-row py-0 px-0 justify-center items-center gap-4xs radius-xs';
 
     const combinedClasses = clsx(
       baseClasses,

--- a/src/components/common/snackbar/SnackBar.stories.tsx
+++ b/src/components/common/snackbar/SnackBar.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import SnackBar from './SnackBar';
+
+const meta: Meta<typeof SnackBar> = {
+  title: 'Components/SnackBar',
+  component: SnackBar,
+  argTypes: {
+    message: {
+      control: 'text',
+      description: 'SnackBar에 표시할 메시지입니다.',
+    },
+    buttonLabel: {
+      control: 'text',
+      description: '버튼에 표시될 텍스트입니다.',
+    },
+    onAction: {
+      action: 'clicked',
+      description: '버튼 클릭 시 실행되는 함수입니다.',
+    },
+  },
+  args: {
+    message: '스낵바 타이틀',
+    buttonLabel: '젝트 3기 지원하기',
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof SnackBar>;
+
+export const DefaultSnackBar: Story = {
+  name: 'Default SnackBar',
+  render: args => <SnackBar {...args} />,
+};
+
+export const SnackBarStory: Story = {
+  name: 'SnackBar',
+  render: () => (
+    <div className='w-[31.25rem]'>
+      <SnackBar message='지금은 젝트 3기 모집 기간이에요!' buttonLabel='젝트 3기 지원하기' />
+    </div>
+  ),
+};

--- a/src/components/common/snackbar/SnackBar.tsx
+++ b/src/components/common/snackbar/SnackBar.tsx
@@ -4,7 +4,7 @@ import Icon from '@/components/common/icon/Icon';
 export interface SnackBarProps {
   message: string;
   buttonLabel: string;
-  onAction?: () => void;
+  onAction: () => void;
 }
 
 export const SnackBar = ({ message, buttonLabel, onAction }: SnackBarProps) => {

--- a/src/components/common/snackbar/SnackBar.tsx
+++ b/src/components/common/snackbar/SnackBar.tsx
@@ -1,0 +1,31 @@
+import BlockButton from '@/components/common/button/BlockButton';
+import Icon from '@/components/common/icon/Icon';
+
+export interface SnackBarProps {
+  message: string;
+  buttonLabel: string;
+  onAction?: () => void;
+}
+
+export const SnackBar = ({ message, buttonLabel, onAction }: SnackBarProps) => {
+  return (
+    <div className='gap-4xl radius-md shadow-overlay bg-accent-trans-neutral-dark flex w-full flex-row items-center px-(--gap-2xl) py-(--gap-sm)'>
+      <span className='text-object-hero-dark label-bold-lg flex flex-1 shrink-0 basis-0'>
+        {message}
+      </span>
+      <BlockButton
+        size='md'
+        style='solid'
+        hierarchy='accent'
+        onClick={onAction}
+        rightIcon={
+          <Icon name='forward' size='sm' fillColor='fill-object-static-inverse-hero-dark' />
+        }
+      >
+        {buttonLabel}
+      </BlockButton>
+    </div>
+  );
+};
+
+export default SnackBar;

--- a/src/styles/blockButtonStyle.ts
+++ b/src/styles/blockButtonStyle.ts
@@ -12,12 +12,17 @@ interface BlockButtonStyleType {
   };
 }
 
-export const blockButtonStyle: BlockButtonStyleType = {
+export const blockButtonStyle: BlockButtonStyleType & {
+  disabled?: {
+    solid: Record<Hierarchy, string>;
+    outlined: Record<Hierarchy, string>;
+  };
+} = {
   size: {
     xs: 'py-(--gap-3xs) px-(--gap-xs) radius-xs label-xs',
     sm: 'py-(--gap-2xs) px-(--gap-sm) radius-2xs label-sm',
     md: 'py-(--gap-xs) px-(--gap-lg) radius-2xs label-md',
-    lg: 'py-(--gap-sm) px-(--gap-2xl) radius-3xs label-xs',
+    lg: 'py-(--gap-sm) px-(--gap-2xl) radius-3xs label-lg',
   },
   variant: {
     solid: {
@@ -31,6 +36,21 @@ export const blockButtonStyle: BlockButtonStyleType = {
       primary: 'border border-hero-dark text-object-hero-dark',
       secondary: 'border border-neutral-dark text-object-neutral-dark',
       tertiary: 'border border-alternative-dark text-object-alternative-dark',
+    },
+  },
+  disabled: {
+    solid: {
+      accent: 'bg-accent-trans-normal-dark text-accent-trans-hero-dark',
+      primary: 'bg-fill-disabled-dark text-object-disabled-dark',
+      secondary: 'bg-fill-disabled-dark text-object-disabled-dark',
+      tertiary: 'bg-fill-disabled-dark text-object-disabled-dark',
+    },
+    outlined: {
+      accent:
+        'border border-accent-trans-hero-dark bg-accent-trans-neutral-dark text-accent-trans-hero-dark',
+      primary: 'border border-border-assistive-dark text-object-disabled-dark',
+      secondary: 'border border-border-assistive-dark text-object-disabled-dark',
+      tertiary: 'border border-border-assistive-dark text-object-disabled-dark',
     },
   },
 };

--- a/src/styles/blockButtonStyle.ts
+++ b/src/styles/blockButtonStyle.ts
@@ -37,18 +37,18 @@ export const blockButtonStyle: BlockButtonStyleType = {
 
 export const blockButtonInteractionMap: Record<
   Style,
-  Record<Hierarchy, { variant: Variant; density: Density }>
+  Record<Hierarchy, { variant: Variant; density: Density; isInversed: boolean }>
 > = {
   solid: {
-    accent: { variant: 'default', density: 'normal' },
-    primary: { variant: 'default', density: 'normal' },
-    secondary: { variant: 'default', density: 'normal' },
-    tertiary: { variant: 'default', density: 'normal' },
+    accent: { variant: 'default', density: 'normal', isInversed: false },
+    primary: { variant: 'default', density: 'normal', isInversed: true },
+    secondary: { variant: 'default', density: 'normal', isInversed: true },
+    tertiary: { variant: 'default', density: 'normal', isInversed: false },
   },
   outlined: {
-    accent: { variant: 'brand', density: 'subtle' },
-    primary: { variant: 'default', density: 'subtle' },
-    secondary: { variant: 'default', density: 'subtle' },
-    tertiary: { variant: 'default', density: 'subtle' },
+    accent: { variant: 'brand', density: 'subtle', isInversed: false },
+    primary: { variant: 'default', density: 'subtle', isInversed: false },
+    secondary: { variant: 'default', density: 'subtle', isInversed: false },
+    tertiary: { variant: 'default', density: 'subtle', isInversed: false },
   },
 };

--- a/src/styles/labelButtonStyle.ts
+++ b/src/styles/labelButtonStyle.ts
@@ -37,10 +37,3 @@ export const labelButtonInteractionMap: Record<Hierarchy, { variant: Variant; de
     secondary: { variant: 'default', density: 'subtle' },
     tertiary: { variant: 'brand', density: 'subtle' },
   };
-
-export const labelButtonOutlineOffsetMap: Record<Size, number> = {
-  xs: 1,
-  sm: 2,
-  md: 3,
-  lg: 4,
-};

--- a/src/styles/labelButtonStyle.ts
+++ b/src/styles/labelButtonStyle.ts
@@ -30,10 +30,12 @@ export const labelButtonStyle: LabelButtonStyleType = {
   },
 };
 
-export const labelButtonInteractionMap: Record<Hierarchy, { variant: Variant; density: Density }> =
-  {
-    accent: { variant: 'brand', density: 'subtle' },
-    primary: { variant: 'default', density: 'subtle' },
-    secondary: { variant: 'default', density: 'subtle' },
-    tertiary: { variant: 'brand', density: 'subtle' },
-  };
+export const labelButtonInteractionMap: Record<
+  Hierarchy,
+  { variant: Variant; density: Density; isInversed: boolean }
+> = {
+  accent: { variant: 'brand', density: 'subtle', isInversed: false },
+  primary: { variant: 'default', density: 'subtle', isInversed: false },
+  secondary: { variant: 'default', density: 'subtle', isInversed: false },
+  tertiary: { variant: 'brand', density: 'subtle', isInversed: false },
+};

--- a/src/styles/labelButtonStyle.ts
+++ b/src/styles/labelButtonStyle.ts
@@ -6,6 +6,7 @@ export type Hierarchy = 'accent' | 'primary' | 'secondary' | 'tertiary';
 interface LabelButtonStyleType {
   size: Record<Size, string>;
   hierarchy: Record<Hierarchy, string>;
+  disabled?: Record<Hierarchy, string>;
 }
 
 export const labelButtonStyle: LabelButtonStyleType = {
@@ -20,6 +21,12 @@ export const labelButtonStyle: LabelButtonStyleType = {
     primary: 'text-object-hero-dark',
     secondary: 'text-object-neutral-dark',
     tertiary: 'text-object-alternative-dark',
+  },
+  disabled: {
+    accent: 'text-accent-trans-hero-dark',
+    primary: 'text-object-disabled-dark',
+    secondary: 'text-object-disabled-dark',
+    tertiary: 'text-object-disabled-dark',
   },
 };
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] SnackBar 컴포넌트 구현
- [x] LabelButton, BlockButton 컴포넌트의 Interaction 재구성

## 💡 자세한 설명

### ✅ SnackBar
- 단순한 컴포넌트이고, 시각적인 변주가 필요하지 않을 것이라고 판단이 되어 인터페이스 선언 시 `ComponentPropsWithoutRef<'div'>` 와 같은 추가적인 속성 주입을 하지 않고 단순 props만 이용해 선언하였습니다.

- 만약 항상 이 컴포넌트의 버튼 클릭 시 이벤트가 발생한다면 `onAction` 을 옵셔널에서 필수 props로 선언하는 것이 옳다고 생각되나, 일단 옵셔널(?) 처리를 하였습니다.

- 사용 시, 상위 div에서 width 제어가 필요합니다. (SnackBarStory 참고)

### ✅ 버튼 내부 Interaction
- #35 에서 처리된 Interaction 내부 props 변경점을 LabelButton과 BlockButton에 반영하였습니다.

- **isInversed** 의 경우에는 label(block)ButtonInteractionMap에 매개변수를 추가하여 처리하였습니다.

### ✅ 버튼 내 disabled 속성 추가
- disabled는 <button>의 기본 props로 별도로 props에는 선언하지 않았습니다.

- disabled 시 스타일을 clsx로 묶을 때, 후순위에 선언하여 오버라이딩을 의도하였지만, 반영이되지 않아 label(block)ButtonStyle 스타일 객체에 disabled 로 분기를 주어 스타일을 처리하였습니다.

- 또한, 컴포넌트 내부 combinedClasses 선언 시 disabled 유무에 따라 커서 이벤트 처리를 분기하였습니다.
```typescript
      {
        'cursor-not-allowed pointer-events-none': disabled,
        'cursor-pointer pointer-events-auto': !disabled,
      },
```

### ✅ LabelButton 추가 요구 사항
- File 컴포넌트에서 사용되는 labelButton의 경우 children이 존재하지 않고, left(right)Icon만 사용되기 때문에, children을 옵셔널 처리 후, **IconOnlyStory** 에서 해당 케이스를 반영하였습니다. 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항
### ✅ LabelButton 추가 요구 사항 시 발견된 문제
- children을 옵셔널로 처리한 뒤, 스토리 북에서 해당 버튼을 개발자 모드로 조회 시, button 컴포넌트 자체의 크기는 정상적으로 출력되지만, Interaction 컴포넌트가 button 컴포넌트와 동일한 범위를 가지고 있지 않습니다.(하단 일부까지 감지됨)

![image](https://github.com/user-attachments/assets/6b8b40b9-2bea-4ef3-9153-c591be9d6309)

- 이에 대한 원인은 LabelButton에서 Interaction 사용 시 주입되는 `scale='scale-x-118 scale-y-129'` 이 영향을 주고 있다고 생각합니다.



## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #38 
