### PR TITLE
refactor: 직군명, 이메일 변경 및 데브옵스 애니메이션 비활성화

### DIFF
--- a/src/components/common/select/Select.stories.tsx
+++ b/src/components/common/select/Select.stories.tsx
@@ -20,7 +20,7 @@ const meta: Meta<typeof Select> = {
     items: [
       { label: '프론트엔드 개발자' },
       { label: '백엔드 개발자' },
-      { label: '프로젝트 매니저' },
+      { label: '프로덕트 매니저' },
       { label: '프로덕트 디자이너' },
     ],
   },
@@ -42,7 +42,7 @@ export const SelectStory: Story = {
         items={[
           { label: '프론트엔드 개발자' },
           { label: '백엔드 개발자' },
-          { label: '프로젝트 매니저', disabled: true },
+          { label: '프로덕트 매니저', disabled: true },
           { label: '프로덕트 디자이너' },
         ]}
       />
@@ -58,7 +58,7 @@ export const SelectWithDefaultValueStory: Story = {
         items={[
           { label: '프론트엔드 개발자' },
           { label: '백엔드 개발자' },
-          { label: '프로젝트 매니저' },
+          { label: '프로덕트 매니저' },
           { label: '프로덕트 디자이너' },
         ]}
         defaultValue='백엔드 개발자'

--- a/src/components/common/tab/Tab.stories.tsx
+++ b/src/components/common/tab/Tab.stories.tsx
@@ -36,7 +36,7 @@ export const TabStory: Story = {
       <TabHeader>
         <TabItem id={0} label='프론트엔드 개발자' />
         <TabItem id={1} label='백엔드 개발자' />
-        <TabItem id={2} label='프로젝트 매니저' />
+        <TabItem id={2} label='프로덕트 매니저' />
         <TabItem id={3} label='프로덕트 디자이너' />
       </TabHeader>
       <div>
@@ -47,7 +47,7 @@ export const TabStory: Story = {
           <div>백엔드 개발자 콘텐츠</div>
         </TabPanel>
         <TabPanel id={2}>
-          <div>프로젝트 매니저 콘텐츠</div>
+          <div>프로덕트 매니저 콘텐츠</div>
         </TabPanel>
         <TabPanel id={3}>
           <div>프로덕트 디자이너 콘텐츠</div>

--- a/src/components/main/animatedSection/AnimatedSection.tsx
+++ b/src/components/main/animatedSection/AnimatedSection.tsx
@@ -137,7 +137,7 @@ const AnimatedSection = () => {
     tl.to(badgeRef.current, { scale: 0, duration: 0.3, ease: 'power1.in' });
 
     tl.call(() => {
-      const variants: RoleVariant[] = ['fe', 'be', 'do', 'pm', 'pd'];
+      const variants: RoleVariant[] = ['fe', 'be', 'pm', 'pd'];
       let variantIndex = 1;
       gsap
         .timeline({ repeat: -1 })

--- a/src/components/main/role/RoleBadge.tsx
+++ b/src/components/main/role/RoleBadge.tsx
@@ -29,7 +29,7 @@ const variantMap: Record<
     style: 'bg-role-do-trans-neutral-dark text-role-do-normal-dark',
   },
   pm: {
-    text: '프로젝트 매니저',
+    text: '프로덕트 매니저',
     icon: clipboard,
     style: 'bg-role-pm-trans-neutral-dark text-role-pm-normal-dark',
   },

--- a/src/components/main/role/RoleHero.stories.tsx
+++ b/src/components/main/role/RoleHero.stories.tsx
@@ -75,7 +75,7 @@ export const RoleHeroStory: Story = {
       </div>
       <div className='story-inner-container w-[45rem]'>
         <RoleHero
-          title='프로젝트 매니저'
+          title='프로덕트 매니저'
           variant='pm'
           labels={['문서 관리', '일정 조율', '커뮤니케이션', '팀 플레']}
         >

--- a/src/constants/faqPageData.tsx
+++ b/src/constants/faqPageData.tsx
@@ -1,5 +1,7 @@
 import { ReactNode } from 'react';
 
+import { JECT_EMAIL } from './footer';
+
 interface Faq {
   id: number;
   title: string;
@@ -256,7 +258,7 @@ export const faqJect: Faq[] = [
     id: 5,
     title: '추가 문의는 어디로 하면 되나요?',
     label: '아래 이메일로 문의해 주세요.',
-    content: 'jectofficial@gmail.com',
+    content: JECT_EMAIL,
     caption: '',
   },
 ];

--- a/src/constants/faqPageData.tsx
+++ b/src/constants/faqPageData.tsx
@@ -89,7 +89,7 @@ export const faqProject: Faq[] = [
         <ul className='list-disc-ject'>
           <li>프론트엔드 개발자(FE) 2명</li>
           <li>백엔드 개발자(BE) 2명</li>
-          <li>프로젝트 매니저(PM) 1명</li>
+          <li>프로덕트 매니저(PM) 1명</li>
           <li>프로덕트 디자이너(PD) 1명</li>
         </ul>
       </>

--- a/src/constants/footer.ts
+++ b/src/constants/footer.ts
@@ -1,3 +1,3 @@
-export const JECT_EMAIL = 'jectofficial@gmail.com';
+export const JECT_EMAIL = 'jectofficial@ject.kr';
 export const JECT_FOOTER_INFO =
   '젝트는 IT 사이드 프로젝트 동아리입니다. 몰입하며 진행하는 즐거운 프로젝트를 지향하고 있어요.';

--- a/src/constants/mainPageData.tsx
+++ b/src/constants/mainPageData.tsx
@@ -73,7 +73,7 @@ export const positionData: PositionItem[] = [
   },
   {
     id: 2,
-    title: '프로젝트 매니저',
+    title: '프로덕트 매니저',
     variant: 'pm',
     labels: ['문서 관리', '일정 조율', '커뮤니케이션', '팀 플레잉'],
     description:


### PR DESCRIPTION
## 💡 작업 내용

- [x] `프로덕트 매니저`로 직군명 변경
- [x] 젝트 공식 이메일 변경 
- [x] 데브옵스 애니메이션 비활성화 

## 💡 자세한 설명

전체 코드에서 사용된 직군명 `프로젝트 매니저`를 `프로덕트 매니저`로 변경했습니다.
푸터와 faq에서 사용되고 있던 `jectofficial@gmail.com` 이메일을 `jectofficial@ject.kr` 로 변경했습니다. 
메인 페이지의 데브옵스 애니메이션을 PM의 요청에 따라 비활성화 처리했습니다.


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #103 
