### PR TITLE
bug: workflow runner 버전 업데이트

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -7,7 +7,7 @@ on:
       - dev
 jobs:
   storybook:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
## 💡 작업 내용

- [x] storybook.yml의 runner 버전 업데이트

## 💡 자세한 설명
![image](https://github.com/user-attachments/assets/5901f3d3-e489-4d00-af7e-27025b58a259)
와 [github-actions 업데이트](https://github.com/actions/runner-images/issues/11101)에 따라 

```yml
...
jobs:
  storybook:
    runs-on: ubuntu-20.04
...
```
로 처리된 `ubuntu-20.04` 버전은 deprecated 되었습니다.

`ubuntu-latest` 와 고민이 되었는데, 명시적으로 Ubuntu 22.04 LTS를 지정해주는 편이 안정적이라는 생각이 들어 22.04 버전으로 runner 버전을 업데이트 해주었습니다.

![image](https://github.com/user-attachments/assets/d0d7a302-92f0-4813-a93b-9eff3e3f4cbc)
해당 PR의 하단 부분에서 작동되는 것을 확인하였습니다!

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #132 
