### PR TITLE
feat: PIN 재설정 기능 구현

### DIFF
--- a/src/apis/apply.ts
+++ b/src/apis/apply.ts
@@ -9,6 +9,8 @@ import {
   PinLoginResponse,
   RegisterMemberPayload,
   RegisterMemberResponse,
+  ResetPinPayload,
+  ResetPinResponse,
   VerificationEmailCodePayload,
   VerificationEmailCodeQueryParams,
   VerificationEmailCodeResponse,
@@ -67,5 +69,13 @@ export const postRegisterMember = async (
     API_ENDPOINT.registerMember,
     data,
     options,
+  );
+};
+
+export const putResetPin = async (data: ResetPinPayload) => {
+  return await requestHandler<ResetPinResponse, ResetPinPayload>(
+    'put',
+    API_ENDPOINT.resetPin,
+    data,
   );
 };

--- a/src/constants/apiEndpoint.ts
+++ b/src/constants/apiEndpoint.ts
@@ -7,6 +7,7 @@ export const API_ENDPOINT = {
   checkEmailExists: '/auth/login/exist',
   memberProfileInitial: '/members/profile/initial',
   registerMember: '/members',
+  resetPin: '/members/pin',
   refreshToken: '/auth/refresh',
   uploadPortfolio: '/upload/portfolios',
   question: '/apply/questions',

--- a/src/hooks/useResetPinMutation.ts
+++ b/src/hooks/useResetPinMutation.ts
@@ -1,0 +1,27 @@
+import { useMutation, UseMutationResult } from '@tanstack/react-query';
+import { AxiosError } from 'axios';
+
+import { putResetPin } from '@/apis/apply';
+import { ResetPinPayload, ResetPinResponse } from '@/types/apis/apply';
+import { ApiResponse } from '@/types/apis/response';
+
+export const useResetPinMutation = (): UseMutationResult<
+  ApiResponse<ResetPinResponse>,
+  AxiosError,
+  ResetPinPayload,
+  unknown
+> => {
+  return useMutation({
+    mutationKey: ['putResetPin'],
+    mutationFn: putResetPin,
+    onMutate: variables => {
+      console.log('useResetPinMutation 시작, variables:', variables);
+    },
+    onSuccess: data => {
+      console.log('useResetPinMutation 성공:', data);
+    },
+    onError: error => {
+      console.error('useResetPinMutation 에러:', error);
+    },
+  });
+};

--- a/src/pages/ApplyVerifyEmail.tsx
+++ b/src/pages/ApplyVerifyEmail.tsx
@@ -369,9 +369,11 @@ function ApplyVerifyEmail({
               size='lg'
               style='solid'
               hierarchy='accent'
-              rightIcon={<Icon name='forward' size='md' fillColor={rightIconFillColor} />}
+              rightIcon={
+                !isResetPin && <Icon name='forward' size='md' fillColor={rightIconFillColor} />
+              }
             >
-              다음 단계로 진행하기
+              {isResetPin ? 'PIN 다시 설정 완료하기' : '다음 단계로 진행하기'}
             </BlockButton>
           </div>
         </div>

--- a/src/pages/ApplyVerifyEmail.tsx
+++ b/src/pages/ApplyVerifyEmail.tsx
@@ -233,6 +233,7 @@ function ApplyVerifyEmail({
 
           if (response.status === 'SUCCESS') {
             addToast('PIN을 다시 설정했어요', 'positive');
+            //TODO: 지원 초기 상태로 state들을 초기화 로직(Zustand, 혹은 외부 함수로)
             setStep(1);
             setStoredEmail('');
             setIsAuthCodeExpired(false);

--- a/src/pages/ApplyVerifyEmail.tsx
+++ b/src/pages/ApplyVerifyEmail.tsx
@@ -51,7 +51,7 @@ function ApplyVerifyEmail({
   const [isAuthCodeExpired, setIsAuthCodeExpired] = useState(false);
   const [emailButtonText, setEmailButtonText] = useState('인증번호 받기');
 
-  const templateType = isResetPin ? 'PIN_RESET' : 'CERTIFICATE';
+  const templateType = isResetPin ? 'PIN_RESET' : 'AUTH_CODE';
 
   const {
     register: registerEmail,

--- a/src/pages/ApplyVerifyEmail.tsx
+++ b/src/pages/ApplyVerifyEmail.tsx
@@ -57,6 +57,7 @@ function ApplyVerifyEmail({
     register: registerEmail,
     handleSubmit: handleSubmitEmail,
     formState: { errors: errorsEmail, isValid: isEmailValid },
+    reset: resetEmailForm,
   } = useApplyEmailForm();
 
   const {
@@ -65,12 +66,14 @@ function ApplyVerifyEmail({
     setError: setVerificationError,
     watch: watchVerification,
     formState: { errors: errorsVerification, isValid: isVerificationValid },
+    reset: resetVerificationForm,
   } = useApplyAuthCodeForm();
 
   const {
     register: registerPin,
     handleSubmit: handleSubmitPin,
     formState: { errors: errorsPin, isValid: isPinValid },
+    reset: resetPinForm,
   } = useApplyPinForm();
 
   const { mutate: checkEmailMutate } = useCheckEmailExistsMutation();
@@ -222,6 +225,10 @@ function ApplyVerifyEmail({
             setStoredEmail('');
             setIsAuthCodeExpired(false);
             setVerificationToken(null);
+
+            resetEmailForm();
+            resetVerificationForm();
+            resetPinForm();
           }
         },
         onError: error => {

--- a/src/pages/ApplyVerifyEmail.tsx
+++ b/src/pages/ApplyVerifyEmail.tsx
@@ -114,10 +114,22 @@ function ApplyVerifyEmail({
             setIsNewApplicant(false);
             return;
           }
+
           setStoredEmail(email);
-          emailMutate({ email, template: templateType });
-          setStep(2);
-          setIsAuthCodeExpired(false);
+
+          emailMutate(
+            { email, template: templateType },
+            {
+              onSuccess: () => {
+                setStep(2);
+                setIsAuthCodeExpired(false);
+              },
+              onError: error => {
+                console.error('이메일 인증 코드 발송 실패:', error);
+                //TODO: 이메일 인증 코드 추가 예외처리 필요
+              },
+            },
+          );
         },
         onError: error => {
           console.error('이메일 존재 여부 확인 실패:', error);

--- a/src/pages/ApplyVerifyPin.tsx
+++ b/src/pages/ApplyVerifyPin.tsx
@@ -34,6 +34,11 @@ function ApplyVerifyPin({ email }: ApplyVerifyPinProps) {
 
   const { mutate: pinLoginMutate, isPending: isPinLoginLoading } = usePinLoginMutation();
 
+  const rightIconFillColor =
+    !isPinValid || isPinLoginLoading
+      ? 'fill-accent-trans-hero-dark'
+      : 'fill-object-static-inverse-hero-dark';
+
   const onPinSubmit = ({ pin }: PinLoginPayload) => {
     const payload = { email, pin };
     console.log('PIN 유효성 검사 통과, 로그인 API 요청 payload:', payload);
@@ -140,8 +145,9 @@ function ApplyVerifyPin({ email }: ApplyVerifyPinProps) {
             size='lg'
             style='solid'
             hierarchy='accent'
+            rightIcon={<Icon name='forward' size='md' fillColor={rightIconFillColor} />}
           >
-            PIN 다시 설정 완료하기
+            다음 단계로 진행하기
           </BlockButton>
         </div>
       </section>

--- a/src/types/apis/apply.ts
+++ b/src/types/apis/apply.ts
@@ -5,7 +5,7 @@ export interface Email {
 export type EmailExistsResponse = boolean;
 
 export interface EmailAuthPayload extends Email {
-  template: 'CERTIFICATE' | 'PIN_RESET';
+  template: 'AUTH_CODE' | 'PIN_RESET';
 }
 
 export interface VerificationEmailCodePayload {
@@ -14,7 +14,7 @@ export interface VerificationEmailCodePayload {
 }
 
 export interface VerificationEmailCodeQueryParams {
-  template: 'CERTIFICATE' | 'PIN_RESET';
+  template: 'AUTH_CODE' | 'PIN_RESET';
 }
 
 export interface VerificationEmailCodeResponse {

--- a/src/types/apis/apply.ts
+++ b/src/types/apis/apply.ts
@@ -46,3 +46,9 @@ export interface RegisterMemberResponse {
   accessToken: string;
   refreshToken: string;
 }
+
+export interface ResetPinPayload {
+  pin: string;
+}
+
+export type ResetPinResponse = null;


### PR DESCRIPTION
## 💡 작업 내용

- [x] PIN 재설정 플로우 구현
- [x] 지원 플로우 중 버튼 텍스트 변경
- [x] 기존 제출과 PIN 재설정 이벤트 핸들러 분리

## 💡 자세한 설명

### ✅ 수정 사항 반영

#134 에서 요청하셨던 버튼의 문구을 요구사항에 맞게 수정하였습니다.

### ✅ 하단 버튼 설정 추가
```typescript
    <BlockButton
        type='submit'
        form={isResetPin ? 'resetPinForm' : 'registerForm'}
        disabled={isSubmitButtonDisabled}
        size='lg'
        style='solid'
        hierarchy='accent'
        rightIcon={
          !isResetPin && <Icon name='forward' size='md' fillColor={rightIconFillColor} />
        }
      >
        {isResetPin ? 'PIN 다시 설정 완료하기' : '다음 단계로 진행하기'}
    </BlockButton>
```
와 같이 `isResetPin` 값에 따라 관리하는 `<form>` 이 변경되며, label도 이에 맞춰서 변경됩니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)
### ✅ PIN 재설정 성공 흐름 관련
(ApplyVerifyEmail의 213 line~ 233 line에서) **resetPinMutate 성공** 시 
```typescript
onSuccess: response => {
          if (response.status === 'SUCCESS') {
            addToast('PIN을 다시 설정했어요', 'positive');
            setStep(1);
            setStoredEmail('');
            setIsAuthCodeExpired(false);
            setVerificationToken(null);

            resetEmailForm();
            resetVerificationForm();
            resetPinForm();
          }
        },
```
와 같이 PIN 재설정 flow에서 사용했던 각 state와 form의 입력값을 초기화하는 과정이 필요한데, 이 흐름이 어떤 동작인지 명확하게 느껴지는 바가 떨어진다고 생각합니다. 

이에 대한 해결방법으로 인증 과정의 전체 상태를 관리하는 Zustand 스토어를 생성하거나, 일련의 동작을 수행하는 별도의 함수를 만드는 방법 등이 있는데, 지금 상태로도 괜찮은지 혹은 제시된 방법(혹은 그 외) 중에 적절하다고 생각하시는 방법이 있는지 질문드려요!


## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #113 
