### PR TITLE
fix: HeroIndex 컴포넌트 수정

### DIFF
--- a/src/components/common/callout/HeroIndex.stories.tsx
+++ b/src/components/common/callout/HeroIndex.stories.tsx
@@ -5,7 +5,6 @@ import HeroIndex from './HeroIndex';
 const meta: Meta<typeof HeroIndex> = {
   title: 'Components/Hero/HeroIndex',
   component: HeroIndex,
-  tags: ['autodocs'],
   argTypes: {
     index: {
       control: 'number',
@@ -19,6 +18,12 @@ const meta: Meta<typeof HeroIndex> = {
     content: {
       control: 'text',
     },
+    badgeBgColor: {
+      control: 'text',
+    },
+    badgeTextColor: {
+      control: 'text',
+    },
   },
 };
 
@@ -26,11 +31,13 @@ export default meta;
 
 type Story = StoryObj<typeof HeroIndex>;
 
-export const Primary: Story = {
+export const HeroIndexStory: Story = {
   args: {
     index: 1,
     title: '히어로 타이틀',
     badgeText: '레이블',
     content: '히어로 내용',
+    badgeBgColor: 'bg-feedback-trans-information-dark',
+    badgeTextColor: 'text-feedback-information-dark',
   },
 };

--- a/src/components/common/callout/HeroIndex.tsx
+++ b/src/components/common/callout/HeroIndex.tsx
@@ -5,9 +5,18 @@ import Title from '@/components/common/title/Title';
 
 interface HeroIndexProps extends HeroProps {
   index: number;
+  badgeBgColor?: string;
+  badgeTextColor?: string;
 }
 
-function HeroIndex({ index, title, badgeText, content }: HeroIndexProps) {
+function HeroIndex({
+  index,
+  title,
+  badgeText,
+  content,
+  badgeBgColor = 'bg-fill-assistive-dark',
+  badgeTextColor = 'text-object-normal-dark',
+}: HeroIndexProps) {
   return (
     <div className='radius-xs border-border-assistive-dark bg-surface-deep-dark gap-4xl flex items-center border px-(--gap-3xl) py-(--gap-2xl)'>
       <div className='min-w-[33px] text-center'>
@@ -16,7 +25,7 @@ function HeroIndex({ index, title, badgeText, content }: HeroIndexProps) {
       <div className='gap-xs flex flex-col'>
         <div className='gap-sm flex'>
           <Title hierarchy='normal'>{title}</Title>
-          <Badge backgroundColor='bg-fill-assistive-dark' textColor='text-object-normal-dark'>
+          <Badge backgroundColor={badgeBgColor} textColor={badgeTextColor}>
             {badgeText}
           </Badge>
         </div>


### PR DESCRIPTION
## 💡 작업 내용

- [x] HeroIndex props 추가

## 💡 자세한 설명

HeroIndex props에 Badge 의 배경색 및 폰트색을 주입할 수 있도록 `badgeBgColor`, `badgeTextColor` 를 추가하였습니다. 

```ts
// 기본값
badgeBgColor = 'bg-fill-assistive-dark',
badgeTextColor = 'text-object-normal-dark',
```

HeroIndex 의 padding값이나 content를 children으로 변경하는 부분은 #78 에서 수정되어 건들지 않았습니다! (머지 충돌 방지)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #79 
