### PR TITLE
bug: 임시 회원가입 버튼 클릭 이벤트가 전송안되는 버그 해결

### DIFF
--- a/src/pages/ApplyVerifyEmail.tsx
+++ b/src/pages/ApplyVerifyEmail.tsx
@@ -27,7 +27,6 @@ import {
   VerificationEmailCodePayload,
 } from '@/types/apis/apply';
 import { CreateSubmitHandler } from '@/utils/formHelpers';
-import { tokenUtils } from '@/utils/interceptor';
 
 interface ApplyVerifyEmailProps {
   isResetPin?: boolean;
@@ -47,7 +46,6 @@ function ApplyVerifyEmail({
   const [isReVerification] = useState(isResetPin);
   const [step, setStep] = useState(1);
   const [isTermsChecked, setIsTermsChecked] = useState(false);
-  const [verificationToken, setVerificationToken] = useState<string | null>(null);
   const [isAuthCodeExpired, setIsAuthCodeExpired] = useState(false);
   const [emailButtonText, setEmailButtonText] = useState('인증번호 받기');
 
@@ -172,15 +170,6 @@ function ApplyVerifyEmail({
             });
             return;
           }
-
-          if (response.data?.token) {
-            if (isResetPin) {
-              tokenUtils.setAccessToken(response.data.token);
-            } else {
-              setVerificationToken(response.data.token);
-            }
-          }
-
           setStep(3);
         },
         onError: error => {
@@ -195,11 +184,6 @@ function ApplyVerifyEmail({
   };
 
   const onRegisterMemberSubmit = ({ pin }: RegisterMemberPayload) => {
-    if (!verificationToken) {
-      console.error('인증 토큰이 없습니다. 인증 단계를 다시 진행해주세요.');
-      return;
-    }
-
     console.log('PIN 유효성 검사 통과, 회원 등록 API 요청 준비:', { pin });
 
     registerMemberMutate(
@@ -234,7 +218,6 @@ function ApplyVerifyEmail({
             setStep(1);
             setStoredEmail('');
             setIsAuthCodeExpired(false);
-            setVerificationToken(null);
 
             resetEmailForm();
             resetVerificationForm();


### PR DESCRIPTION
## 💡 작업 내용

- [x] 임시 회원가입 버튼 클릭 이벤트가 전송안되는 버그 해결

## 💡 자세한 설명

### ✅ 삭제된 내용
- `const [verificationToken, setVerificationToken] = useState<string | null>(null);`
해당 상태는 더 이상 쓰지 않습니다. #152 에서 쿠키 관리를 서버에서 직접 처리하는 구조로 인한 변경점

```typescript
  const onRegisterMemberSubmit = ({ pin }: RegisterMemberPayload) => {
    if (!verificationToken) {
      console.error('인증 토큰이 없습니다. 인증 단계를 다시 진행해주세요.');
      return;
    }
```
에서 처럼 인증 토큰이 없으면 return 해주는 로직을 제거합니다. 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #155  
