### PR TITLE
feat: 답변 SELECT 필드 추가 

### DIFF
--- a/src/components/apply/Answers.tsx
+++ b/src/components/apply/Answers.tsx
@@ -1,6 +1,7 @@
 import { useEffect } from 'react';
 
 import FileField from './FileField';
+import SelectField from './SelectField';
 import TextField from './textField';
 import UrlField from './UrlField';
 
@@ -65,6 +66,15 @@ function Answers({
                 data={data}
                 onChange={onChangePortfolios}
                 values={answersPayload.portfolios}
+              />
+            );
+          case 'SELECT':
+            return (
+              <SelectField
+                key={data.id}
+                data={data}
+                onChange={onChangeAnswer}
+                value={answersPayload.answers[data.id]}
               />
             );
         }

--- a/src/components/apply/FileField.tsx
+++ b/src/components/apply/FileField.tsx
@@ -113,7 +113,7 @@ function FileField({ data, onChange, values }: FileFieldProps) {
     <fieldset className='gap-2xl flex flex-col'>
       <Title hierarchy='normal'>{data.title}</Title>
       <InputFile
-        labelText='첨부파일'
+        labelText={data.label}
         maxSize={data.maxFileSize ?? 100}
         fileExtensions={['pdf']}
         currentSize={totalSize}

--- a/src/components/apply/FileField.tsx
+++ b/src/components/apply/FileField.tsx
@@ -114,7 +114,7 @@ function FileField({ data, onChange, values }: FileFieldProps) {
       <Title hierarchy='normal'>{data.title}</Title>
       <InputFile
         labelText='첨부파일'
-        maxSize={100}
+        maxSize={data.maxFileSize ?? 100}
         fileExtensions={['pdf']}
         currentSize={totalSize}
         isDisabled={false}

--- a/src/components/apply/SelectField.tsx
+++ b/src/components/apply/SelectField.tsx
@@ -24,12 +24,12 @@ function SelectField({ data, onChange, value }: SelectFieldProps) {
   const inputRef = useRef<HTMLInputElement>(null);
   const [selectedItem, setSelectedItem] = useState(value ?? '');
   const { isOpen, setIsOpen } = useCloseOutside([selectRef, inputRef]);
-  const selectLabels = data.body?.map(item => ({ label: item })) ?? [];
+  const selectLabels = data.selectOptions?.map(item => ({ label: item })) ?? [];
 
   const handleSelect = (label: string | null) => {
-    if (!data.body) return;
+    if (!data.selectOptions) return;
 
-    const item = data.body.find(item => item === label);
+    const item = data.selectOptions.find(item => item === label);
 
     if (!item) return setIsOpen(false);
 

--- a/src/components/apply/SelectField.tsx
+++ b/src/components/apply/SelectField.tsx
@@ -33,7 +33,7 @@ function SelectField({ data, onChange, value }: SelectFieldProps) {
 
     if (!item) return setIsOpen(false);
 
-    onChange(data.id, selectedItem);
+    onChange(data.id, item);
     setSelectedItem(item);
     setIsOpen(false);
   };

--- a/src/components/apply/SelectField.tsx
+++ b/src/components/apply/SelectField.tsx
@@ -49,7 +49,7 @@ function SelectField({ data, onChange, value }: SelectFieldProps) {
           onKeyUp={({ key }) => key === 'Enter' && setIsOpen(prev => !prev)}
           value={selectedItem}
           required={data.isRequired}
-          labelText='답변'
+          labelText={data.label}
           isError={false}
           isSuccess={false}
           placeholder={data.inputHint}

--- a/src/components/apply/SelectField.tsx
+++ b/src/components/apply/SelectField.tsx
@@ -1,0 +1,75 @@
+import { useRef, useState } from 'react';
+
+import Icon from '../common/icon/Icon';
+import InputField from '../common/input/InputField';
+import { Select } from '../common/select/Select';
+import Title from '../common/title/Title';
+
+import useCloseOutside from '@/hooks/useCloseOutside';
+import { Question } from '@/types/apis/question';
+
+export interface SelectItem {
+  id: number;
+  label: string;
+}
+
+interface SelectFieldProps {
+  data: Question;
+  onChange: (id: number, text: string) => void;
+  value: string;
+}
+
+function SelectField({ data, onChange, value }: SelectFieldProps) {
+  const selectRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [selectedItem, setSelectedItem] = useState(value ?? '');
+  const { isOpen, setIsOpen } = useCloseOutside([selectRef, inputRef]);
+  const selectLabels = data.body?.map(item => ({ label: item })) ?? [];
+
+  const handleSelect = (label: string | null) => {
+    if (!data.body) return;
+
+    const item = data.body.find(item => item === label);
+
+    if (!item) return setIsOpen(false);
+
+    onChange(data.id, selectedItem);
+    setSelectedItem(item);
+    setIsOpen(false);
+  };
+
+  return (
+    <fieldset className='gap-2xl flex flex-col'>
+      <Title hierarchy='normal'>{data.title}</Title>
+      <div className='relative'>
+        <InputField
+          readOnly
+          ref={inputRef}
+          onClick={() => setIsOpen(prev => !prev)}
+          onKeyUp={({ key }) => key === 'Enter' && setIsOpen(prev => !prev)}
+          value={selectedItem}
+          required={data.isRequired}
+          labelText='답변'
+          isError={false}
+          isSuccess={false}
+          placeholder={data.inputHint}
+          className='group'
+          InputChildren={
+            <Icon
+              name='dropDown'
+              size='lg'
+              fillColor='fill-object-assistive-dark group-focus-within:fill-object-neutral-dark'
+            />
+          }
+        />
+        {isOpen && (
+          <div className='absolute z-40 mt-[8px] w-full' ref={selectRef}>
+            <Select items={selectLabels} defaultValue={selectedItem} onChange={handleSelect} />
+          </div>
+        )}
+      </div>
+    </fieldset>
+  );
+}
+
+export default SelectField;

--- a/src/components/apply/UrlField.tsx
+++ b/src/components/apply/UrlField.tsx
@@ -33,7 +33,7 @@ function UrlField({ data, onChange, value }: UrlFieldProps) {
     <fieldset className='gap-2xl flex flex-col'>
       <Title hierarchy='normal'>{data.title}</Title>
       <InputField
-        labelText='URL'
+        labelText={data.label}
         isSuccess={false}
         placeholder={data.inputHint}
         required={data.isRequired}

--- a/src/components/apply/selectBox.tsx
+++ b/src/components/apply/selectBox.tsx
@@ -23,7 +23,8 @@ const jobFamily: Record<JobFamily, string> = {
 
 function SelectBox({ selectedJob, onLoadQuestion, onOpenDialog }: selectBoxProps) {
   const selectRef = useRef<HTMLDivElement>(null);
-  const { isOpen, setIsOpen } = useCloseOutside(selectRef);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const { isOpen, setIsOpen } = useCloseOutside([selectRef, inputRef]);
 
   const handleSelect = (label: string | null) => {
     const job = JOB_FAMILY.find(key => jobFamily[key] === label);
@@ -42,9 +43,10 @@ function SelectBox({ selectedJob, onLoadQuestion, onOpenDialog }: selectBoxProps
   return (
     <div className='relative'>
       <InputField
+        ref={inputRef}
         readOnly
-        onClick={() => setIsOpen(!isOpen)}
-        onKeyUp={({ key }) => key === 'Enter' && setIsOpen(!isOpen)}
+        onClick={() => setIsOpen(prev => !prev)}
+        onKeyUp={({ key }) => key === 'Enter' && setIsOpen(prev => !prev)}
         value={selectedJob ? jobFamily[selectedJob] : ''}
         required
         labelText='포지션'

--- a/src/components/apply/textField.tsx
+++ b/src/components/apply/textField.tsx
@@ -23,7 +23,7 @@ function TextField({ data, onChange, value }: TextFieldProps) {
       <InputArea
         labelText='답변'
         errorHelper={APPLY_MESSAGE.invalid.exceedText}
-        maxLength={data.maxLength || undefined}
+        maxLength={data.maxTextLength || undefined}
         required={data.isRequired}
         placeholder={data.inputHint}
         onChange={handleChange}

--- a/src/components/apply/textField.tsx
+++ b/src/components/apply/textField.tsx
@@ -21,7 +21,7 @@ function TextField({ data, onChange, value }: TextFieldProps) {
     <fieldset className='gap-2xl flex flex-col'>
       <Title hierarchy='normal'>{data.title}</Title>
       <InputArea
-        labelText='답변'
+        labelText={data.label}
         errorHelper={APPLY_MESSAGE.invalid.exceedText}
         maxLength={data.maxTextLength || undefined}
         required={data.isRequired}

--- a/src/hooks/useCloseOutside.ts
+++ b/src/hooks/useCloseOutside.ts
@@ -1,13 +1,21 @@
 import { RefObject, useEffect, useState } from 'react';
 
-const useCloseOutside = <T extends HTMLElement>(ref: RefObject<T>) => {
+const useCloseOutside = <T extends HTMLElement>(refs: RefObject<T>[] | RefObject<T>) => {
   const [isOpen, setIsOpen] = useState(false);
 
   useEffect(() => {
     if (!isOpen) return;
 
+    const isOutSide = (e: MouseEvent) => {
+      if (refs instanceof Array) {
+        return refs.every(ref => ref.current && !ref.current.contains(e.target as Node));
+      }
+
+      return refs.current && !refs.current.contains(e.target as Node);
+    };
+
     const outsideClick = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) {
+      if (isOutSide(e)) {
         setIsOpen(false);
       }
     };
@@ -15,7 +23,7 @@ const useCloseOutside = <T extends HTMLElement>(ref: RefObject<T>) => {
     document.addEventListener('mousedown', outsideClick);
 
     return () => document.removeEventListener('mousedown', outsideClick);
-  }, [ref, isOpen]);
+  }, [refs, isOpen]);
 
   return { isOpen, setIsOpen };
 };

--- a/src/types/apis/question.ts
+++ b/src/types/apis/question.ts
@@ -7,7 +7,7 @@ export interface Question {
   isRequired: boolean;
   title: string;
   label: string;
-  selectOptions: null | string[];
+  selectOptions: string[] | null;
   inputHint: string;
   maxTextLength: number | null;
   maxFileSize: number | null;

--- a/src/types/apis/question.ts
+++ b/src/types/apis/question.ts
@@ -2,12 +2,15 @@ export type JobFamily = 'PM' | 'PD' | 'FE' | 'BE';
 
 export interface Question {
   id: number;
+  sequence: number;
   inputType: 'TEXT' | 'URL' | 'FILE' | 'SELECT';
-  title: string;
-  body: null | string[];
-  inputHint: string;
-  maxLength: number | null;
   isRequired: boolean;
+  title: string;
+  label: string;
+  selectOptions: null | string[];
+  inputHint: string;
+  maxTextLength: number | null;
+  maxFileSize: number | null;
 }
 
 export type QuestionResponse = Question[];

--- a/src/types/apis/question.ts
+++ b/src/types/apis/question.ts
@@ -2,9 +2,9 @@ export type JobFamily = 'PM' | 'PD' | 'FE' | 'BE';
 
 export interface Question {
   id: number;
-  inputType: 'TEXT' | 'URL' | 'FILE';
+  inputType: 'TEXT' | 'URL' | 'FILE' | 'SELECT';
   title: string;
-  body: null;
+  body: null | string[];
   inputHint: string;
   maxLength: number | null;
   isRequired: boolean;

--- a/src/utils/validateAnswersPayload.ts
+++ b/src/utils/validateAnswersPayload.ts
@@ -40,14 +40,14 @@ export const validateAnswersPayload = (questions: Question[], answersPayload: An
       const text = answersPayload.answers[question.id] || '';
 
       if (!question.isRequired) {
-        if (question.maxLength) return text.length <= question.maxLength;
+        if (question.maxTextLength) return text.length <= question.maxTextLength;
 
         return true;
       }
 
       if (text.trim().length === 0) return false;
 
-      if (question.maxLength) return text.length <= question.maxLength;
+      if (question.maxTextLength) return text.length <= question.maxTextLength;
 
       return true;
     }


### PR DESCRIPTION
## 💡 작업 내용

- [x] SelectField 컴포넌트 구현
- [x] Questions 서버데이터 타입 업데이트
- [x] useCloseOutside 훅 기능 추가 (여러개의 ref 받도록 수정)

## 💡 자세한 설명

### 1️⃣SelectField 컴포넌트 구현
SelectField 컴포넌트를 구현했습니다. 
업데이트된 지원서 문항 api를 바탕으로 문항의 `inputType`이 `SELECT` 타입일 경우 SelectField 컴포넌트를 그립니다.

#### 스크린샷
![image](https://github.com/user-attachments/assets/d7c94791-c8f0-4eb1-9962-99d62168d8b6)

### 2️⃣ 변경된 Questions 서버데이터 반영
아래 사항으로 업데이트 되었고 변경된 타입에 맞춰 수정했습니다!
- `label`, `selectOptions`, `maxFileSize` 추가
- `maxLength` -> `maxTextLength` 변경
- `inputType`에 `SELECT` 추가

### 3️⃣ useCloseOutside 훅 수정
셀렉트 필드에서 선택창을 연속 클릭하면 select가 닫혔다가 다시 열리는 깜빡임 현상이 있었습니다. 
이 문제를 해결하기 위해 useCloseOutside 훅에 outSide 범위 기준을 판단하는 ref를 여러 개 받을 수 있도록 수정했습니다. 
ref를 배열로 넘겨줄 수도 있고 여전히 ref 하나만 단독으로도 넘길 수 있어 이전 useCloseOutside를 사용하고 있던 부분에 영향은 없습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #123 
