### PR TITLE
fix: 스크롤 최상단 이동 기능 추가, 지원서 임시 저장 조회 및 파일 업로드 버그 수정

### DIFF
--- a/src/components/apply/Answers.tsx
+++ b/src/components/apply/Answers.tsx
@@ -31,7 +31,7 @@ function Answers({
   onChangePortfolios,
   onActiveSubmitButton,
 }: AnswersProps) {
-  const { data, isError, refetch } = useQuestionsQuery(questionJob);
+  const { data, isPending, isError, refetch } = useQuestionsQuery(questionJob);
   const { addToast } = useToastActions();
 
   const questions = data?.data.questionResponses;
@@ -54,6 +54,10 @@ function Answers({
       return addToast('일시적 오류로 추가 질문들을 불러올 수 없었어요.', 'negative');
     }
   }, [isError, addToast, status]);
+
+  if (isPending) {
+    return null;
+  }
 
   if (isError || status !== 'SUCCESS') {
     return (

--- a/src/components/apply/FileField.tsx
+++ b/src/components/apply/FileField.tsx
@@ -75,6 +75,14 @@ function FileField({ data, onChange, values }: FileFieldProps) {
 
     const newFilesArr = Array.from(newFiles);
 
+    const isSameFile = portfolios.some(portfolio =>
+      newFilesArr.some(file => file.name === portfolio.fileName),
+    );
+
+    if (isSameFile) {
+      return addToast(APPLY_MESSAGE.invalid.sameFile, 'negative');
+    }
+
     if (validateMaxSize(totalSize, newFilesArr)) {
       return addToast(APPLY_MESSAGE.invalid.fileSize, 'negative');
     }

--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -1,6 +1,7 @@
 import { Outlet } from 'react-router-dom';
 
 import PagesContainer from './PagesContainer';
+import ScrollToTop from './ScrollToTop';
 
 import Dialog from '@/components/common/dialog/Dialog';
 import Footer from '@/components/common/footer/Footer';
@@ -12,6 +13,7 @@ function Layout() {
     <>
       <Header />
       <PagesContainer>
+        <ScrollToTop />
         <Outlet />
       </PagesContainer>
       <Toast />

--- a/src/components/layout/ScrollToTop.tsx
+++ b/src/components/layout/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/constants/applyMessages.tsx
+++ b/src/constants/applyMessages.tsx
@@ -9,6 +9,7 @@ export const APPLY_MESSAGE = {
     fileType: '첨부 가능한 파일 형식을 다시 확인해주세요.',
     unknownFile: '정상적인 PDF 파일인지 다시 확인해주세요',
     exceedText: '최대 글자수를 초과했어요.',
+    sameFile: '동일한 이름의 파일이 있어요. 파일을 다시 확인해주세요.',
   },
   success: {
     sendVerificationEmail: '인증 메일이 발송되었습니다.',

--- a/src/constants/applyPageData.tsx
+++ b/src/constants/applyPageData.tsx
@@ -98,7 +98,7 @@ export const applyInfoList: Info[] = [
           지원 기간 종료까지 지원자분의 소중한 정보를 안전하게 보관할 것을 약속드립니다.`,
     link: (
       <NewTabLink
-        href='https://www.notion.so/JECT-1cf62a893ac581cba52beb59a1eca908'
+        href='https://cultured-phalange-7de.notion.site/JECT-1cf62a893ac581cba52beb59a1eca908'
         className='text-feedback-information-dark decoration-feedback-information-dark underline'
       >
         개인정보 수집 및 이용 동의서

--- a/src/hooks/useDraftQuery.ts
+++ b/src/hooks/useDraftQuery.ts
@@ -15,6 +15,7 @@ const useDraftQuery = (enabled?: boolean) => {
     queryKey: ['getDraft'],
     queryFn: getDraft,
     enabled: enabled ?? true,
+    retry: 0,
   });
 
   if (isError) {

--- a/src/pages/ApplyVerifyEmail.tsx
+++ b/src/pages/ApplyVerifyEmail.tsx
@@ -392,7 +392,7 @@ function ApplyVerifyEmail({
                   />
                 )}
               </div>
-              <NewTabLink href='https://www.notion.so/JECT-1cf62a893ac581cba52beb59a1eca908'>
+              <NewTabLink href='https://cultured-phalange-7de.notion.site/JECT-1cf62a893ac581cba52beb59a1eca908'>
                 <Icon name='rightChevron' size='lg' fillColor='fill-object-assistive-dark' />
               </NewTabLink>
             </div>

--- a/src/pages/ApplyVerifyPin.tsx
+++ b/src/pages/ApplyVerifyPin.tsx
@@ -71,23 +71,25 @@ function ApplyVerifyPin({ email }: ApplyVerifyPinProps) {
         }
 
         void refetchDraftServer().then(({ data }) => {
-          if (!getDraftLocal() && data?.status !== 'SUCCESS') {
+          if (!getDraftLocal() && data?.status === 'TEMP_APPLICATION_NOT_FOUND') {
             return void navigate(PATH.applyRegistration);
           }
 
-          openDialog({
-            type: 'continueWriting',
-            onPrimaryBtnClick: () => {
-              void navigate(PATH.applyRegistration, { state: { continue: true } });
-            },
-            onSecondaryBtnClick: () => {
-              deleteDraftMutate(null, {
-                onSuccess: () => {
-                  void navigate(PATH.applyRegistration, { state: { continue: false } });
-                },
-              });
-            },
-          });
+          if (getDraftLocal() || data?.status === 'SUCCESS') {
+            openDialog({
+              type: 'continueWriting',
+              onPrimaryBtnClick: () => {
+                void navigate(PATH.applyRegistration, { state: { continue: true } });
+              },
+              onSecondaryBtnClick: () => {
+                deleteDraftMutate(null, {
+                  onSuccess: () => {
+                    void navigate(PATH.applyRegistration, { state: { continue: false } });
+                  },
+                });
+              },
+            });
+          }
         });
       },
       onError: error => {


### PR DESCRIPTION
## 💡 작업 내용

- [x] `개인정보 수집 및 이용 동의서` 링크 변경 
- [x] 페이지 이동 시 최상단으로 스크롤 이동하도록 수정
- [x] 임시저장 조회 시 딜레이 문제, 또한 해당 api 요청이 많이 발생되는 문제
- [x] 동일한 이름의 파일 업로드가 가능한 문제 (이름으로 감지하여 못올리도록)

## 💡 자세한 설명

### 스크롤 최상단 이동
스크롤 최상단으로 이동할 때 `window.scrollTo()` 속성으로 behavior: 'smooth' 효과를 줄 수 있는데 현재는 줄 수 없을 것 같습니다.
메인 페이지에서 스크롤 기능이 잠깐 방지되는 로직이 있어 `메인페이지` -> 다른 페이지 혹은 다른 페이지 -> `메인 페이지` 일 때 최상단으로 이동되지 않기 때문입니다 그래서 지금은 부드러운 효과 없이 바로 최상단으로 순간이동합니다 

![2025-04-17 05;20;42](https://github.com/user-attachments/assets/a64dcf67-03cc-48d2-9d39-a146d2da91ca)

### 임시저장 조회 및 파일 업로드 

이 두 부분은 배포해봐야 확실히 해결되었는지 확인 가능합니다. 


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [ ] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [ ] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

#159 
