### PR TITLE
feat: 활동 페이지 UI 구현

### DIFF
--- a/src/pages/Activity.tsx
+++ b/src/pages/Activity.tsx
@@ -1,0 +1,121 @@
+import cardSampleImage from '@/assets/CardSample.png';
+import { Card } from '@/components/common/card/Card';
+import Title from '@/components/common/title/Title';
+
+const miniStudyData = [
+  {
+    name: 'Docker & Kubernetes 심화 스터디',
+    linkUrl: 'https://youtube.com/watch?v=docker_k8s_tips789',
+    imageUrl: cardSampleImage,
+  },
+  {
+    name: 'Python 웹 크롤링 실습 스터디',
+    linkUrl: 'https://youtube.com/watch?v=python_scraping456',
+    imageUrl: cardSampleImage,
+  },
+  {
+    name: 'Spring Boot & JPA 스터디',
+    linkUrl: 'https://youtube.com/watch?v=springboot_jpa123',
+    imageUrl: cardSampleImage,
+  },
+  {
+    name: 'Docker & Kubernetes 심화 스터디',
+    linkUrl: 'https://youtube.com/watch?v=docker_k8s_tips789',
+    imageUrl: cardSampleImage,
+  },
+  {
+    name: 'Python 웹 크롤링 실습 스터디',
+    linkUrl: 'https://youtube.com/watch?v=python_scraping456',
+    imageUrl: cardSampleImage,
+  },
+  {
+    name: 'Spring Boot & JPA 스터디',
+    linkUrl: 'https://youtube.com/watch?v=springboot_jpa123',
+    imageUrl: cardSampleImage,
+  },
+];
+
+const jecttalkData = [
+  {
+    name: '마이크로서비스 아키텍처 개념',
+    youtubeUrl: 'https://youtube.com/watch?v=microservices_tips789',
+    imageUrl: cardSampleImage,
+  },
+  {
+    name: 'Python 비동기 프로그래밍(AIOHTTP)',
+    youtubeUrl: 'https://youtube.com/watch?v=python_async456',
+    imageUrl: cardSampleImage,
+  },
+  {
+    name: 'Spring Boot REST API 개발',
+    youtubeUrl: 'https://youtube.com/watch?v=springboot_api123',
+    imageUrl: cardSampleImage,
+  },
+  {
+    name: '마이크로서비스 아키텍처 개념',
+    youtubeUrl: 'https://youtube.com/watch?v=microservices_tips789',
+    imageUrl: cardSampleImage,
+  },
+  {
+    name: 'Python 비동기 프로그래밍(AIOHTTP)',
+    youtubeUrl: 'https://youtube.com/watch?v=python_async456',
+    imageUrl: cardSampleImage,
+  },
+  {
+    name: 'Spring Boot REST API 개발',
+    youtubeUrl: 'https://youtube.com/watch?v=springboot_api123',
+    imageUrl: cardSampleImage,
+  },
+  {
+    name: '마이크로서비스 아키텍처 개념',
+    youtubeUrl: 'https://youtube.com/watch?v=microservices_tips789',
+    imageUrl: cardSampleImage,
+  },
+];
+
+function Activity() {
+  return (
+    <div className='gap-12xl flex flex-col items-center py-(--gap-12xl)'>
+      <section className='gap-8xl flex flex-col items-center'>
+        <Title hierarchy='strong'>미니 스터디</Title>
+        <div className='gap-4xl grid max-w-[60rem] grid-cols-3'>
+          {miniStudyData.map((item, index) => (
+            <Card
+              key={index}
+              to={item.linkUrl}
+              title={item.name}
+              label={item.name}
+              imgUrl={item.imageUrl}
+              isDescriptionVisible={false}
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              ''
+            </Card>
+          ))}
+        </div>
+      </section>
+      <section className='gap-8xl flex flex-col items-center'>
+        <Title hierarchy='strong'>JECTALK</Title>
+        <div className='gap-4xl grid max-w-[60rem] grid-cols-3'>
+          {jecttalkData.map((item, index) => (
+            <Card
+              key={index}
+              to={item.youtubeUrl}
+              title={item.name}
+              label={item.name}
+              imgUrl={item.imageUrl}
+              isDescriptionVisible={false}
+              target='_blank'
+              rel='noopener noreferrer'
+            >
+              ''
+            </Card>
+          ))}
+        </div>
+      </section>
+    </div>
+  );
+}
+
+export default Activity;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -1,6 +1,7 @@
 import { PATH } from './constants/path';
 
 import Layout from '@/components/layout/Layout';
+import Activity from '@/pages/Activity';
 import Apply from '@/pages/Apply';
 import Faq from '@/pages/Faq';
 
@@ -10,7 +11,7 @@ const routerList = [
     children: [
       { path: PATH.main, element: <></> },
       { path: PATH.project, element: <></> },
-      { path: PATH.activity, element: <></> },
+      { path: PATH.activity, element: <Activity /> },
       { path: PATH.apply, element: <Apply /> },
       { path: PATH.faq, element: <Faq /> },
     ],


### PR DESCRIPTION
## 💡 작업 내용

- [x] 활동 페이지 UI 구현

## 💡 자세한 설명

### 활동 페이지 UI 구현

![2025-03-05 01;08;54](https://github.com/user-attachments/assets/2c4ab306-6c63-4100-b0d5-ee7d2801a6e3)

활동 페이지 UI는 간단한 편이고 Card 컴포넌트가 사용됩니다 
데이터 배열은 임시로 노션 API 명세서에 있는 예시 데이터를 이용했는데 API 연동하면서 대체될 예정입니다!
API 명세서에 나와있는 임시 데이터에 id,label, content 와 같은 내용은 따로 없어서 백엔드 팀원분과 논의해봐야 할 것 같습니다
스크린샷에서는 링크 이동되는 과정 캡처가 불가능해서 안보이지만 링크 이동 잘 동작하는 것도 확인했습니다!

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #43 
