### PR TITLE
feat: CheckBox 컴포넌트 구현

### DIFF
--- a/src/components/common/checkbox/CheckBox.stories.tsx
+++ b/src/components/common/checkbox/CheckBox.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react';
+import { ChangeEvent, useState } from 'react';
 
 import CheckBox from './CheckBox';
 
@@ -40,11 +41,33 @@ export default meta;
 
 type Story = StoryObj<typeof CheckBox>;
 
-export const Default: Story = {
+export const DefaultStory: Story = {
   name: 'CheckBox',
   render: args => (
     <div className='story-container'>
       <CheckBox {...args} />
     </div>
   ),
+};
+
+export const InteractiveStory: Story = {
+  name: 'Interactive CheckBox',
+  render: args => {
+    const [checked, setChecked] = useState(args.checked);
+
+    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+      setChecked(e.target.checked);
+    };
+
+    return (
+      <div className='story-container'>
+        <CheckBox
+          {...args}
+          checked={checked}
+          isIndeterminate={isIndeterminate}
+          onChange={handleChange}
+        />
+      </div>
+    );
+  },
 };

--- a/src/components/common/checkbox/CheckBox.stories.tsx
+++ b/src/components/common/checkbox/CheckBox.stories.tsx
@@ -53,21 +53,19 @@ export const DefaultStory: Story = {
 export const InteractiveStory: Story = {
   name: 'Interactive CheckBox',
   render: args => {
-    const [checked, setChecked] = useState(args.checked);
+    const Interactive = () => {
+      const [isChecked, setIsChecked] = useState(args.checked);
+      const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
+        setIsChecked(e.target.checked);
+      };
 
-    const handleChange = (e: ChangeEvent<HTMLInputElement>) => {
-      setChecked(e.target.checked);
+      return (
+        <div className='story-container'>
+          <CheckBox {...args} checked={isChecked} onChange={handleChange} />
+        </div>
+      );
     };
 
-    return (
-      <div className='story-container'>
-        <CheckBox
-          {...args}
-          checked={checked}
-          isIndeterminate={isIndeterminate}
-          onChange={handleChange}
-        />
-      </div>
-    );
+    return <Interactive />;
   },
 };

--- a/src/components/common/checkbox/CheckBox.stories.tsx
+++ b/src/components/common/checkbox/CheckBox.stories.tsx
@@ -1,0 +1,50 @@
+import type { Meta, StoryObj } from '@storybook/react';
+
+import CheckBox from './CheckBox';
+
+const meta: Meta<typeof CheckBox> = {
+  title: 'components/CheckBox',
+  component: CheckBox,
+  args: {
+    checked: false,
+    isIndeterminate: false,
+    disabled: false,
+    id: 'my-checkbox',
+    labelText: '레이블',
+  },
+  argTypes: {
+    checked: {
+      control: 'boolean',
+      description: '체크박스가 선택되었는지 여부를 결정합니다.',
+    },
+    isIndeterminate: {
+      control: 'boolean',
+      description: '체크박스가 불확실(indeterminate)한 상태인지 결정합니다.',
+    },
+    disabled: {
+      control: 'boolean',
+      description: 'true이면 체크박스가 비활성화됩니다.',
+    },
+    labelText: {
+      control: 'text',
+      description: '체크박스 옆에 표시될 라벨 텍스트입니다.',
+    },
+    id: {
+      control: 'text',
+      description: '체크박스의 고유 식별자입니다.',
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof CheckBox>;
+
+export const Default: Story = {
+  name: 'CheckBox',
+  render: args => (
+    <div className='story-container'>
+      <CheckBox {...args} />
+    </div>
+  ),
+};

--- a/src/components/common/checkbox/CheckBox.tsx
+++ b/src/components/common/checkbox/CheckBox.tsx
@@ -28,7 +28,7 @@ const CheckBox = forwardRef<HTMLInputElement, CheckboxProps>(function CheckBox(
         className={clsx(
           baseStyles,
           disabled ? disabledStyles : enabledStyles,
-          'transition-faster-fluent-hover transition-faster-fluent-active',
+          'transition-faster-fluent-hover transition-faster-fluent-active transition-faster-fluent-focus',
         )}
       >
         <div className='relative inline-flex items-center'>

--- a/src/components/common/checkbox/CheckBox.tsx
+++ b/src/components/common/checkbox/CheckBox.tsx
@@ -6,7 +6,7 @@ import { CheckboxIcon } from './CheckboxIcon';
 
 import Label from '@/components/common/label/Label';
 
-const CheckBox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+const CheckBox = forwardRef<HTMLInputElement, CheckboxProps>(function CheckBox(
   { id, isIndeterminate, checked, disabled, className, labelText, ...restProps },
   ref,
 ) {

--- a/src/components/common/checkbox/CheckBox.tsx
+++ b/src/components/common/checkbox/CheckBox.tsx
@@ -1,6 +1,5 @@
 import clsx from 'clsx';
 import { forwardRef } from 'react';
-import type { MouseEvent } from 'react';
 
 import { CheckBoxProps } from './CheckBox.types';
 import { CheckBoxIcon } from './CheckBoxIcon';
@@ -12,7 +11,7 @@ const CheckBox = forwardRef<HTMLInputElement, CheckBoxProps>(function CheckBox(
   ref,
 ) {
   const baseStyles =
-    'group relative outline-none radius-4xs before:absolute duration-faster ease-(--motion-fluent) before:inset-0 before:rounded-[inherit] inline-flex items-center justify-center border';
+    'group relative outline-none radius-4xs inline-flex items-center justify-center border';
 
   const enabledStyles =
     checked || isIndeterminate
@@ -24,20 +23,13 @@ const CheckBox = forwardRef<HTMLInputElement, CheckBoxProps>(function CheckBox(
       ? 'bg-feedback-trans-information-dark border-border-trans-assistive-dark'
       : 'bg-object-static-inverse-disabled-dark border-border-trans-assistive-dark';
 
-  const handleClick = (e: MouseEvent<HTMLInputElement>) => {
-    e.currentTarget.blur();
-    if (restProps.onClick) {
-      restProps.onClick(e);
-    }
-  };
-
   return (
     <div className={clsx('gap-2xs inline-flex items-center', className)}>
       <div
         className={clsx(
           baseStyles,
           disabled ? disabledStyles : enabledStyles,
-          'focus-within:before:shadow-focus-visible group-hover:before:bg-[rgba(26,27,35,0.12)] group-active:before:bg-[rgba(26,27,35,0.12)]',
+          'interaction-default-bold-inverse active:shadow-focus-visible duration-faster ease-(--motion-fluent)',
         )}
       >
         <div className='relative inline-flex items-center'>
@@ -45,7 +37,6 @@ const CheckBox = forwardRef<HTMLInputElement, CheckBoxProps>(function CheckBox(
           <input
             id={id}
             ref={ref}
-            onClick={handleClick}
             className={clsx(
               'absolute top-0 left-0 h-full w-full opacity-0',
               !disabled && 'cursor-pointer',

--- a/src/components/common/checkbox/CheckBox.tsx
+++ b/src/components/common/checkbox/CheckBox.tsx
@@ -1,0 +1,55 @@
+import clsx from 'clsx';
+import { forwardRef } from 'react';
+
+import { CheckboxProps } from './Checkbox.types';
+import { CheckboxIcon } from './CheckboxIcon';
+
+import Label from '@/components/common/label/Label';
+
+const CheckBox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
+  { id, isIndeterminate, checked, disabled, className, labelText, ...restProps },
+  ref,
+) {
+  const baseStyles = 'group radius-4xs inline-flex items-center justify-center border';
+
+  const enabledStyles =
+    checked || isIndeterminate
+      ? 'bg-feedback-information-dark border-border-trans-normal-dark'
+      : 'bg-object-static-inverse-hero-dark border-border-normal-dark';
+
+  const disabledStyles =
+    checked || isIndeterminate
+      ? 'bg-feedback-trans-information-dark border-border-trans-assistive-dark'
+      : 'bg-object-static-inverse-disabled-dark border-border-trans-assistive-dark';
+
+  return (
+    <div className={clsx('gap-2xs inline-flex items-center', className)}>
+      <div className={clsx(baseStyles, disabled ? disabledStyles : enabledStyles)}>
+        <div className='relative inline-flex items-center'>
+          <CheckboxIcon isIndeterminate={isIndeterminate} disabled={disabled} checked={checked} />
+          <input
+            id={id}
+            ref={ref}
+            className={clsx(
+              'absolute top-0 left-0 h-full w-full opacity-0',
+              !disabled && 'cursor-pointer',
+            )}
+            type='checkbox'
+            checked={checked}
+            disabled={disabled}
+            {...restProps}
+          />
+        </div>
+      </div>
+      {!!labelText && (
+        <div className={clsx(!!id && !disabled && 'cursor-pointer')}>
+          <Label htmlFor={id} hierarchy='weak' textColor='text-object-neutral-dark' weight='normal'>
+            {labelText}
+          </Label>
+        </div>
+      )}
+    </div>
+  );
+});
+
+export default CheckBox;

--- a/src/components/common/checkbox/CheckBox.tsx
+++ b/src/components/common/checkbox/CheckBox.tsx
@@ -26,28 +26,25 @@ const CheckBox = forwardRef<HTMLInputElement, CheckBoxProps>(function CheckBox(
   return (
     <div className={clsx('gap-2xs inline-flex items-center', className)}>
       <div
-        tabIndex={0}
         className={clsx(
           baseStyles,
           disabled ? disabledStyles : enabledStyles,
-          'interaction-default-bold-inverse active:shadow-focus-visible duration-faster ease-(--motion-fluent)',
+          'focus-within:before:shadow-focus-visible active:shadow-focus-visible duration-faster relative ease-(--motion-fluent) outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(26,27,35,0.12)] active:before:bg-[rgba(26,27,35,0.12)]',
         )}
       >
-        <div className='relative inline-flex items-center'>
-          <CheckBoxIcon isIndeterminate={isIndeterminate} disabled={disabled} checked={checked} />
-          <input
-            id={id}
-            ref={ref}
-            className={clsx(
-              'absolute top-0 left-0 h-full w-full opacity-0',
-              !disabled && 'cursor-pointer',
-            )}
-            type='checkbox'
-            checked={checked}
-            disabled={disabled}
-            {...restProps}
-          />
-        </div>
+        <CheckBoxIcon isIndeterminate={isIndeterminate} disabled={disabled} checked={checked} />
+        <input
+          id={id}
+          ref={ref}
+          className={clsx(
+            'absolute top-0 left-0 h-full w-full opacity-0',
+            !disabled && 'cursor-pointer',
+          )}
+          type='checkbox'
+          checked={checked}
+          disabled={disabled}
+          {...restProps}
+        />
       </div>
       {!!labelText && (
         <div className={clsx(!!id && !disabled && 'cursor-pointer')}>

--- a/src/components/common/checkbox/CheckBox.tsx
+++ b/src/components/common/checkbox/CheckBox.tsx
@@ -29,7 +29,7 @@ const CheckBox = forwardRef<HTMLInputElement, CheckBoxProps>(function CheckBox(
         className={clsx(
           baseStyles,
           disabled ? disabledStyles : enabledStyles,
-          'focus-within:before:shadow-focus-visible active:shadow-focus-visible duration-faster relative ease-(--motion-fluent) outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(26,27,35,0.12)] active:before:bg-[rgba(26,27,35,0.12)]',
+          'has-focus-visible:shadow-focus-visible active:shadow-focus-visible duration-faster relative ease-(--motion-fluent) outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(26,27,35,0.12)] active:before:bg-[rgba(26,27,35,0.12)]',
         )}
       >
         <CheckBoxIcon isIndeterminate={isIndeterminate} disabled={disabled} checked={checked} />

--- a/src/components/common/checkbox/CheckBox.tsx
+++ b/src/components/common/checkbox/CheckBox.tsx
@@ -23,13 +23,14 @@ const CheckBox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
       : 'bg-object-static-inverse-disabled-dark border-border-trans-assistive-dark';
 
   return (
-    <div
-      className={clsx(
-        'gap-2xs transition-faster-fluent-hover transition-faster-fluent-active inline-flex items-center',
-        className,
-      )}
-    >
-      <div className={clsx(baseStyles, disabled ? disabledStyles : enabledStyles)}>
+    <div className={clsx('gap-2xs inline-flex items-center', className)}>
+      <div
+        className={clsx(
+          baseStyles,
+          disabled ? disabledStyles : enabledStyles,
+          'transition-faster-fluent-hover transition-faster-fluent-active',
+        )}
+      >
         <div className='relative inline-flex items-center'>
           <CheckboxIcon isIndeterminate={isIndeterminate} disabled={disabled} checked={checked} />
           <input

--- a/src/components/common/checkbox/CheckBox.tsx
+++ b/src/components/common/checkbox/CheckBox.tsx
@@ -1,12 +1,12 @@
 import clsx from 'clsx';
 import { forwardRef } from 'react';
 
-import { CheckboxProps } from './Checkbox.types';
-import { CheckboxIcon } from './CheckboxIcon';
+import { CheckBoxProps } from './CheckBox.types';
+import { CheckBoxIcon } from './CheckBoxIcon';
 
 import Label from '@/components/common/label/Label';
 
-const CheckBox = forwardRef<HTMLInputElement, CheckboxProps>(function CheckBox(
+const CheckBox = forwardRef<HTMLInputElement, CheckBoxProps>(function CheckBox(
   { id, isIndeterminate, checked, disabled, className, labelText, ...restProps },
   ref,
 ) {
@@ -32,7 +32,7 @@ const CheckBox = forwardRef<HTMLInputElement, CheckboxProps>(function CheckBox(
         )}
       >
         <div className='relative inline-flex items-center'>
-          <CheckboxIcon isIndeterminate={isIndeterminate} disabled={disabled} checked={checked} />
+          <CheckBoxIcon isIndeterminate={isIndeterminate} disabled={disabled} checked={checked} />
           <input
             id={id}
             ref={ref}

--- a/src/components/common/checkbox/CheckBox.tsx
+++ b/src/components/common/checkbox/CheckBox.tsx
@@ -24,7 +24,7 @@ const CheckBox = forwardRef<HTMLInputElement, CheckBoxProps>(function CheckBox(
       : 'bg-object-static-inverse-disabled-dark border-border-trans-assistive-dark';
 
   return (
-    <div className={clsx('group gap-2xs inline-flex items-center', className)}>
+    <div className={clsx('gap-2xs inline-flex items-center', className)}>
       <div
         tabIndex={0}
         className={clsx(

--- a/src/components/common/checkbox/CheckBox.tsx
+++ b/src/components/common/checkbox/CheckBox.tsx
@@ -11,7 +11,7 @@ const CheckBox = forwardRef<HTMLInputElement, CheckBoxProps>(function CheckBox(
   ref,
 ) {
   const baseStyles =
-    'group relative outline-none radius-4xs inline-flex items-center justify-center border';
+    'relative outline-none radius-4xs inline-flex items-center justify-center border';
 
   const enabledStyles =
     checked || isIndeterminate
@@ -24,8 +24,9 @@ const CheckBox = forwardRef<HTMLInputElement, CheckBoxProps>(function CheckBox(
       : 'bg-object-static-inverse-disabled-dark border-border-trans-assistive-dark';
 
   return (
-    <div className={clsx('gap-2xs inline-flex items-center', className)}>
+    <div className={clsx('group gap-2xs inline-flex items-center', className)}>
       <div
+        tabIndex={0}
         className={clsx(
           baseStyles,
           disabled ? disabledStyles : enabledStyles,

--- a/src/components/common/checkbox/CheckBox.tsx
+++ b/src/components/common/checkbox/CheckBox.tsx
@@ -23,7 +23,12 @@ const CheckBox = forwardRef<HTMLInputElement, CheckboxProps>(function Checkbox(
       : 'bg-object-static-inverse-disabled-dark border-border-trans-assistive-dark';
 
   return (
-    <div className={clsx('gap-2xs inline-flex items-center', className)}>
+    <div
+      className={clsx(
+        'gap-2xs transition-faster-fluent-hover transition-faster-fluent-active inline-flex items-center',
+        className,
+      )}
+    >
       <div className={clsx(baseStyles, disabled ? disabledStyles : enabledStyles)}>
         <div className='relative inline-flex items-center'>
           <CheckboxIcon isIndeterminate={isIndeterminate} disabled={disabled} checked={checked} />

--- a/src/components/common/checkbox/CheckBox.tsx
+++ b/src/components/common/checkbox/CheckBox.tsx
@@ -1,5 +1,6 @@
 import clsx from 'clsx';
 import { forwardRef } from 'react';
+import type { MouseEvent } from 'react';
 
 import { CheckBoxProps } from './CheckBox.types';
 import { CheckBoxIcon } from './CheckBoxIcon';
@@ -10,7 +11,8 @@ const CheckBox = forwardRef<HTMLInputElement, CheckBoxProps>(function CheckBox(
   { id, isIndeterminate, checked, disabled, className, labelText, ...restProps },
   ref,
 ) {
-  const baseStyles = 'group radius-4xs inline-flex items-center justify-center border';
+  const baseStyles =
+    'group relative outline-none radius-4xs before:absolute duration-faster ease-(--motion-fluent) before:inset-0 before:rounded-[inherit] inline-flex items-center justify-center border';
 
   const enabledStyles =
     checked || isIndeterminate
@@ -22,13 +24,20 @@ const CheckBox = forwardRef<HTMLInputElement, CheckBoxProps>(function CheckBox(
       ? 'bg-feedback-trans-information-dark border-border-trans-assistive-dark'
       : 'bg-object-static-inverse-disabled-dark border-border-trans-assistive-dark';
 
+  const handleClick = (e: MouseEvent<HTMLInputElement>) => {
+    e.currentTarget.blur();
+    if (restProps.onClick) {
+      restProps.onClick(e);
+    }
+  };
+
   return (
     <div className={clsx('gap-2xs inline-flex items-center', className)}>
       <div
         className={clsx(
           baseStyles,
           disabled ? disabledStyles : enabledStyles,
-          'transition-faster-fluent-hover transition-faster-fluent-active transition-faster-fluent-focus',
+          'focus-within:before:shadow-focus-visible group-hover:before:bg-[rgba(26,27,35,0.12)] group-active:before:bg-[rgba(26,27,35,0.12)]',
         )}
       >
         <div className='relative inline-flex items-center'>
@@ -36,6 +45,7 @@ const CheckBox = forwardRef<HTMLInputElement, CheckBoxProps>(function CheckBox(
           <input
             id={id}
             ref={ref}
+            onClick={handleClick}
             className={clsx(
               'absolute top-0 left-0 h-full w-full opacity-0',
               !disabled && 'cursor-pointer',

--- a/src/components/common/checkbox/CheckBox.types.ts
+++ b/src/components/common/checkbox/CheckBox.types.ts
@@ -1,6 +1,6 @@
 import type { ComponentPropsWithoutRef } from 'react';
 
-export type CheckboxProps = ComponentPropsWithoutRef<'input'> & {
+export type CheckBoxProps = ComponentPropsWithoutRef<'input'> & {
   isIndeterminate?: boolean;
   disabled?: boolean;
   checked?: boolean;
@@ -11,7 +11,7 @@ export type CheckboxProps = ComponentPropsWithoutRef<'input'> & {
     | { isIndeterminate?: false; checked?: false }
   );
 
-export type CheckboxIconProps = {
+export type CheckBoxIconProps = {
   checked?: boolean;
   disabled?: boolean;
   isIndeterminate?: boolean;

--- a/src/components/common/checkbox/CheckBox.types.ts
+++ b/src/components/common/checkbox/CheckBox.types.ts
@@ -1,0 +1,18 @@
+import type { ComponentPropsWithoutRef } from 'react';
+
+export type CheckboxProps = ComponentPropsWithoutRef<'input'> & {
+  isIndeterminate?: boolean;
+  disabled?: boolean;
+  checked?: boolean;
+  labelText?: string;
+} & (
+    | { isIndeterminate?: false; checked: true }
+    | { isIndeterminate: true; checked?: false }
+    | { isIndeterminate?: false; checked?: false }
+  );
+
+export type CheckboxIconProps = {
+  checked?: boolean;
+  disabled?: boolean;
+  isIndeterminate?: boolean;
+};

--- a/src/components/common/checkbox/CheckBoxIcon.tsx
+++ b/src/components/common/checkbox/CheckBoxIcon.tsx
@@ -1,8 +1,8 @@
-import { CheckboxIconProps } from './CheckBox.types.ts';
+import { CheckBoxIconProps } from './CheckBox.types.ts';
 
 import Icon from '@/components/common/icon/Icon';
 
-export const CheckboxIcon = ({ checked, isIndeterminate, disabled }: CheckboxIconProps) => {
+export const CheckBoxIcon = ({ checked, isIndeterminate, disabled }: CheckBoxIconProps) => {
   if (isIndeterminate) {
     return (
       <Icon

--- a/src/components/common/checkbox/CheckBoxIcon.tsx
+++ b/src/components/common/checkbox/CheckBoxIcon.tsx
@@ -1,4 +1,5 @@
-import { CheckboxIconProps } from '@/components/common/checkbox/CheckBox.types.ts';
+import { CheckboxIconProps } from './CheckBox.types.ts';
+
 import Icon from '@/components/common/icon/Icon';
 
 export const CheckboxIcon = ({ checked, isIndeterminate, disabled }: CheckboxIconProps) => {

--- a/src/components/common/checkbox/CheckBoxIcon.tsx
+++ b/src/components/common/checkbox/CheckBoxIcon.tsx
@@ -1,0 +1,32 @@
+import { CheckboxIconProps } from '@/components/common/checkbox/CheckBox.types.ts';
+import Icon from '@/components/common/icon/Icon';
+
+export const CheckboxIcon = ({ checked, isIndeterminate, disabled }: CheckboxIconProps) => {
+  if (isIndeterminate) {
+    return (
+      <Icon
+        name='minus'
+        size='2xs'
+        fillColor={
+          disabled
+            ? 'fill-object-static-inverse-assistive-dark'
+            : 'fill-object-static-inverse-hero-dark'
+        }
+      />
+    );
+  }
+  if (checked) {
+    return (
+      <Icon
+        name='check'
+        size='2xs'
+        fillColor={
+          disabled
+            ? 'fill-object-static-inverse-assistive-dark'
+            : 'fill-object-static-inverse-hero-dark'
+        }
+      />
+    );
+  }
+  return <div className='h-[0.875rem] w-[0.875rem]' />;
+};

--- a/src/components/common/icon/Icon.tsx
+++ b/src/components/common/icon/Icon.tsx
@@ -1,3 +1,5 @@
+import { FunctionComponent, SVGProps } from 'react';
+
 import Check from '@/assets/svg/check.svg?react';
 import Clear from '@/assets/svg/clear.svg?react';
 import Download from '@/assets/svg/download.svg?react';
@@ -29,7 +31,7 @@ interface IconProps {
 function Icon({ name, size, fillColor }: IconProps) {
   const iconSize = iconStyle.size[size];
 
-  const icons: Record<IconNames, React.FunctionComponent<React.SVGProps<SVGSVGElement>>> = {
+  const icons: Record<IconNames, FunctionComponent<SVGProps<SVGSVGElement>>> = {
     check: Check,
     clear: Clear,
     dropDown: DropDown,

--- a/src/styles/interaction.css
+++ b/src/styles/interaction.css
@@ -19,6 +19,11 @@
     transition-timing-function: var(--motion-fluent);
   }
 
+  .transition-faster-fluent-active:active::before {
+    transition-duration: var(--duration-faster);
+    transition-timing-function: var(--motion-fluent);
+  }
+
   /* inversed false*/
   .interaction-default-bold {
     @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(255,255,255,0.12)] active:before:bg-[rgba(255,255,255,0.12)];

--- a/src/styles/interaction.css
+++ b/src/styles/interaction.css
@@ -19,11 +19,6 @@
     transition-timing-function: var(--motion-fluent);
   }
 
-  .transition-faster-fluent-active:active::before {
-    transition-duration: var(--duration-faster);
-    transition-timing-function: var(--motion-fluent);
-  }
-
   /* inversed false*/
   .interaction-default-bold {
     @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(255,255,255,0.12)] active:before:bg-[rgba(255,255,255,0.12)];


### PR DESCRIPTION
## 💡 작업 내용

- [x] CheckBox 컴포넌트 구현

## 💡 자세한 설명

### ✅ CheckBoxIcon
- CheckBox의 상태(checked, isIndeterminate)에 따라  랜더링되는 Icon 컴포넌트를 분기합니다.
- 기본적으로 랜더링 하는 svg를 분기하는 쪽이 더 적절하다고 생각했지만, 공통적으로 사용하는 Icon 컴포넌트를 사용했습니다.

### ✅ CheckBox.type.ts
기본적으로 input 요소의 기본 props를 활용했습니다.
```typescript
    | { isIndeterminate?: false; checked: true }
    | { isIndeterminate: true; checked?: false }
    | { isIndeterminate?: false; checked?: false }
  );
```
해당 부분은 **체크박스의 상태를 세 가지 경우로 제한**하기 위한 유니온 타입입니다.
1. 체크박스가 checked 된 상태
2. 체크 박스가 indeterminate인 상태
3. 체크박스가 선택되지 않은 상태(inderminated 되지 않고, checked 되지 않음)

해당 유니온 타입을 통해 세 가지 경우로 제한함으로써, 체크박스가 동시에 indeterminate와 checked 상태가 되는 조합을 방지합니다.

### ✅ CheckBox
- id props는 해당 `<input>` 의 식별자입니다. >> 여러 체크 박스가 있어도 id 값을 통해 구분가
- `<input>` 요소에 id를 부여하고, <Label> 컴포넌트에는 이 id를 htmlFor 속성으로 전달합니다.

- 순수 컴포넌트로 활용하기 위해 컴포넌트 내부에서는 상태관리를 하지 않습니다.

(3/09 추가)
### ✅ Interaction 부여
- 체크 박스의 경우 Interaction을 가지는 실제 요소 `<input>`은 opacity가 0이기 때문에 부모 요소로 부터 해당 interaction이 수행되도록 수정했습니다.
- 이 과정에서 
```typescript
      <div
        className={clsx(
          baseStyles,
          disabled ? disabledStyles : enabledStyles,
          'focus-within:before:shadow-focus-visible group-hover:before:bg-[rgba(26,27,35,0.12)] group-active:before:bg-[rgba(26,27,35,0.12)]',
        )}
      >
```
가 처리되었으며, 기존 디자인 토큰을 사용하지 못하는 이유는 focus가 아닌 `focus-within`, hover, active 역시 `group-hover`, `group-active`를 사용하기 때문입니다.

- 최상위 `<div>`에서 해당 요소들을 그룹핑하기 위해 group 이 사용되고 있습니다. (기존과 동일)

### ✅ 핸들러 함수
```typescript
  const handleClick = (e: MouseEvent<HTMLInputElement>) => {
    e.currentTarget.blur();
    if (restProps.onClick) {
      restProps.onClick(e);
    }
  };
```
의 역할은 [제공해주신 참고 체크박스](https://[vaadin.com/docs/latest/example?embed=checkbox-indeterminate-wc.js&import=component/checkbox/checkbox-indeterminate.ts,component/checkbox/react/checkbox-indeterminate.tsx](https://vaadin.com/docs/latest/example?embed=checkbox-indeterminate-wc.js&import=component/checkbox/checkbox-indeterminate.ts,component/checkbox/react/checkbox-indeterminate.tsx)) 처럼 focus 처리를 하기 위함입니다.
checkbox 클릭 시 focus가 자동으로 되는데, 이 focus는 다른 창이나 외부 요소를 클릭 전까지 유지됩니다. 레퍼런스 처럼 클릭 시 focus가 작동하고 즉시 해제되는 플로우를 위해 반영했습니다.

### ✅ 추가 스토리북 구현
Interaction을 확인할 수 있는 추가 스토리북 예제를 생성했고, 이 구조는 render 콜백 내에 useState를 선언할 수 없기 때문에 실제 선언 방식과는 상이할 수 있습니다.

(3/12 추가) [103b58e](https://github.com/JECT-Study/JECT-Official-WebSite-Client/pull/86/commits/103b58e633e34f15b32663a60f0934b0556661a2)
### ✅ Interaction 관련
- 기존 Interaction을 위해 추가로 생성한 `<div>` 를 제거하였습니다.
- 기존 스타일 토큰을 사용하지 않고, `focus-visible` 에서 `focus-within` 으로 처리된 interaction을 직접 작성했습니다. (tailwind 특성상 일부 재사용은 불가능)

`focus-within` 을 통해 자식 요소(`<input>`)가 포커스를 받으면 부모 요소에 스타일을 적용하여, 숨겨진 input(opacity가 0으로 처리됨)의 포커스 상태를 부모에게 반영할 수 있습니다.

또한 이를 통해, `<input>` 에서 제공되는 **기본 focus 및 별도 핸들러 없는 focus 수행**이 가능해졌습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항
### ❌  hover 및 active가 적용되지 않는 문제
사실 상 hover 및 active가 적용이 되지만, div에 적용한 bg 색상 때문에 hover 와 active 시 색상이 시각적으로 보여지지 않습니다.

이에 대한 원인으로 
1. `CheckBoxIcon` 에서 Icon 컴포넌트를 사용하고 있기 때문이라고 판단되는데, 해당 컴포넌트를 사용하지 않고, svg 요소를 직접 입력하고 해당 요소 내부에서 fill 색상을 주입하면 div에 bg이 들어가지 않기 때문에 정상적인 Interaction이 수행될 것으로 예상됩니다. 만..... 

2. #89 를 보고, :before를 제거했더니 hover 효과는 작동하는데(group-hover 대신 hover 사용) 색상이 의도치 않은 색상으로 처리되네요.. (1) 또는 (2)의 해결법 중에 답이 있을 거 같습니다.

시간적 요인 때문에 해당 건과 관련해서 해당 Interaction 관련한 처리를 추가 이슈로 만들어 후순위로 구현할 지, 현재 issue에서 해결할지 고민이되네요 (제가 제시한 해결법이 정답이 아닐수도 있습니다.) 

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #65
