### PR TITLE
fix: 인터렉션 focus-visible 효과 나타날 때 border가 보이지 않는 버그 해결

### DIFF
--- a/src/components/common/accordion/Accordion.tsx
+++ b/src/components/common/accordion/Accordion.tsx
@@ -22,7 +22,7 @@ function Accordion({ title, label, children, caption }: AccordionProps) {
     <div className='gap-xs flex flex-col'>
       <button
         onClick={toggle}
-        className='interaction-default-subtle transition-faster-fluent-hover gap-xs radius-3xs flex w-full text-start before:scale-x-102 before:scale-y-128 [&>*:first-child]:grow'
+        className='interaction-default-subtle-scale transition-faster-fluent-hover gap-xs radius-3xs flex w-full text-start before:scale-x-102 before:scale-y-128 [&>*:first-child]:grow'
       >
         <Title hierarchy='weak' textColor={isOpen ? null : 'text-object-neutral-dark'}>
           {title}

--- a/src/components/common/button/LabelButton.tsx
+++ b/src/components/common/button/LabelButton.tsx
@@ -20,7 +20,7 @@ export const LabelButton = forwardRef<HTMLButtonElement, LabelButtonProps>(
   ({ children, leftIcon, rightIcon, size, hierarchy, className, disabled, ...props }, ref) => {
     const { variant, density, isInversed } = labelButtonInteractionMap[hierarchy];
 
-    const interaction = `interaction-${variant}-${density}${isInversed ? '-inverse' : ''}`;
+    const interaction = `interaction-${variant}-${density}${isInversed ? '-inverse-scale' : '-scale'}`;
 
     const baseClasses =
       'inline-flex flex-row py-0 px-0 justify-center items-center gap-4xs radius-xs transition-faster-fluent before:scale-x-118 before:scale-y-129';

--- a/src/styles/interaction.css
+++ b/src/styles/interaction.css
@@ -1,3 +1,5 @@
+@import './tokens/semantic.css';
+
 @layer utilities {
   .transition-faster-fluent-hover:hover::before {
     transition-duration: var(--duration-faster);
@@ -67,5 +69,55 @@
 
   .interaction-brand-subtle-inverse {
     @apply focus-visible:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(100,101,241,0.05)] active:before:bg-[rgba(100,101,241,0.05)];
+  }
+
+  /* scale inversed false*/
+  .interaction-default-bold-scale {
+    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(255,255,255,0.12)] active:before:bg-[rgba(255,255,255,0.12)];
+  }
+
+  .interaction-default-normal-scale {
+    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(212,211,222,0.08)] active:before:bg-[rgba(212,211,222,0.08)];
+  }
+
+  .interaction-default-subtle-scale {
+    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(247,245,255,0.033)] active:before:bg-[rgba(247,245,255,0.033)];
+  }
+
+  .interaction-brand-bold-scale {
+    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(145,147,255,0.12)] active:before:bg-[rgba(145,147,255,0.12)];
+  }
+
+  .interaction-brand-normal-scale {
+    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(113,115,255,0.08)] active:before:bg-[rgba(113,115,255,0.08)];
+  }
+
+  .interaction-brand-subtle-scale {
+    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(87,88,227,0.05)] active:before:bg-[rgba(87,88,227,0.05)];
+  }
+
+  /* scale inversed true */
+  .interaction-default-bold-inverse-scale {
+    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(26,27,35,0.12)] active:before:bg-[rgba(26,27,35,0.12)];
+  }
+
+  .interaction-default-normal-inverse-scale {
+    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(58,59,67,0.08)] active:before:bg-[rgba(58,59,67,0.08)];
+  }
+
+  .interaction-default-subtle-inverse-scale {
+    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(2,3,18,0.032)] active:before:bg-[rgba(2,3,18,0.032)];
+  }
+
+  .interaction-brand-bold-inverse-scale {
+    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(48,45,190,0.12)] active:before:bg-[rgba(48,45,190,0.12)];
+  }
+
+  .interaction-brand-normal-inverse-scale {
+    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(74,74,214,0.08)] active:before:bg-[rgba(74,74,214,0.08)];
+  }
+
+  .interaction-brand-subtle-inverse-scale {
+    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(100,101,241,0.05)] active:before:bg-[rgba(100,101,241,0.05)];
   }
 }

--- a/src/styles/interaction.css
+++ b/src/styles/interaction.css
@@ -21,51 +21,51 @@
 
   /* inversed false*/
   .interaction-default-bold {
-    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(255,255,255,0.12)] active:before:bg-[rgba(255,255,255,0.12)];
+    @apply focus-visible:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(255,255,255,0.12)] active:before:bg-[rgba(255,255,255,0.12)];
   }
 
   .interaction-default-normal {
-    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(212,211,222,0.08)] active:before:bg-[rgba(212,211,222,0.08)];
+    @apply focus-visible:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(212,211,222,0.08)] active:before:bg-[rgba(212,211,222,0.08)];
   }
 
   .interaction-default-subtle {
-    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(247,245,255,0.033)] active:before:bg-[rgba(247,245,255,0.033)];
+    @apply focus-visible:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(247,245,255,0.033)] active:before:bg-[rgba(247,245,255,0.033)];
   }
 
   .interaction-brand-bold {
-    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(145,147,255,0.12)] active:before:bg-[rgba(145,147,255,0.12)];
+    @apply focus-visible:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(145,147,255,0.12)] active:before:bg-[rgba(145,147,255,0.12)];
   }
 
   .interaction-brand-normal {
-    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(113,115,255,0.08)] active:before:bg-[rgba(113,115,255,0.08)];
+    @apply focus-visible:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(113,115,255,0.08)] active:before:bg-[rgba(113,115,255,0.08)];
   }
 
   .interaction-brand-subtle {
-    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(87,88,227,0.05)] active:before:bg-[rgba(87,88,227,0.05)];
+    @apply focus-visible:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(87,88,227,0.05)] active:before:bg-[rgba(87,88,227,0.05)];
   }
 
   /* inversed true */
   .interaction-default-bold-inverse {
-    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(26,27,35,0.12)] active:before:bg-[rgba(26,27,35,0.12)];
+    @apply focus-visible:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(26,27,35,0.12)] active:before:bg-[rgba(26,27,35,0.12)];
   }
 
   .interaction-default-normal-inverse {
-    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(58,59,67,0.08)] active:before:bg-[rgba(58,59,67,0.08)];
+    @apply focus-visible:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(58,59,67,0.08)] active:before:bg-[rgba(58,59,67,0.08)];
   }
 
   .interaction-default-subtle-inverse {
-    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(2,3,18,0.032)] active:before:bg-[rgba(2,3,18,0.032)];
+    @apply focus-visible:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(2,3,18,0.032)] active:before:bg-[rgba(2,3,18,0.032)];
   }
 
   .interaction-brand-bold-inverse {
-    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(48,45,190,0.12)] active:before:bg-[rgba(48,45,190,0.12)];
+    @apply focus-visible:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(48,45,190,0.12)] active:before:bg-[rgba(48,45,190,0.12)];
   }
 
   .interaction-brand-normal-inverse {
-    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(74,74,214,0.08)] active:before:bg-[rgba(74,74,214,0.08)];
+    @apply focus-visible:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(74,74,214,0.08)] active:before:bg-[rgba(74,74,214,0.08)];
   }
 
   .interaction-brand-subtle-inverse {
-    @apply focus-visible:before:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(100,101,241,0.05)] active:before:bg-[rgba(100,101,241,0.05)];
+    @apply focus-visible:shadow-focus-visible relative outline-none before:absolute before:inset-0 before:rounded-[inherit] hover:before:bg-[rgba(100,101,241,0.05)] active:before:bg-[rgba(100,101,241,0.05)];
   }
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 인터렉션 버그 해결
- [x] 아코디언, 레이블 버튼 인터렉션 스타일 수정 (-scale 붙는 스타일네임 사용)

## 💡 자세한 설명

(해결방법이 시원치 않지만)
focus-visible 효과 발생 시 border이 덮어씌워지는 경우
그리고 overflow hidden 으로 인해 인터렉션 focus outline이 제대로 보이지 않던 문제를 해결했습니다. 

#### 해결 과정
기존에 `focus-visible:before:shadow-focus-visible` 를 `focus-visible:shadow-focus-visible` 로 변경했습니다.
focus-visible 시 나타나는 하늘색 라인은 가상요소가 아닌 선택된 요소에 직접 나타납니다. 
이로써 위 2가지 문제를 해결할 수 있었습니다. 

카드 컴포넌트 
![image](https://github.com/user-attachments/assets/9daa88c3-4a0b-4362-8bee-1ee9663bde89)
임의로 border이 들어간 박스
![image](https://github.com/user-attachments/assets/11e0b6f7-2ad1-46a2-9902-208834d35b8a)

하지만 이렇게 변경할 경우 scale을 준 아코디언과 레이블 버튼에는 확장한 크기만큼 아웃라인이 나타나지 않는 문제가 발생합니다. 
그래서 scale을 위해 기존 인터렉션 스타일도 (스타일 네임에 `-sclae` 붙여서 ) 남기는 쪽으로 해결했습니다

생각했던 다른 방법
- 가상요소에 border를 inherit하는 방법 => 실패
  - border-width 값 inherit이 제대로 동작 못함 
  - 인라인으로 생기는 border의 특성 때문에 border가 2배로 들어가 요소의 크기가 작아져보임,
- scale 스타일을 가지고 있다면 focus-visible 코드를 동적 할당? 
  - css 파일에선 불가능

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
문제는 해결됐는데 이렇게 하면 interaction.css 파일 코드 양이 2배가 되어서,, 🥺 
여러 방법을 생각해보았는데 이 방법이 최선인 것 같습니다..
조금이라도 중복되는 코드를 줄이기 위해서 유틸리티 클래스가 css 파일에서도 사용 가능하다면 좋았을 텐데 테일윈드는 아직 이런 기능은 지원하지 않는 모양입니다 😭
계속 연구는 해보겠지만 혹시 더 좋은 방법이 있을까요..?!

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #87
