### PR TITLE
feat: FAQ 페이지 기능 변경 및 개선

### DIFF
--- a/src/components/common/accordion/Accordion.stories.tsx
+++ b/src/components/common/accordion/Accordion.stories.tsx
@@ -1,24 +1,20 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import Accordion from './Accordion';
+import { Accordion } from './Accordion';
 
 const meta: Meta<typeof Accordion> = {
   title: 'Components/Accordion',
   component: Accordion,
   argTypes: {
-    title: {
+    items: {
+      description: '아코디언 항목 데이터의 배열입니다.',
+    },
+    defaultOpenId: {
       control: 'text',
-      description: '아코디언 헤더에 들어갈 타이틀입니다.',
+      description: '기본적으로 열려있는 아코디언의 아이디입니다. 아이디는 string 타입입니다.',
     },
-    label: {
-      control: 'text',
-      description: '아코디언 레이블입니다.',
-    },
-    children: {
-      description: 'ReactNode 타입의 아코디언 바디 내용입니다.',
-    },
-    caption: {
-      description: 'ReactNode 타입의 아코디언 캡션 내용 입니다.',
+    onChange: {
+      description: '아코디언 상태 변경 시 호출되는 콜백 함수입니다.',
     },
   },
 };
@@ -27,57 +23,42 @@ export default meta;
 
 type Story = StoryObj<typeof Accordion>;
 
-export const Default: Story = {
-  args: {
-    title: '아코디언 헤더 타이틀',
+const sampleAccordionItems = [
+  {
+    id: 'accordion-1',
+    title: '아코디언 헤더 타이틀1',
     label: '아코디언 레이블',
     children: '아코디언 바디 내용',
     caption: '아코디언 캡션 내용',
   },
-};
+  {
+    id: 'accordion-2',
+    title: '아코디언 헤더 타이틀2',
+    label: '아코디언 레이블',
+    children: '아코디언 바디 내용',
+    caption: '아코디언 캡션 내용',
+  },
+];
 
-export const AccordionStory: Story = {
-  name: 'Accordion Story',
-  render: () => {
-    return (
-      <div className='gap-xs flex flex-col'>
-        <Accordion
-          title='아코디언 헤더 타이틀1'
-          label='아코디언 레이블'
-          caption='아코디언 캡션 내용'
-        >
-          아코디언 바디 내용
-        </Accordion>
-        <Accordion
-          title='아코디언 헤더 타이틀2'
-          label='아코디언 레이블'
-          caption='아코디언 캡션 내용'
-        >
-          아코디언 바디 내용
-        </Accordion>
-      </div>
-    );
+export const Default: Story = {
+  name: 'Default Accordion',
+  args: {
+    items: sampleAccordionItems,
+    defaultOpenId: null,
   },
 };
 
-export const AccordionListStory: Story = {
-  name: 'Accordion List Story',
+export const WithDefaultOpenStory: Story = {
+  name: 'Opened Accordion',
+  args: {
+    items: sampleAccordionItems,
+    defaultOpenId: 'accordion-1',
+  },
+};
+
+export const AccordionStory: Story = {
+  name: 'Accordion',
   render: () => {
-    return (
-      <Accordion title='아코디언 헤더 타이틀' label='아코디언 레이블' caption='아코디언 캡션 내용'>
-        아코디언 바디 내용으로 리스트가 있을 때 `list-disc-ject`, `list-inside list-decimal` 클래스
-        스타일을 사용합니다
-        <ul className='list-disc-ject'>
-          <li>리스트1</li>
-          <li>리스트1</li>
-          <li>리스트1</li>
-        </ul>
-        <ul className='list-inside list-decimal'>
-          <li>리스트1</li>
-          <li>리스트1</li>
-          <li>리스트1</li>
-        </ul>
-      </Accordion>
-    );
+    return <Accordion items={sampleAccordionItems} defaultOpenId={null} />;
   },
 };

--- a/src/components/common/accordion/Accordion.tsx
+++ b/src/components/common/accordion/Accordion.tsx
@@ -65,7 +65,7 @@ interface AccordionItemData {
   id: string;
   title: string;
   label: string;
-  children: ReactNode;
+  content: ReactNode;
   caption?: ReactNode;
 }
 
@@ -86,7 +86,7 @@ export const Accordion = ({ items, defaultOpenId = null, onChange }: AccordionPr
 
   return (
     <div className='gap-4xl flex flex-col'>
-      {items.map(({ id, title, label, children, caption }) => (
+      {items.map(({ id, title, label, content, caption }) => (
         <AccordionItem
           key={id}
           id={id}
@@ -96,7 +96,7 @@ export const Accordion = ({ items, defaultOpenId = null, onChange }: AccordionPr
           toggleHandler={handleItemToggle}
           caption={caption}
         >
-          {children}
+          {content}
         </AccordionItem>
       ))}
     </div>

--- a/src/components/common/accordion/Accordion.tsx
+++ b/src/components/common/accordion/Accordion.tsx
@@ -102,5 +102,3 @@ export const Accordion = ({ items, defaultOpenId = null, onChange }: AccordionPr
     </div>
   );
 };
-
-export default Accordion;

--- a/src/components/common/accordion/Accordion.tsx
+++ b/src/components/common/accordion/Accordion.tsx
@@ -1,30 +1,45 @@
-import { ReactNode, useState } from 'react';
+import clsx from 'clsx';
+import { ComponentPropsWithoutRef, ReactNode, useState } from 'react';
 
 import Icon from '../icon/Icon';
 import Label from '../label/Label';
 import Title from '../title/Title';
 
-interface AccordionProps {
+interface AccordionItemProps extends ComponentPropsWithoutRef<'button'> {
+  id: string;
   title: string;
   label: string;
   children: ReactNode;
-  caption: ReactNode;
+  caption?: ReactNode;
+  isOpen: boolean;
+  toggleHandler: (id: string) => void;
 }
 
-// TODO : Select 컴포넌트 처럼 기본 펼침 상태(Select 에서는 선택 상태)를 제어할 수 있는 props 필요
-function Accordion({ title, label, children, caption }: AccordionProps) {
-  const [isOpen, setIsOpen] = useState(false);
+export const AccordionItem = ({
+  id,
+  title,
+  label,
+  children,
+  caption,
+  isOpen,
+  toggleHandler,
+  ...restProps
+}: AccordionItemProps) => {
+  const buttonClass = clsx(
+    'interaction-default-subtle-scale transition-faster-fluent-hover gap-xs radius-3xs flex w-full text-start before:scale-x-102 before:scale-y-128 [&>*:first-child]:grow',
+  );
 
-  const toggle = () => {
-    setIsOpen(!isOpen);
-  };
+  const contentClass = clsx(
+    'bg-surface-deep-dark radius-2xs border-border-trans-assistive-dark gap-xs duration-normal ease(--motion-fluent) flex flex-col overflow-hidden px-(--gap-xs)',
+    {
+      'max-h-[500px] border py-(--gap-md)': isOpen,
+      'max-h-0': !isOpen,
+    },
+  );
 
   return (
     <div className='gap-xs flex flex-col'>
-      <button
-        onClick={toggle}
-        className='interaction-default-subtle-scale transition-faster-fluent-hover gap-xs radius-3xs flex w-full text-start before:scale-x-102 before:scale-y-128 [&>*:first-child]:grow'
-      >
+      <button onClick={() => toggleHandler(id)} className={buttonClass} {...restProps}>
         <Title hierarchy='weak' textColor={isOpen ? null : 'text-object-neutral-dark'}>
           {title}
         </Title>
@@ -35,9 +50,7 @@ function Accordion({ title, label, children, caption }: AccordionProps) {
         )}
       </button>
 
-      <div
-        className={`${isOpen ? 'max-h-[500px] border py-(--gap-md)' : 'max-h-0'} bg-surface-deep-dark radius-2xs border-border-trans-assistive-dark gap-xs duration-normal ease(--motion-fluent) flex flex-col overflow-hidden px-(--gap-xs)`}
-      >
+      <div className={contentClass}>
         <Label hierarchy='stronger' weight='normal' textColor='text-object-hero-dark'>
           {label}
         </Label>
@@ -46,6 +59,48 @@ function Accordion({ title, label, children, caption }: AccordionProps) {
       </div>
     </div>
   );
+};
+
+interface AccordionItemData {
+  id: string;
+  title: string;
+  label: string;
+  children: ReactNode;
+  caption?: ReactNode;
 }
+
+interface AccordionProps {
+  items: AccordionItemData[];
+  defaultOpenId?: string | null;
+  onChange?: (id: string | null) => void;
+}
+
+export const Accordion = ({ items, defaultOpenId = null, onChange }: AccordionProps) => {
+  const [openItemId, setOpenItemId] = useState<string | null>(defaultOpenId);
+
+  const handleItemToggle = (id: string) => {
+    const newValue = openItemId === id ? null : id;
+    setOpenItemId(newValue);
+    onChange?.(newValue);
+  };
+
+  return (
+    <div className='gap-4xl flex flex-col'>
+      {items.map(({ id, title, label, children, caption }) => (
+        <AccordionItem
+          key={id}
+          id={id}
+          title={title}
+          label={label}
+          isOpen={openItemId === id}
+          toggleHandler={handleItemToggle}
+          caption={caption}
+        >
+          {children}
+        </AccordionItem>
+      ))}
+    </div>
+  );
+};
 
 export default Accordion;

--- a/src/constants/faqPageData.tsx
+++ b/src/constants/faqPageData.tsx
@@ -2,17 +2,17 @@ import { ReactNode } from 'react';
 
 import { JECT_EMAIL } from './footer';
 
-interface Faq {
-  id: number;
+interface FaqItemData {
+  id: string;
   title: string;
   label: string;
   content: ReactNode;
-  caption: ReactNode;
+  caption?: ReactNode;
 }
 
-export const faqApply: Faq[] = [
+export const faqApply: FaqItemData[] = [
   {
-    id: 1,
+    id: 'apply-1',
     title: '참여하려면 어느 정도의 실력이 필요한가요?',
     label: '지원자분들의 실력을 직접 평가하는 정량적인 기준은 없어요.',
     content: (
@@ -29,7 +29,7 @@ export const faqApply: Faq[] = [
     caption: '',
   },
   {
-    id: 2,
+    id: 'apply-2',
     title: '다른 IT 동아리에 소속되어 있는데, 젝트에도 지원 가능한가요?',
     label: '다른 IT 동아리 소속 시에는 지원이 어려워요.',
     content: (
@@ -43,7 +43,7 @@ export const faqApply: Faq[] = [
     caption: '',
   },
   {
-    id: 3,
+    id: 'apply-3',
     title: '불합격도 별도로 통지하나요?',
     label: '네. 젝트는 불합격 시에도 이메일로 통지드려요.',
     content:
@@ -51,7 +51,7 @@ export const faqApply: Faq[] = [
     caption: '',
   },
   {
-    id: 4,
+    id: 'apply-4',
     title: '연령이나 신분에 따른 지원 제한이 있나요?',
     label: '특별히 제한을 두고 있지 않아요.',
     content: (
@@ -67,7 +67,7 @@ export const faqApply: Faq[] = [
     caption: '젝트의 지향점에 공감할 수 있는 분이면 더욱 좋아요.',
   },
   {
-    id: 5,
+    id: 'apply-5',
     title: '지원하기 중 인증번호 메일이 오지 않았는데, 어떻게 해야 하나요?',
     label: '스팸 메일함을 우선적으로 확인해 주세요.',
     content:
@@ -77,9 +77,9 @@ export const faqApply: Faq[] = [
   },
 ];
 
-export const faqProject: Faq[] = [
+export const faqProject: FaqItemData[] = [
   {
-    id: 1,
+    id: 'project-1',
     title: '프로젝트 관련 비용은 어떻게 해결하나요?',
     label: '일반적으로 팀원들과 분담해서 해결해요.',
     content: (
@@ -92,7 +92,7 @@ export const faqProject: Faq[] = [
     caption: '',
   },
   {
-    id: 2,
+    id: 'project-2',
     title: '팀 구성은 어떻게 이루어지나요?',
     label: '기본적으로 6인 1팀을 전제로 해요.',
     content: (
@@ -108,7 +108,7 @@ export const faqProject: Faq[] = [
     caption: null,
   },
   {
-    id: 3,
+    id: 'project-3',
     title: '동아리원이 아닌 외부인도 프로젝트에 참여할 수 있나요?',
     label: '일반적으로는 동아리 구성원만 참여 가능해요.',
     content: (
@@ -122,7 +122,7 @@ export const faqProject: Faq[] = [
     caption: '이 경우, 운영진에게 먼저 상황을 충분히 설명해 주셔야 해요.',
   },
   {
-    id: 4,
+    id: 'project-4',
     title: '팀 빌딩은 어떻게 이루어지나요?',
     label: '내가 원하는 팀원을 직접 고를 수 있어요.',
     content: (
@@ -139,7 +139,7 @@ export const faqProject: Faq[] = [
     caption: null,
   },
   {
-    id: 5,
+    id: 'project-5',
     title: 'OT, 데모데이 등의 프로젝트 행사 참여는 필수인가요?',
     label: '기본적으로 온라인 행사에는 필수적으로 참여를 요청드려요.',
     content: (
@@ -152,7 +152,7 @@ export const faqProject: Faq[] = [
     caption: null,
   },
   {
-    id: 6,
+    id: 'project-6',
     title: '프로젝트 후기는 작성 필수인가요?',
     label: '프로젝트 참여 후 후기 작성은 필수예요.',
     content: (
@@ -167,9 +167,9 @@ export const faqProject: Faq[] = [
   },
 ];
 
-export const faqActivity: Faq[] = [
+export const faqActivity: FaqItemData[] = [
   {
-    id: 1,
+    id: 'activity-1',
     title: '미니 스터디 참여는 필수인가요?',
     label: '팀 프로젝트에 참여하고 있다면 필수는 아니지만 권장드려요.',
     content: (
@@ -182,14 +182,14 @@ export const faqActivity: Faq[] = [
     caption: '',
   },
   {
-    id: 2,
+    id: 'activity-2',
     title: '미니 스터디 활동 내용을 외부 플랫폼에 공유해도 되나요?',
     label: '외부 플랫폼 공유 가능 여부는 미니 스터디 리더의 재량에 따라 달라져요.',
     content: '외부 플랫폼 공유를 희망하는 경우 ‘문의하기’ 를 통해 사전 문의해 주세요.',
     caption: '',
   },
   {
-    id: 3,
+    id: 'activity-3',
     title: 'JECTALK은 어떤 활동인가요?',
     label: '내 분야와 관련한 자유 주제를 발표해요.',
     content: (
@@ -204,9 +204,9 @@ export const faqActivity: Faq[] = [
   },
 ];
 
-export const faqJect: Faq[] = [
+export const faqJect: FaqItemData[] = [
   {
-    id: 1,
+    id: 'ject-1',
     title: '젝트에 대해 더 알고 싶어요.',
     label: '젝트는 개발자 취업을 위한 작은 스터디에서 시작됐어요.',
     content: (
@@ -221,7 +221,7 @@ export const faqJect: Faq[] = [
     caption: '',
   },
   {
-    id: 2,
+    id: 'ject-2',
     title: '젝트에서 진행하는 팀 프로젝트가 무엇인가요?',
     label: '젝트는 IT 관련 사이드 프로젝트를 진행해요.',
     content: (
@@ -234,7 +234,7 @@ export const faqJect: Faq[] = [
     caption: '',
   },
   {
-    id: 3,
+    id: 'ject-3',
     title: '주 활동 지역은 어디인가요?',
     label: '정해진 주 활동 지역은 없어요.',
     content: (
@@ -249,7 +249,7 @@ export const faqJect: Faq[] = [
     caption: '',
   },
   {
-    id: 4,
+    id: 'ject-4',
     title: '사용하는 메신저나 공용 플랫폼이 있나요?',
     label: '젝트는 Discord(디스코드)를 주로 사용해요.',
     content: (
@@ -264,7 +264,7 @@ export const faqJect: Faq[] = [
       '*공지 전달의 경우 확실한 전달이 중요하기 때문에 접근성을 위해 카카오톡을 별도로 사용하기도 해요.',
   },
   {
-    id: 5,
+    id: 'ject-5',
     title: '추가 문의는 어디로 하면 되나요?',
     label: '아래 이메일로 문의해 주세요.',
     content: JECT_EMAIL,

--- a/src/hooks/useFaqNavigation.ts
+++ b/src/hooks/useFaqNavigation.ts
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+interface UseFaqNavigationResult {
+  activeTabId: number;
+  openAccordionId: string | null;
+  handleTabChange: (tabId: number) => void;
+  handleAccordionChange: (id: string | null) => void;
+}
+
+export const useFaqNavigation = (): UseFaqNavigationResult => {
+  const { tabId: tabIdParam, questionId: questionIdParam } = useParams<{
+    tabId?: string;
+    questionId?: string;
+  }>();
+
+  const [activeTabId, setActiveTabId] = useState<number>(tabIdParam ? parseInt(tabIdParam, 10) : 1);
+
+  const [openAccordionId, setOpenAccordionId] = useState<string | null>(questionIdParam || null);
+
+  useEffect(() => {
+    if (tabIdParam) {
+      setActiveTabId(parseInt(tabIdParam, 10));
+    }
+
+    if (questionIdParam) {
+      setOpenAccordionId(questionIdParam);
+    }
+  }, [tabIdParam, questionIdParam]);
+
+  const handleTabChange = (tabId: number): void => {
+    setActiveTabId(tabId);
+    setOpenAccordionId(null);
+  };
+
+  const handleAccordionChange = (id: string | null): void => {
+    setOpenAccordionId(id);
+  };
+
+  return {
+    activeTabId,
+    openAccordionId,
+    handleTabChange,
+    handleAccordionChange,
+  };
+};

--- a/src/hooks/useFaqNavigation.ts
+++ b/src/hooks/useFaqNavigation.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
-import { useParams } from 'react-router-dom';
+import { useParams, useNavigate } from 'react-router-dom';
+
+import { PATH } from '@/constants/path.ts';
 
 interface UseFaqNavigationResult {
   activeTabId: number;
@@ -9,13 +11,13 @@ interface UseFaqNavigationResult {
 }
 
 export const useFaqNavigation = (): UseFaqNavigationResult => {
+  const navigate = useNavigate();
   const { tabId: tabIdParam, questionId: questionIdParam } = useParams<{
     tabId?: string;
     questionId?: string;
   }>();
 
   const [activeTabId, setActiveTabId] = useState<number>(tabIdParam ? parseInt(tabIdParam, 10) : 1);
-
   const [openAccordionId, setOpenAccordionId] = useState<string | null>(questionIdParam || null);
 
   useEffect(() => {
@@ -31,6 +33,12 @@ export const useFaqNavigation = (): UseFaqNavigationResult => {
   const handleTabChange = (tabId: number): void => {
     setActiveTabId(tabId);
     setOpenAccordionId(null);
+
+    if (tabId !== 1) {
+      void navigate(`${PATH.faq}/${tabId}`, { replace: true });
+    } else {
+      void navigate(`${PATH.faq}`, { replace: true });
+    }
   };
 
   const handleAccordionChange = (id: string | null): void => {

--- a/src/hooks/useFaqNavigation.ts
+++ b/src/hooks/useFaqNavigation.ts
@@ -35,9 +35,9 @@ export const useFaqNavigation = (): UseFaqNavigationResult => {
     setOpenAccordionId(null);
 
     if (tabId !== 1) {
-      void navigate(`${PATH.faq}/${tabId}`, { replace: true });
+      void navigate(`${PATH.faq}/${tabId}`);
     } else {
-      void navigate(`${PATH.faq}`, { replace: true });
+      void navigate(`${PATH.faq}`);
     }
   };
 

--- a/src/pages/ApplyVerifyEmail.tsx
+++ b/src/pages/ApplyVerifyEmail.tsx
@@ -357,7 +357,7 @@ function ApplyVerifyEmail({
                 rightIcon={
                   <Icon name='rightChevron' size='2xs' fillColor='fill-object-alternative-dark' />
                 }
-                onClick={() => void navigate(PATH.faq)}
+                onClick={() => void navigate(`${PATH.faq}/1/apply-5`)}
               >
                 이메일이 오지 않았나요?
               </LabelButton>

--- a/src/pages/Faq.tsx
+++ b/src/pages/Faq.tsx
@@ -1,11 +1,40 @@
 import ApplySnackBar from '@/components/apply/ApplySnackBar';
-import Accordion from '@/components/common/accordion/Accordion';
+import { Accordion } from '@/components/common/accordion/Accordion';
 import { Tab, TabHeader, TabItem, TabPanel } from '@/components/common/tab/Tab';
 import Title from '@/components/common/title/Title';
 import { APPLY_SNACKBAR } from '@/constants/applyMessages';
 import { faqActivity, faqApply, faqJect, faqProject } from '@/constants/faqPageData';
+import { useFaqNavigation } from '@/hooks/useFaqNavigation';
 
 function Faq() {
+  const { activeTabId, openAccordionId, handleTabChange, handleAccordionChange } =
+    useFaqNavigation();
+
+  const getActiveFaqData = () => {
+    let data;
+    switch (activeTabId) {
+      case 1:
+        data = faqApply;
+        break;
+      case 2:
+        data = faqProject;
+        break;
+      case 3:
+        data = faqActivity;
+        break;
+      case 4:
+        data = faqJect;
+        break;
+      default:
+        data = faqApply;
+    }
+
+    return data.map(item => ({
+      ...item,
+      children: item.content,
+    }));
+  };
+
   return (
     <div className='flex flex-col items-center py-(--gap-12xl)'>
       <div className='gap-8xl flex flex-col'>
@@ -13,7 +42,7 @@ function Faq() {
           <Title hierarchy='strong'>자주 묻는 질문</Title>
         </div>
         <section className='w-[45rem]'>
-          <Tab defaultActiveTabId={1}>
+          <Tab defaultActiveTabId={activeTabId} onTabChange={handleTabChange}>
             <TabHeader>
               <TabItem id={1} label='지원 관련' />
               <TabItem id={2} label='프로젝트 관련' />
@@ -22,39 +51,39 @@ function Faq() {
             </TabHeader>
             <div>
               <TabPanel id={1}>
-                <div className='gap-4xl mt-(--gap-4xl) flex flex-col'>
-                  {faqApply.map(({ id, title, label, content, caption }) => (
-                    <Accordion key={id} title={title} label={label} caption={caption}>
-                      {content}
-                    </Accordion>
-                  ))}
+                <div className='mt-(--gap-4xl)'>
+                  <Accordion
+                    items={getActiveFaqData()}
+                    defaultOpenId={openAccordionId}
+                    onChange={handleAccordionChange}
+                  />
                 </div>
               </TabPanel>
               <TabPanel id={2}>
-                <div className='gap-4xl mt-(--gap-4xl) flex flex-col'>
-                  {faqProject.map(({ id, title, label, content, caption }) => (
-                    <Accordion key={id} title={title} label={label} caption={caption}>
-                      {content}
-                    </Accordion>
-                  ))}
+                <div className='mt-(--gap-4xl)'>
+                  <Accordion
+                    items={getActiveFaqData()}
+                    defaultOpenId={openAccordionId}
+                    onChange={handleAccordionChange}
+                  />
                 </div>
               </TabPanel>
               <TabPanel id={3}>
-                <div className='gap-4xl mt-(--gap-4xl) flex flex-col'>
-                  {faqActivity.map(({ id, title, label, content, caption }) => (
-                    <Accordion key={id} title={title} label={label} caption={caption}>
-                      {content}
-                    </Accordion>
-                  ))}
+                <div className='mt-(--gap-4xl)'>
+                  <Accordion
+                    items={getActiveFaqData()}
+                    defaultOpenId={openAccordionId}
+                    onChange={handleAccordionChange}
+                  />
                 </div>
               </TabPanel>
               <TabPanel id={4}>
-                <div className='gap-4xl mt-(--gap-4xl) flex flex-col'>
-                  {faqJect.map(({ id, title, label, content, caption }) => (
-                    <Accordion key={id} title={title} label={label} caption={caption}>
-                      {content}
-                    </Accordion>
-                  ))}
+                <div className='mt-(--gap-4xl)'>
+                  <Accordion
+                    items={getActiveFaqData()}
+                    defaultOpenId={openAccordionId}
+                    onChange={handleAccordionChange}
+                  />
                 </div>
               </TabPanel>
             </div>

--- a/src/pages/Faq.tsx
+++ b/src/pages/Faq.tsx
@@ -11,28 +11,18 @@ function Faq() {
     useFaqNavigation();
 
   const getActiveFaqData = () => {
-    let data;
     switch (activeTabId) {
       case 1:
-        data = faqApply;
-        break;
+        return faqApply;
       case 2:
-        data = faqProject;
-        break;
+        return faqProject;
       case 3:
-        data = faqActivity;
-        break;
+        return faqActivity;
       case 4:
-        data = faqJect;
-        break;
+        return faqJect;
       default:
-        data = faqApply;
+        return faqApply;
     }
-
-    return data.map(item => ({
-      ...item,
-      children: item.content,
-    }));
   };
 
   return (

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -21,7 +21,7 @@ const routerList = [
       { path: `${PATH.project}/:id`, element: <ProjectDetail /> },
       { path: PATH.activity, element: <Activity /> },
       { path: PATH.apply, element: <Apply /> },
-      { path: PATH.faq, element: <Faq /> },
+      { path: `${PATH.faq}/:tabId?/:questionId?`, element: <Faq /> },
       { path: PATH.applyVerify, element: <ApplyVerify /> },
       { path: PATH.applicantInfo, element: <ApplyApplicantInfo /> },
       { path: PATH.applyRegistration, element: <ApplyRegistration /> },


### PR DESCRIPTION
## 💡 작업 내용

- [x] Accordion 컴포넌트 개선
- [x] 커스텀 훅을 이용해 Faq 페이지 내 Tab와 Accordion 의 action 제어
- [x] 이메일 인증 페이지에서 Faq 페이지로 이동하는 로직 추가 

## 💡 자세한 설명

### ✅ Accordion 컴포넌트 개선
- 전반적인 컴포넌트 내 개선이 있었으며, 기본적인 틀은 `Select` 컴포넌트의 구조와 유사하게 조정하였습니다.

- 실제 사용되는 컴포넌트는 기존과 그대로 `Accordion` 이며, 기존에 단일한 `Accordion`(열고 닫는 하나의 요소)는 `AccordionItem` 으로 선언하였습니다. (이러한 처리로 인해 기존에 Accordion 자체를 mapping 하는 방식에서 Accordion 내부의 상태 변경으로 열고 닫음을 수행합니다. == 다수의 열고 닫는 요소들이 모인 것이 하나의 `Accordion`)

```typescript
  <TabPanel id={1}>
  <div className='mt-(--gap-4xl)'>
    <Accordion
      items={getActiveFaqData()}
      defaultOpenId={openAccordionId}
      onChange={handleAccordionChange}
    />
  </div>
</TabPanel>
```
와 같이 하나의 `TabPanel` 안에 하나의 `Accordion` 이 들어갑니다. (스토리북을 참고해주세요!)

### ✅ 라우팅 처리
- 옵셔널 파라미터 방식을 이용해서
```typescript
      { path: `${PATH.faq}/:tabId?/:questionId?`, element: <Faq /> }
```
와 같이 url 자체에 탭 ID와 해당 탭 중 출력하는 Accordion의 ID를 알 수 있도록 설정하였습니다.

### ✅ useFaqNavigation 훅
- react-router-dom의 `useParams` 를 이용하기 때문에 url에서 감지하는 `tabId` 와 `questionId` 는 string 형태입니다. 따라서 기존 `Tab` 컴포넌트에서 사용하는 number 타입의 id 값을 제어하기 위해
```typescript
  const [activeTabId, setActiveTabId] = useState<number>(tabIdParam ? parseInt(tabIdParam, 10) : 1);
``` 
로 정수형 변환을 수행했습니다.

```typescript
  const handleTabChange = (tabId: number): void => {
    setActiveTabId(tabId);
    setOpenAccordionId(null);
  };

  const handleAccordionChange = (id: string | null): void => {
    setOpenAccordionId(id);
  };
```

탭이 바뀌면 open된 Accordion을 모두 닫아주고(handleTabChange), 같은 탭 내에서도 Accordion을 open 시기존의 openAccordionId 값이 새로운 값으로 대체되어 이전 항목이 닫히게 됩니다.

https://github.com/user-attachments/assets/b22274f2-a461-458b-8d2c-74c726a6442d

### ✅ Faq 객체 데이터 변경점
- 기존 `id: number` 로 선언되었던 것이 `useParams` 로 처리되는 id 값으로 변경되었기 때문에 string 타입으로 변경 후 조금 더 명시적인 이름으로 변경하였습니다.
```typescript
...
export const faqApply: FaqItemData[] = [
  {
    id: 'apply-1', (기존 id: 1)
    title: '참여하려면 어느 정도의 실력이 필요한가요?',
    label: '지원자분들의 실력을 직접 평가하는 정량적인 기준은 없어요.',
...
```

### ✅ 이메일 인증 플로우에서 Faq로 이동 로직 추가 (영상으로 대체)

https://github.com/user-attachments/assets/d31bcb2e-b33f-4eae-be2c-5105187e7829



## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
### ✅ Faq 페이지 내부 데이터 변환 과정(13lines ~ 36lines)
```typescript
  const getActiveFaqData = () => {
    let data;
    switch (activeTabId) {
      case 1:
        data = faqApply;
        break;
      case 2:
        data = faqProject;
        break;
      case 3:
        data = faqActivity;
        break;
      case 4:
        data = faqJect;
        break;
      default:
        data = faqApply;
    }

    return data.map(item => ({
      ...item,
      children: item.content,
    }));
  };
```
와 같이 객체 데이터에서 사용되는 이름이 `content` 이기 때문에 이 content 라는 네이밍을 children 으로 변경해줘야 합니다. 이 과정에서 
1. 객체 데이터에서의 네이밍을 `children` 으로 변경 (객체 데이터인데 children 이라는 네이밍이 적절한가??)
2. Accordion 컴포넌트에서 children으로 받는 요소를 `content` 라는 네이밍으로 변환(컴포넌트인데, content보다 children 이라는 네이밍이 더 적절하지 않나?)

이러한 고민이 듭니다...! 이에 대한 의견을 여쭙고 싶어요!!!

- 현재 url은 `Tab`의 이동이 수행될 때만 Tab에 부여된 id 값으로 변경이 됩니다. (e.g. faq/1, ....) url이 숫자 1,2,3,4,... 로 변경되는 흐름 자체가 다소 어색하게 느껴져 Tab 자체에 부여한 id 타입을 string으로 변경을 해야하나 고민중입니다. 
(이 변경사항 수행 시 Tab을 사용하는 컴포넌트 및 페이지에 일부 영향이 있어 해당 수정작업 역시 수행해야 할 것으로 예상됩니다)


## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #126 
