### PR TITLE
feat: 페이지 하단 지원 스낵바 구현

### DIFF
--- a/src/components/apply/ApplySnackBar.tsx
+++ b/src/components/apply/ApplySnackBar.tsx
@@ -17,7 +17,7 @@ function ApplySnackBar({ message, width = '' }: ApplySnackBarProps) {
   };
 
   return (
-    <div className={`${width} fixed inset-x-0 bottom-[7.875rem] left-1/2 z-50 -translate-x-1/2`}>
+    <div className={`${width} fixed inset-x-0 bottom-[3rem] left-1/2 z-50 -translate-x-1/2`}>
       <SnackBar message={message} buttonLabel='젝트 3기 지원하기' onAction={handleAction} />
     </div>
   );

--- a/src/components/apply/ApplySnackBar.tsx
+++ b/src/components/apply/ApplySnackBar.tsx
@@ -6,10 +6,10 @@ import { PATH } from '@/constants/path';
 
 interface ApplySnackBarProps {
   message: string;
-  isMain?: boolean;
+  width?: string;
 }
 
-function ApplySnackBar({ message, isMain = false }: ApplySnackBarProps) {
+function ApplySnackBar({ message, width = '' }: ApplySnackBarProps) {
   const navigate = useNavigate();
 
   const handleAction = () => {
@@ -17,9 +17,7 @@ function ApplySnackBar({ message, isMain = false }: ApplySnackBarProps) {
   };
 
   return (
-    <div
-      className={`${isMain ? 'w-[33.5rem]' : 'w-[31.25rem]'} fixed inset-x-0 bottom-[7.875rem] left-1/2 z-50 -translate-x-1/2`}
-    >
+    <div className={`${width} fixed inset-x-0 bottom-[7.875rem] left-1/2 z-50 -translate-x-1/2`}>
       <SnackBar message={message} buttonLabel='젝트 3기 지원하기' onAction={handleAction} />
     </div>
   );

--- a/src/components/apply/ApplySnackBar.tsx
+++ b/src/components/apply/ApplySnackBar.tsx
@@ -17,7 +17,7 @@ function ApplySnackBar({ message, width = '' }: ApplySnackBarProps) {
   };
 
   return (
-    <div className={`${width} fixed inset-x-0 bottom-[3rem] left-1/2 z-50 -translate-x-1/2`}>
+    <div className={`${width} animate-toast-fade-in fixed left-1/2 z-50 -translate-x-1/2`}>
       <SnackBar message={message} buttonLabel='젝트 3기 지원하기' onAction={handleAction} />
     </div>
   );

--- a/src/components/apply/ApplySnackBar.tsx
+++ b/src/components/apply/ApplySnackBar.tsx
@@ -1,0 +1,28 @@
+import { useNavigate } from 'react-router-dom';
+
+import SnackBar from '../common/snackbar/SnackBar';
+
+import { PATH } from '@/constants/path';
+
+interface ApplySnackBarProps {
+  message: string;
+  isMain?: boolean;
+}
+
+function ApplySnackBar({ message, isMain = false }: ApplySnackBarProps) {
+  const navigate = useNavigate();
+
+  const handleAction = () => {
+    void navigate(PATH.apply);
+  };
+
+  return (
+    <div
+      className={`${isMain ? 'w-[33.5rem]' : 'w-[31.25rem]'} fixed inset-x-0 bottom-[7.875rem] left-1/2 z-50 -translate-x-1/2`}
+    >
+      <SnackBar message={message} buttonLabel='젝트 3기 지원하기' onAction={handleAction} />
+    </div>
+  );
+}
+
+export default ApplySnackBar;

--- a/src/components/common/snackbar/SnackBar.tsx
+++ b/src/components/common/snackbar/SnackBar.tsx
@@ -9,7 +9,7 @@ export interface SnackBarProps {
 
 export const SnackBar = ({ message, buttonLabel, onAction }: SnackBarProps) => {
   return (
-    <div className='gap-4xl radius-md shadow-overlay bg-accent-trans-neutral-dark flex w-full flex-row items-center px-(--gap-2xl) py-(--gap-sm)'>
+    <div className='gap-4xl radius-md shadow-overlay bg-surface-embossed-dark flex w-full flex-row items-center px-(--gap-2xl) py-(--gap-sm)'>
       <span className='text-object-hero-dark label-bold-lg flex flex-1 shrink-0 basis-0'>
         {message}
       </span>

--- a/src/constants/applyMessages.tsx
+++ b/src/constants/applyMessages.tsx
@@ -29,3 +29,8 @@ export const APPLY_MESSAGE = {
     reset: '포지션을 변경해서 답변들이 초기화됐어요. ',
   },
 };
+
+export const APPLY_SNACKBAR = {
+  default: '지금은 젝트 3기 모집 기간이에요!',
+  main: '젝트에서 함께 재밌는 프로젝트 해요!',
+};

--- a/src/pages/Activity.tsx
+++ b/src/pages/Activity.tsx
@@ -58,7 +58,7 @@ function Activity() {
           <EmptyData />
         )}
       </section>
-      <ApplySnackBar message={APPLY_SNACKBAR.default} />
+      <ApplySnackBar message={APPLY_SNACKBAR.default} width='w-[31.25rem]' />
     </div>
   );
 }

--- a/src/pages/Activity.tsx
+++ b/src/pages/Activity.tsx
@@ -1,6 +1,8 @@
+import ApplySnackBar from '@/components/apply/ApplySnackBar';
 import { Card } from '@/components/common/card/Card';
 import EmptyData from '@/components/common/emptyState/EmptyData';
 import Title from '@/components/common/title/Title';
+import { APPLY_SNACKBAR } from '@/constants/applyMessages';
 import useJectalks from '@/hooks/useJectalksQuery';
 import useMiniStudies from '@/hooks/useMiniStudiesQuery';
 
@@ -56,6 +58,7 @@ function Activity() {
           <EmptyData />
         )}
       </section>
+      <ApplySnackBar message={APPLY_SNACKBAR.default} />
     </div>
   );
 }

--- a/src/pages/Faq.tsx
+++ b/src/pages/Faq.tsx
@@ -1,6 +1,8 @@
+import ApplySnackBar from '@/components/apply/ApplySnackBar';
 import Accordion from '@/components/common/accordion/Accordion';
 import { Tab, TabHeader, TabItem, TabPanel } from '@/components/common/tab/Tab';
 import Title from '@/components/common/title/Title';
+import { APPLY_SNACKBAR } from '@/constants/applyMessages';
 import { faqActivity, faqApply, faqJect, faqProject } from '@/constants/faqPageData';
 
 function Faq() {
@@ -59,6 +61,7 @@ function Faq() {
           </Tab>
         </section>
       </div>
+      <ApplySnackBar message={APPLY_SNACKBAR.default} />
     </div>
   );
 }

--- a/src/pages/Faq.tsx
+++ b/src/pages/Faq.tsx
@@ -61,7 +61,7 @@ function Faq() {
           </Tab>
         </section>
       </div>
-      <ApplySnackBar message={APPLY_SNACKBAR.default} />
+      <ApplySnackBar message={APPLY_SNACKBAR.default} width='w-[31.25rem]' />
     </div>
   );
 }

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -182,7 +182,7 @@ const Main = () => {
           </div>
         </div>
       </section>
-      <ApplySnackBar message={APPLY_SNACKBAR.main} isMain={true} />
+      <ApplySnackBar message={APPLY_SNACKBAR.main} width='w-[33.5rem]' />
     </div>
   );
 };

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -2,6 +2,7 @@ import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import { useEffect, useRef } from 'react';
 
+import ApplySnackBar from '@/components/apply/ApplySnackBar';
 import CalloutNumerical from '@/components/common/callout/CalloutNumerical';
 import Hero from '@/components/common/callout/Hero';
 import HeroIndex from '@/components/common/callout/HeroIndex';
@@ -9,6 +10,7 @@ import { Tab, TabHeader, TabItem, TabPanel } from '@/components/common/tab/Tab';
 import Title from '@/components/common/title/Title';
 import AnimatedSection from '@/components/main/animatedSection/AnimatedSection';
 import RoleHero from '@/components/main/role/RoleHero';
+import { APPLY_SNACKBAR } from '@/constants/applyMessages';
 import { corePrincipleData, positionData, timelineData } from '@/constants/mainPageData';
 
 const sectionClassName =
@@ -180,6 +182,7 @@ const Main = () => {
           </div>
         </div>
       </section>
+      <ApplySnackBar message={APPLY_SNACKBAR.main} isMain={true} />
     </div>
   );
 };

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -196,7 +196,7 @@ const Project = () => {
           ))}
         </div>
       </section>
-      <ApplySnackBar message={APPLY_SNACKBAR.default} />
+      <ApplySnackBar message={APPLY_SNACKBAR.default} width='w-[31.25rem]' />
     </div>
   );
 };

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 
 import cardSampleImage from '@/assets/CardSample.png';
+import ApplySnackBar from '@/components/apply/ApplySnackBar';
 import LabelButton from '@/components/common/button/LabelButton';
 import { Card } from '@/components/common/card/Card';
 import Icon from '@/components/common/icon/Icon';
@@ -8,6 +9,7 @@ import { Post } from '@/components/common/post/Post';
 import { Select } from '@/components/common/select/Select';
 import { Tab, TabHeader, TabItem, TabPanel } from '@/components/common/tab/Tab';
 import Title from '@/components/common/title/Title';
+import { APPLY_SNACKBAR } from '@/constants/applyMessages';
 import { PATH } from '@/constants/path';
 
 const projectCardData = [
@@ -194,6 +196,7 @@ const Project = () => {
           ))}
         </div>
       </section>
+      <ApplySnackBar message={APPLY_SNACKBAR.default} />
     </div>
   );
 };

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -139,7 +139,7 @@ const ProjectDetail = () => {
           </div>
         </Tab>
       </section>
-      <ApplySnackBar message={APPLY_SNACKBAR.default} />
+      <ApplySnackBar message={APPLY_SNACKBAR.default} width='w-[31.25rem]' />
     </div>
   );
 };

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1,10 +1,12 @@
 import cardSampleImage from '@/assets/CardSample.png';
+import ApplySnackBar from '@/components/apply/ApplySnackBar';
 import BlockButton from '@/components/common/button/BlockButton';
 import CalloutInformation from '@/components/common/callout/CalloutInformation';
 import Icon from '@/components/common/icon/Icon';
 import Label from '@/components/common/label/Label';
 import { Tab, TabHeader, TabItem, TabPanel } from '@/components/common/tab/Tab';
 import Title from '@/components/common/title/Title';
+import { APPLY_SNACKBAR } from '@/constants/applyMessages';
 
 const projectDetailData = {
   thumbnailUrl: cardSampleImage,
@@ -137,6 +139,7 @@ const ProjectDetail = () => {
           </div>
         </Tab>
       </section>
+      <ApplySnackBar message={APPLY_SNACKBAR.default} />
     </div>
   );
 };


### PR DESCRIPTION
## 💡 작업 내용

- [x] 메인, 프로젝트, 프로젝트 상세, 활동, faq 페이지에 스낵바 노출
- [x] 지원 스낵바 공통 컴포넌트로 분리

## 💡 자세한 설명

### 스낵바 공통 컴포넌트 분리 
- 지원 스낵바의 경우 5개의 페이지에 들어가기 때문에 공통 컴포넌트로 분리 `ApplySnackBar`
- 메인 페이지만 스낵바의 문구가 달라 `message` props로 받습니다. 
- `width` props를 통해 스낵바의 너비가 달라집니다.

#### gif
![2025-04-01 12;40;51](https://github.com/user-attachments/assets/efd42086-0c29-4517-8421-d62cc3367bc0)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #119 
