### PR TITLE
feat: 로컬스토리지 자동 임시 저장 기능 구현

### DIFF
--- a/src/components/common/file/FileItem.tsx
+++ b/src/components/common/file/FileItem.tsx
@@ -23,11 +23,17 @@ function FileItem({ file, onDelete, isDisabled = false, feedback = null }: FileI
   const feedbackType = isNetworkError ? 'error' : feedback;
 
   const openFile = () => {
-    if (isDisabled || !file || !rawFile) return;
+    if (isDisabled || (!fileUrl && !rawFile)) return;
 
-    const url = fileUrl ?? URL.createObjectURL(rawFile);
+    let url = '';
 
-    window.open(url, '_blank', 'noopener,noreferrer');
+    if (fileUrl) {
+      url = fileUrl;
+    } else if (rawFile) {
+      url = URL.createObjectURL(rawFile);
+    }
+
+    if (url) window.open(url, '_blank', 'noopener,noreferrer');
 
     if (!fileUrl) setTimeout(() => URL.revokeObjectURL(url), 5000);
   };

--- a/src/pages/ApplyRegistration.tsx
+++ b/src/pages/ApplyRegistration.tsx
@@ -69,7 +69,7 @@ function ApplyRegistration() {
     closeDialog: closeDialogSubmitAnswer,
   } = useDialog();
 
-  const saveDraftServer = useCallback(() => {
+  const saveDraftServerAndLocal = useCallback(() => {
     if (!selectedJob) return;
 
     saveDraftMutate({ param: selectedJob, answers: answersPayload });
@@ -106,7 +106,7 @@ function ApplyRegistration() {
     });
   };
 
-  // 임시 저장 데이터로 업데이트
+  // 임시 저장 불러오기
   useEffect(() => {
     if (!isLoadDraft(location)) return;
 
@@ -121,21 +121,18 @@ function ApplyRegistration() {
     }
   }, [location, updateAnswerByDraft, draftServer]);
 
-  // 서버 자동 임시 저장 : 15분
+  // 로컬 스토리지 및 서버 임시저장
   useEffect(() => {
-    const autosaveDraft = setInterval(saveDraftServer, 900000);
+    const autosaveDraft = setInterval(saveDraftServerAndLocal, 900000);
 
     return () => clearInterval(autosaveDraft);
-  }, [saveDraftServer]);
+  }, [saveDraftServerAndLocal]);
 
-  // 로컬 스토리지 자동 임시 저장: 1분
+  // 로컬 스토리지 임시 저장
   useEffect(() => {
     if (!selectedJob) return;
 
-    const saveDraftLocal = () => {
-      setDraftLocal({ jobFamily: selectedJob, ...answersPayload });
-    };
-
+    const saveDraftLocal = () => setDraftLocal({ jobFamily: selectedJob, ...answersPayload });
     const autoSaveDraftLocal = setInterval(saveDraftLocal, 60000);
 
     return () => clearInterval(autoSaveDraftLocal);
@@ -173,7 +170,12 @@ function ApplyRegistration() {
           )}
 
           <div aria-label='button-area' className='gap-md flex w-full self-center *:flex-1'>
-            <BlockButton size='lg' style='solid' hierarchy='secondary' onClick={saveDraft}>
+            <BlockButton
+              size='lg'
+              style='solid'
+              hierarchy='secondary'
+              onClick={saveDraftServerAndLocal}
+            >
               임시 저장하기
             </BlockButton>
             <BlockButton

--- a/src/pages/ApplyRegistration.tsx
+++ b/src/pages/ApplyRegistration.tsx
@@ -18,6 +18,7 @@ import useDraftQuery from '@/hooks/useDraftQuery';
 import useSaveDraftQuery from '@/hooks/useSaveDraftQuery';
 import useSubmitAnswerQuery from '@/hooks/useSubmitAnswerQuery';
 import { JobFamily } from '@/types/apis/question';
+import { getDraftLocal, removeDraftLocal, setDraftLocal } from '@/utils/draftUtils';
 
 interface LocationState {
   continue: boolean;
@@ -52,7 +53,7 @@ function ApplyRegistration() {
     setSubmitButtonActive,
   } = useApplicationState();
 
-  const { draft } = useDraftQuery();
+  const { draft: draftServer } = useDraftQuery();
   const { saveDraftMutate } = useSaveDraftQuery();
   const { changeJobMutate } = useChangeJobQuery();
   const { submitAnswerMutate } = useSubmitAnswerQuery();
@@ -68,10 +69,11 @@ function ApplyRegistration() {
     closeDialog: closeDialogSubmitAnswer,
   } = useDialog();
 
-  const saveDraft = useCallback(() => {
+  const saveDraftServer = useCallback(() => {
     if (!selectedJob) return;
 
     saveDraftMutate({ param: selectedJob, answers: answersPayload });
+    setDraftLocal({ jobFamily: selectedJob, ...answersPayload });
     removeLocationState(location);
   }, [saveDraftMutate, answersPayload, selectedJob, location]);
 
@@ -81,6 +83,7 @@ function ApplyRegistration() {
     resetAnswers();
     changeJobMutate(selectedJob);
     closeDialogChangeJob();
+    removeDraftLocal();
   };
 
   const notChangeJob = () => {
@@ -95,24 +98,48 @@ function ApplyRegistration() {
 
     submitAnswerMutate(answer, {
       onSuccess: data => {
-        if (data?.status === 'SUCCESS') void navigate(PATH.applyComplete);
+        if (data?.status === 'SUCCESS') {
+          void navigate(PATH.applyComplete);
+          removeDraftLocal();
+        }
       },
     });
   };
 
+  // 임시 저장 데이터로 업데이트
   useEffect(() => {
     if (!isLoadDraft(location)) return;
 
-    if (!draft || draft.status !== 'SUCCESS') return;
+    const draftLocal = getDraftLocal();
 
-    updateAnswerByDraft(draft.data);
-  }, [draft, location, updateAnswerByDraft]);
+    if (draftLocal) {
+      return updateAnswerByDraft(draftLocal);
+    }
 
+    if (draftServer && draftServer.status === 'SUCCESS') {
+      return updateAnswerByDraft(draftServer.data);
+    }
+  }, [location, updateAnswerByDraft, draftServer]);
+
+  // 서버 자동 임시 저장 : 15분
   useEffect(() => {
-    const autosaveDraft = setInterval(saveDraft, 900000);
+    const autosaveDraft = setInterval(saveDraftServer, 900000);
 
     return () => clearInterval(autosaveDraft);
-  }, [saveDraft]);
+  }, [saveDraftServer]);
+
+  // 로컬 스토리지 자동 임시 저장: 1분
+  useEffect(() => {
+    if (!selectedJob) return;
+
+    const saveDraftLocal = () => {
+      setDraftLocal({ jobFamily: selectedJob, ...answersPayload });
+    };
+
+    const autoSaveDraftLocal = setInterval(saveDraftLocal, 60000);
+
+    return () => clearInterval(autoSaveDraftLocal);
+  }, [selectedJob, answersPayload]);
 
   return (
     <div className='gap-9xl flex flex-col items-center pt-(--gap-9xl) pb-(--gap-12xl)'>

--- a/src/utils/draftUtils.ts
+++ b/src/utils/draftUtils.ts
@@ -13,9 +13,7 @@ const getDraftLocal = () => {
 
   if (!data) return null;
 
-  const draft = JSON.parse(data) as AnswersResponse;
-
-  return draft;
+  return JSON.parse(data) as AnswersResponse;
 };
 
 export { setDraftLocal, removeDraftLocal, getDraftLocal };

--- a/src/utils/draftUtils.ts
+++ b/src/utils/draftUtils.ts
@@ -1,0 +1,21 @@
+import { AnswersResponse } from '@/types/apis/answer';
+
+const setDraftLocal = (answersData: AnswersResponse) => {
+  window.localStorage.setItem('draft', JSON.stringify(answersData));
+};
+
+const removeDraftLocal = () => {
+  window.localStorage.removeItem('draft');
+};
+
+const getDraftLocal = () => {
+  const data = window.localStorage.getItem('draft');
+
+  if (!data) return null;
+
+  const draft = JSON.parse(data) as AnswersResponse;
+
+  return draft;
+};
+
+export { setDraftLocal, removeDraftLocal, getDraftLocal };


### PR DESCRIPTION
## 💡 작업 내용

- [x] 로컬스토리지를 이용한 자동 임시 저장
- [x] fileItem pdf 파일 열기 버그 해결

## 💡 자세한 설명

### 1️⃣ 임시저장 
15분 간격으로 서버에 저장되는 임시저장 외 1분 간격으로 로컬 스토리지에 자동 임시 저장합니다. 

임시저장 플로우는 이렇게 진행됩니다. 
1. 지원서 작성 페이지 접근 전 로컬 스토리지 혹은 서버에 저장된 임시저장데이터가 있는지 확인 
2. 임시저장 불러오기는 로컬 스토리지 -> 서버 순으로 데이터를 가져옴. (로컬스토리지에 없다면 서버 값으로 업데이트)
3. 1분 간격으로 로컬 스토리지에 임시 저장
4. 15분 간격으로 서버로 임시 저장 요청 + 로컬 스토리에 임시 저장 
5. 직군 변경 시 로컬 스토리지 임시 저장 데이터 삭제
6. 제출 시 로컬 스토리지 데이터 삭제

로컬 스토리지가 서버에 있는 데이터보다 최신 데이터이기 때문에 먼저 가져옵니다. 
서버에 저장될 때 로컬 스토리지도 같이 저장시키는 이유는 서버가 로컬 스토리지보다 최신 데이터가 되지 않도록하기 위함입니다. 

### 2️⃣ 업로드된 포트폴리오 파일 PDF 열기 버그 해결
업로드된 파일을 새로운 탭으로 열리지 않는 버그를 발견했습니다. 
FileItem 컴포넌트의 `openFile` 함수의 얼리 리턴 조건문을 수정해 해결했습니다.


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #121 
