### PR TITLE
refactor: requestHandler 제네릭 타입 수정

### DIFF
--- a/src/apis/miniStudy.ts
+++ b/src/apis/miniStudy.ts
@@ -1,8 +1,7 @@
 import { API_ENDPOINT } from '@/constants/apiEndpoint';
 import { MiniStudies } from '@/types/apis/miniStudy';
-import { ApiResponse } from '@/types/apis/response';
 import { requestHandler } from '@/utils/httpClient';
 
 export const getMiniStudies = async () => {
-  return await requestHandler<ApiResponse<MiniStudies>>('get', API_ENDPOINT.miniStudy);
+  return await requestHandler<MiniStudies>('get', API_ENDPOINT.miniStudy);
 };

--- a/src/utils/httpClient.ts
+++ b/src/utils/httpClient.ts
@@ -1,5 +1,7 @@
 import axios, { AxiosError, AxiosRequestConfig } from 'axios';
 
+import { ApiResponse } from '@/types/apis/response';
+
 const BASE_URL = '/api';
 const DEFAULT_TIMEOUT = 30000;
 
@@ -17,26 +19,26 @@ export const httpClient = createClient();
 
 type RequestMethod = 'get' | 'post' | 'put' | 'delete';
 
-export const requestHandler = async <T>(
+export const requestHandler = async <TResponse, TPayload = undefined>(
   method: RequestMethod,
   url: string,
-  payload?: T,
-): Promise<T> => {
+  payload?: TPayload,
+): Promise<ApiResponse<TResponse>> => {
   try {
     let response;
 
     switch (method) {
       case 'post':
-        response = await httpClient.post<T>(url, payload);
+        response = await httpClient.post<ApiResponse<TResponse>>(url, payload);
         break;
       case 'get':
-        response = await httpClient.get<T>(url);
+        response = await httpClient.get<ApiResponse<TResponse>>(url);
         break;
       case 'put':
-        response = await httpClient.put<T>(url, payload);
+        response = await httpClient.put<ApiResponse<TResponse>>(url, payload);
         break;
       case 'delete':
-        response = await httpClient.delete<T>(url);
+        response = await httpClient.delete<ApiResponse<TResponse>>(url);
         break;
     }
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] requestHandler 제네릭 타입 수정
- [x] 미니스터디 fetch 함수 타입 수정

## 💡 자세한 설명

#101 이슈에서 설명했듯 requestHandler에서 요청과 응답의 제네릭 타입을 별도로 지정해줄 수 있도록 수정했습니다. 
payload 타입은 생략할 경우 undefiend로 지정됩니다. 

또한, api fetch 함수를 적을 때 응답 타입으로 `ApiResponse<T>` 를 중복적으로 작성하는 것을 피하기 위해 
requestHandler 내부에서 감싸주도록 수정했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #101
