### PR TITLE
bug: 지원서 제출 버튼 활성화 버그 및 지원서 문항 에러 토스트 버그 해결 

### DIFF
--- a/src/components/apply/Answers.tsx
+++ b/src/components/apply/Answers.tsx
@@ -50,7 +50,7 @@ function Answers({
       return addToast('일시적 오류로 추가 질문들을 불러올 수 없었어요.', 'negative');
     }
 
-    if (status !== 'SUCCESS') {
+    if (status && status !== 'SUCCESS') {
       return addToast('일시적 오류로 추가 질문들을 불러올 수 없었어요.', 'negative');
     }
   }, [isError, addToast, status]);

--- a/src/utils/validateApplication.ts
+++ b/src/utils/validateApplication.ts
@@ -22,6 +22,10 @@ import { Application } from '@/types/ui/application';
  *   답변 필수 O : 유효한 url이여야한다.
  *   답변 필수 X : 답변이 있다면 유효한 url이여야한다. 답변이 없으면 통과.
  *
+ * - SELECT 타입
+ *   답변 필수 O : 빈 문자열이 아닌 값이 있어야한다.
+ *   답변 필수 X : 무조건 통과
+ *
  * 만약 예상하지 못한 inputType이 전달되면 기본적으로 false를 반환한다.
  *
  * @param questions - 질문 객체들의 배열.
@@ -37,7 +41,7 @@ export const validateApplication = (questions: Question[], application: Applicat
     }
 
     if (question.inputType === 'TEXT') {
-      const text = application.answers[question.id] || '';
+      const text = application.answers[question.id] ?? '';
 
       if (!question.isRequired) {
         if (question.maxTextLength) return text.length <= question.maxTextLength;
@@ -56,6 +60,14 @@ export const validateApplication = (questions: Question[], application: Applicat
       const url = application.answers[question.id] || '';
 
       return url ? validateUrlDetail(url) : !question.isRequired;
+    }
+
+    if (question.inputType === 'SELECT') {
+      if (!question.isRequired) return true;
+
+      const text = application.answers[question.id] ?? '';
+
+      return text !== '';
     }
 
     return false;


### PR DESCRIPTION
## 💡 작업 내용

- [x] SELECT 타입 답변 필수 답변 검증 로직 추가
- [x] 지원서 문항(questions) 에러 토스트 처리 조건문 변경

## 💡 자세한 설명

### 1️⃣ 지원서 제출 버튼 활성화 버그
#### 원인
지원서 제출 버튼이 필수 답변을 전부 작성했는데도 불구하고 활성화되지 않았던 이유는 
필수 답변 작성을 확인하는 `validateApplication` 유틸함수에서 `SELECT` 타입이 추가된 사항을 반영하지 않아 발생한 문제입니다.

#### 해결
해당 타입의 답변이 필수 답변인 경우, undefiend 일 경우 false, 값이 있을 경우 true
필수 답변이 아닐 경우에는 무조건 true를 반환하도록 코드를 추가했습니다. 

### 2️⃣ 직군 선택할 때마다 에러 토스트가 나타나는 버그 
#### 원인 
지원서 문항이 아직 응답이 도착하지 않은 상태 (즉, status가 undefined인 상태)에서 조건문에 걸러지지 않고 통과되어 발생한 문제로 예상합니다. 
```ts
 // 기존 코드
  useEffect(() => {
   ...
    if ( status !== 'SUCCESS') {
      return addToast('일시적 오류로 추가 질문들을 불러올 수 없었어요.', 'negative');
    }
  }, [isError, addToast, status]);
```

#### 해결

status가 truly한 값이면서 SUCCESS가 아닐 경우에만 에러 토스트가 뜨도록 조건문을 수정했습니다.
- 질문을 불러올 수 없는 경우에는 stauts가 truly하면서 에러 코드가 SUCCESS가 아님. 
- 지원서 문항 api가 아예 실패한 경우엔 isError 조건문에 걸림.

```ts
 // 수정 코드
  useEffect(() => {
   ...
    if (status && status !== 'SUCCESS') {
      return addToast('일시적 오류로 추가 질문들을 불러올 수 없었어요.', 'negative');
    }
  }, [isError, addToast, status]);
```

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #156 
