### PR TITLE
bug: 임시 회원가입 시 토큰 핸들링이 정상적으로 처리되지 않는 문제 해결

### DIFF
--- a/src/apis/apply.ts
+++ b/src/apis/apply.ts
@@ -60,15 +60,11 @@ export const putMemberProfileInitial = async (data: MemberProfileInitialPayload)
   );
 };
 
-export const postRegisterMember = async (
-  data: RegisterMemberPayload,
-  options?: { headers: { Authorization: string } },
-) => {
+export const postRegisterMember = async (data: RegisterMemberPayload) => {
   return await requestHandler<RegisterMemberResponse, RegisterMemberPayload>(
     'post',
     API_ENDPOINT.registerMember,
     data,
-    options,
   );
 };
 

--- a/src/hooks/useRegisterMemberMutation.ts
+++ b/src/hooks/useRegisterMemberMutation.ts
@@ -4,49 +4,21 @@ import { AxiosError } from 'axios';
 import { postRegisterMember } from '@/apis/apply';
 import { RegisterMemberPayload, RegisterMemberResponse } from '@/types/apis/apply';
 import { ApiResponse } from '@/types/apis/response';
-import { isLocalStorageEnabled, tokenUtils } from '@/utils/interceptor';
-
-export interface RegisterMemberMutationVariables {
-  pin: string;
-  verificationToken: string;
-}
 
 export const useRegisterMemberMutation = (): UseMutationResult<
   ApiResponse<RegisterMemberResponse>,
   AxiosError,
-  RegisterMemberMutationVariables,
+  RegisterMemberPayload,
   unknown
 > => {
   return useMutation({
     mutationKey: ['postRegisterMember'],
-    mutationFn: variables => {
-      const { pin, verificationToken } = variables;
-
-      if (isLocalStorageEnabled) {
-        tokenUtils.removeTokens();
-      }
-
-      const payload: RegisterMemberPayload = { pin };
-
-      const options = {
-        headers: {
-          Authorization: `Bearer ${verificationToken}`,
-        },
-      };
-
-      return postRegisterMember(payload, options);
-    },
-    onMutate: variables => {
-      console.log('useRegisterMemberMutation 시작, variables:', variables);
+    mutationFn: postRegisterMember,
+    onMutate: payload => {
+      console.log('useRegisterMemberMutation 시작, payload:', payload);
     },
     onSuccess: data => {
       console.log('useRegisterMemberMutation 성공:', data);
-
-      if (isLocalStorageEnabled && data.status === 'SUCCESS' && data.data) {
-        const { accessToken, refreshToken } = data.data;
-        tokenUtils.setAccessToken(accessToken);
-        tokenUtils.setRefreshToken(refreshToken);
-      }
     },
     onError: error => {
       console.error('useRegisterMemberMutation 에러:', error);

--- a/src/pages/ApplyVerifyEmail.tsx
+++ b/src/pages/ApplyVerifyEmail.tsx
@@ -203,10 +203,7 @@ function ApplyVerifyEmail({
     console.log('PIN 유효성 검사 통과, 회원 등록 API 요청 준비:', { pin });
 
     registerMemberMutate(
-      {
-        pin,
-        verificationToken,
-      },
+      { pin },
       {
         onSuccess: response => {
           console.log('회원 등록 성공:', response);

--- a/src/types/apis/apply.ts
+++ b/src/types/apis/apply.ts
@@ -42,10 +42,7 @@ export interface RegisterMemberPayload {
   pin: string;
 }
 
-export interface RegisterMemberResponse {
-  accessToken: string;
-  refreshToken: string;
-}
+export type RegisterMemberResponse = boolean;
 
 export interface ResetPinPayload {
   pin: string;


### PR DESCRIPTION
## 💡 작업 내용

- [x] 임시 회원가입 시 토큰 핸들링 로직 제거

## 💡 자세한 설명

### ✅ useRegisterMemberMutation 
- useRegisterMemberMutation 에서 기존 로직으로 로컬에서 직접 토큰을 header로 전달하는 로직을 제거하였습니다.

기존 임시회원가입 시 요구되는 `verficationToken`의 경우에도 서버에서 직접 쿠키에 있는 값을 읽어 권한을 부여하는 방식으로 변경된 점을 반영하였습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #152 