### PR TITLE
bug: 프로젝트 목록, 상세 페이지 관련 이슈 해결

### DIFF
--- a/src/apis/project.ts
+++ b/src/apis/project.ts
@@ -38,6 +38,9 @@ export const getProjectList = async ({
 };
 
 export const getProjectDetail = async (projectId: string) => {
-  const url = `${API_ENDPOINT.projectDetail.replace(':projectId', projectId)}`;
+  const numericId = parseInt(projectId, 10);
+
+  const url = `${API_ENDPOINT.projectDetail.replace(':projectId', String(numericId))}`;
+
   return await requestHandler<ProjectDetailResponse>('get', url);
 };

--- a/src/apis/project.ts
+++ b/src/apis/project.ts
@@ -23,12 +23,15 @@ export const getProjectList = async ({
   page,
   size,
 }: ProjectListQueryParams) => {
-  const params = new URLSearchParams({
-    semesterId: semesterId.toString(),
-    category: category,
-    page: page.toString(),
-    size: size.toString(),
-  });
+  const params = new URLSearchParams();
+
+  if (semesterId !== undefined) {
+    params.append('semesterId', semesterId.toString());
+  }
+
+  params.append('category', category);
+  params.append('page', page.toString());
+  params.append('size', size.toString());
 
   const url = `${API_ENDPOINT.projectList}?${params.toString()}`;
   return await requestHandler<ProjectListResponse>('get', url);

--- a/src/components/common/callout/CalloutInformation.tsx
+++ b/src/components/common/callout/CalloutInformation.tsx
@@ -12,7 +12,7 @@ function CalloutInformation({ title, labels = [] }: CalloutProps) {
         {title}
       </Label>
       {labels.map(label => (
-        <Label hierarchy='normal' weight='normal' textColor='text-object-neutral-dark'>
+        <Label key={label} hierarchy='normal' weight='normal' textColor='text-object-neutral-dark'>
           {label}
         </Label>
       ))}

--- a/src/hooks/useProjectListQuery.ts
+++ b/src/hooks/useProjectListQuery.ts
@@ -3,13 +3,14 @@ import { useInfiniteQuery } from '@tanstack/react-query';
 import { getProjectList } from '@/apis/project';
 import { ProjectCategory } from '@/types/apis/project';
 
-export const useProjectListQuery = (semesterId: number, category: ProjectCategory) => {
+export const useProjectListQuery = (semesterId: number | null, category: ProjectCategory) => {
   return useInfiniteQuery({
     queryKey: ['getProjectList', semesterId, category],
     queryFn: ({ pageParam = 0 }) => {
       const size = pageParam === 0 ? 6 : 12;
+
       return getProjectList({
-        semesterId,
+        ...(semesterId !== null && { semesterId }),
         category,
         page: pageParam,
         size,

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -8,7 +8,6 @@ import LabelButton from '@/components/common/button/LabelButton';
 import { Card } from '@/components/common/card/Card';
 import EmptyData from '@/components/common/emptyState/EmptyData';
 import Icon from '@/components/common/icon/Icon';
-import { Post } from '@/components/common/post/Post';
 import { Select } from '@/components/common/select/Select';
 import { Tab } from '@/components/common/tab/Tab';
 import Title from '@/components/common/title/Title';
@@ -16,7 +15,6 @@ import { APPLY_SNACKBAR } from '@/constants/applyMessages';
 import { PATH } from '@/constants/path';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { useProjectListQuery } from '@/hooks/useProjectListQuery';
-import { useProjectReviewsQuery } from '@/hooks/useProjectReviewsQuery';
 import { useSemestersQuery } from '@/hooks/useSemestersQuery';
 
 const Project = () => {
@@ -34,24 +32,10 @@ const Project = () => {
     isFetchingNextPage: isFetchingNextProjects,
   } = useProjectListQuery(semesterId, 'MAIN');
 
-  const {
-    data: reviewsData,
-    isError: isReviewsError,
-    fetchNextPage: fetchNextReviews,
-    hasNextPage: isHasNextReviews,
-    isFetchingNextPage: isFetchingNextReviews,
-  } = useProjectReviewsQuery();
-
   const projectsObserverRef = useInfiniteScroll({
     hasNextPage: isHasNextProjects,
     isFetchingNextPage: isFetchingNextProjects,
     fetchNextPage: fetchNextProjects,
-  });
-
-  const reviewsObserverRef = useInfiniteScroll({
-    hasNextPage: isHasNextReviews,
-    isFetchingNextPage: isFetchingNextReviews,
-    fetchNextPage: fetchNextReviews,
   });
 
   const selectItems =
@@ -74,8 +58,6 @@ const Project = () => {
   };
 
   const allProjects = projectsData?.pages.flatMap(page => page.data.content) || [];
-
-  const allReviews = reviewsData?.pages.flatMap(page => page.data.content) || [];
 
   return (
     <div className='gap-12xl flex flex-col items-center px-(--gap-5xl) py-(--gap-12xl)'>
@@ -131,30 +113,6 @@ const Project = () => {
             </div>
           </Tab>
         </div>
-      </section>
-
-      <section className='gap-8xl flex w-full max-w-[60rem] flex-col items-center'>
-        <Title hierarchy='strong'>프로젝트 후기</Title>
-
-        {isReviewsError || allReviews.length === 0 ? (
-          <EmptyData />
-        ) : (
-          <>
-            <div className='gap-2xl flex w-full flex-col'>
-              {allReviews.map(review => (
-                <Post key={review.id} href={review.linkUrl} title={review.title} label='바로가기'>
-                  {review.summary}
-                </Post>
-              ))}
-            </div>
-            <div
-              ref={reviewsObserverRef}
-              className='mt-(--gap-md) flex h-[2.5rem] w-full items-center justify-center'
-            >
-              {isFetchingNextReviews && <Lottie animationData={loadingSpinner} />}
-            </div>
-          </>
-        )}
       </section>
       <ApplySnackBar message={APPLY_SNACKBAR.default} width='w-[31.25rem]' />
     </div>

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -1,5 +1,5 @@
 import Lottie from 'lottie-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
 import cardSampleImage from '@/assets/CardSample.png';
 import loadingSpinner from '@/assets/lottie/ject-loadingSpinner.json';
@@ -13,12 +13,14 @@ import { Select } from '@/components/common/select/Select';
 import Title from '@/components/common/title/Title';
 import { APPLY_SNACKBAR } from '@/constants/applyMessages';
 import { PATH } from '@/constants/path';
+import useCloseOutside from '@/hooks/useCloseOutside';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
 import { useProjectListQuery } from '@/hooks/useProjectListQuery';
 import { useSemestersQuery } from '@/hooks/useSemestersQuery';
 
 const Project = () => {
-  const [isSelectOpen, setIsSelectOpen] = useState(false);
+  const selectContainerRef = useRef(null);
+  const { isOpen: isSelectOpen, setIsOpen: setIsSelectOpen } = useCloseOutside(selectContainerRef);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
   const [semesterId, setSemesterId] = useState<number | null>(null);
 
@@ -72,7 +74,7 @@ const Project = () => {
         <Title hierarchy='strong'>프로젝트</Title>
         <div className='flex w-full flex-col'>
           <div className='gap-4xl flex w-full flex-col'>
-            <div className='relative w-fit'>
+            <div className='relative w-fit' ref={selectContainerRef}>
               <LabelButton
                 size='lg'
                 hierarchy='secondary'

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -9,7 +9,6 @@ import { Card } from '@/components/common/card/Card';
 import EmptyData from '@/components/common/emptyState/EmptyData';
 import Icon from '@/components/common/icon/Icon';
 import { Select } from '@/components/common/select/Select';
-import { Tab } from '@/components/common/tab/Tab';
 import Title from '@/components/common/title/Title';
 import { APPLY_SNACKBAR } from '@/constants/applyMessages';
 import { PATH } from '@/constants/path';
@@ -64,54 +63,50 @@ const Project = () => {
       <section className='gap-8xl flex w-full max-w-[60rem] flex-col items-center'>
         <Title hierarchy='strong'>프로젝트</Title>
         <div className='flex w-full flex-col'>
-          <Tab>
-            <div className='gap-4xl flex w-full flex-col'>
-              <div className='relative w-fit'>
-                <LabelButton
-                  size='lg'
-                  hierarchy='secondary'
-                  rightIcon={
-                    <Icon name='dropDown' size='md' fillColor='fill-object-neutral-dark' />
-                  }
-                  onClick={() => setIsSelectOpen(prev => !prev)}
-                >
-                  {selectedOption ? selectedOption : '기수 선택'}
-                </LabelButton>
-                {isSelectOpen && (
-                  <div className='absolute top-full left-[-9%] z-10 mt-3 w-[7.5rem]'>
-                    <Select items={selectItems} onChange={handleSelectChange} />
-                  </div>
-                )}
-              </div>
-
-              {isProjectsError || allProjects.length === 0 ? (
-                <EmptyData />
-              ) : (
-                <div className='gap-4xl grid grid-cols-3'>
-                  {allProjects.map(project => (
-                    <Card
-                      key={project.id}
-                      to={`${PATH.project}/${project.id}`}
-                      title={project.name}
-                      label={project.name}
-                      imgUrl={project.thumbnailUrl || cardSampleImage}
-                    >
-                      {project.summary}
-                    </Card>
-                  ))}
-                </div>
-              )}
-
-              {!isProjectsError && allProjects.length > 0 && (
-                <div
-                  ref={projectsObserverRef}
-                  className='mt-(--gap-md) flex h-[2.5rem] w-full items-center justify-center'
-                >
-                  {isFetchingNextProjects && <Lottie animationData={loadingSpinner} />}
+          <div className='gap-4xl flex w-full flex-col'>
+            <div className='relative w-fit'>
+              <LabelButton
+                size='lg'
+                hierarchy='secondary'
+                rightIcon={<Icon name='dropDown' size='md' fillColor='fill-object-neutral-dark' />}
+                onClick={() => setIsSelectOpen(prev => !prev)}
+              >
+                {selectedOption ? selectedOption : '기수 선택'}
+              </LabelButton>
+              {isSelectOpen && (
+                <div className='absolute top-full left-[-9%] z-10 mt-3 w-[7.5rem]'>
+                  <Select items={selectItems} onChange={handleSelectChange} />
                 </div>
               )}
             </div>
-          </Tab>
+
+            {isProjectsError || allProjects.length === 0 ? (
+              <EmptyData />
+            ) : (
+              <div className='gap-4xl grid grid-cols-3'>
+                {allProjects.map(project => (
+                  <Card
+                    key={project.id}
+                    to={`${PATH.project}/${project.id}`}
+                    title={project.name}
+                    label={project.name}
+                    imgUrl={project.thumbnailUrl || cardSampleImage}
+                  >
+                    {project.summary}
+                  </Card>
+                ))}
+              </div>
+            )}
+
+            {!isProjectsError && allProjects.length > 0 && (
+              <div
+                ref={projectsObserverRef}
+                className='mt-(--gap-md) flex h-[2.5rem] w-full items-center justify-center'
+              >
+                {isFetchingNextProjects && <Lottie animationData={loadingSpinner} />}
+              </div>
+            )}
+          </div>
         </div>
       </section>
       <ApplySnackBar message={APPLY_SNACKBAR.default} width='w-[31.25rem]' />

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -8,6 +8,7 @@ import LabelButton from '@/components/common/button/LabelButton';
 import { Card } from '@/components/common/card/Card';
 import EmptyData from '@/components/common/emptyState/EmptyData';
 import Icon from '@/components/common/icon/Icon';
+import Label from '@/components/common/label/Label';
 import { Select } from '@/components/common/select/Select';
 import Title from '@/components/common/title/Title';
 import { APPLY_SNACKBAR } from '@/constants/applyMessages';
@@ -80,8 +81,14 @@ const Project = () => {
               )}
             </div>
 
-            {isProjectsError || allProjects.length === 0 ? (
+            {isProjectsError ? (
               <EmptyData />
+            ) : allProjects.length === 0 ? (
+              <div className='flex w-full items-center justify-center py-(--gap-12xl)'>
+                <Label hierarchy='stronger' weight='bold' textColor='text-object-assistive-dark'>
+                  함께할 프로젝트를 기대하고 있어요
+                </Label>
+              </div>
             ) : (
               <div className='gap-4xl grid grid-cols-3'>
                 {allProjects.map(project => (

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -20,7 +20,7 @@ import { useSemestersQuery } from '@/hooks/useSemestersQuery';
 const Project = () => {
   const [isSelectOpen, setIsSelectOpen] = useState(false);
   const [selectedOption, setSelectedOption] = useState<string | null>(null);
-  const [semesterId, setSemesterId] = useState(1);
+  const [semesterId, setSemesterId] = useState<number | null>(null);
 
   const { data: semestersData } = useSemestersQuery();
 
@@ -38,13 +38,20 @@ const Project = () => {
     fetchNextPage: fetchNextProjects,
   });
 
-  const selectItems =
-    semestersData?.data.semesterResponses.map(semester => ({
+  const selectItems = [
+    { label: '전체' },
+    ...(semestersData?.data.semesterResponses.map(semester => ({
       label: semester.name,
-    })) ?? [];
+    })) ?? []),
+  ];
 
   useEffect(() => {
     if (!selectedOption || !semestersData) return;
+
+    if (selectedOption === '전체') {
+      setSemesterId(null);
+      return;
+    }
 
     const semester = semestersData.data.semesterResponses.find(s => s.name === selectedOption);
     if (semester) {
@@ -72,7 +79,7 @@ const Project = () => {
                 rightIcon={<Icon name='dropDown' size='md' fillColor='fill-object-neutral-dark' />}
                 onClick={() => setIsSelectOpen(prev => !prev)}
               >
-                {selectedOption ? selectedOption : '기수 선택'}
+                {selectedOption ? selectedOption : '기수'}
               </LabelButton>
               {isSelectOpen && (
                 <div className='absolute top-full left-[-9%] z-10 mt-3 w-[7.5rem]'>

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -10,7 +10,7 @@ import EmptyData from '@/components/common/emptyState/EmptyData';
 import Icon from '@/components/common/icon/Icon';
 import { Post } from '@/components/common/post/Post';
 import { Select } from '@/components/common/select/Select';
-import { Tab, TabHeader, TabItem, TabPanel } from '@/components/common/tab/Tab';
+import { Tab } from '@/components/common/tab/Tab';
 import Title from '@/components/common/title/Title';
 import { APPLY_SNACKBAR } from '@/constants/applyMessages';
 import { PATH } from '@/constants/path';
@@ -84,10 +84,6 @@ const Project = () => {
         <div className='flex w-full flex-col'>
           <Tab>
             <div className='gap-4xl flex w-full flex-col'>
-              <TabHeader>
-                <TabItem id={0} label='프로젝트' />
-                <TabItem id={1} label='해커톤' disabled />
-              </TabHeader>
               <div className='relative w-fit'>
                 <LabelButton
                   size='lg'
@@ -106,45 +102,23 @@ const Project = () => {
                 )}
               </div>
 
-              <TabPanel id={0}>
-                {isProjectsError || allProjects.length === 0 ? (
-                  <EmptyData />
-                ) : (
-                  <div className='gap-4xl grid grid-cols-3'>
-                    {allProjects.map(project => (
-                      <Card
-                        key={project.id}
-                        to={`${PATH.project}/${project.id}`}
-                        title={project.name}
-                        label={project.name}
-                        imgUrl={project.thumbnailUrl || cardSampleImage}
-                      >
-                        {project.summary}
-                      </Card>
-                    ))}
-                  </div>
-                )}
-              </TabPanel>
-
-              <TabPanel id={1}>
-                {isProjectsError || allProjects.length === 0 ? (
-                  <EmptyData />
-                ) : (
-                  <div className='gap-4xl grid grid-cols-3'>
-                    {allProjects.map(project => (
-                      <Card
-                        key={project.id}
-                        to={`${PATH.jeckathon}/${project.id}`}
-                        title={project.name}
-                        label={project.name}
-                        imgUrl={project.thumbnailUrl || cardSampleImage}
-                      >
-                        {project.summary}
-                      </Card>
-                    ))}
-                  </div>
-                )}
-              </TabPanel>
+              {isProjectsError || allProjects.length === 0 ? (
+                <EmptyData />
+              ) : (
+                <div className='gap-4xl grid grid-cols-3'>
+                  {allProjects.map(project => (
+                    <Card
+                      key={project.id}
+                      to={`${PATH.project}/${project.id}`}
+                      title={project.name}
+                      label={project.name}
+                      imgUrl={project.thumbnailUrl || cardSampleImage}
+                    >
+                      {project.summary}
+                    </Card>
+                  ))}
+                </div>
+              )}
 
               {!isProjectsError && allProjects.length > 0 && (
                 <div

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -90,7 +90,7 @@ const ProjectDetail = () => {
                         key={intro.sequence}
                         src={intro.imageUrl}
                         alt={`서비스 소개 ${intro.sequence}번`}
-                        className='border-border-alternative-dark block h-[29rem] w-full border object-cover'
+                        className='border-border-alternative-dark block h-[29rem] w-full border object-contain'
                       />
                     ))
                 ) : (
@@ -108,7 +108,7 @@ const ProjectDetail = () => {
                         key={intro.sequence}
                         src={intro.imageUrl}
                         alt={`개발 소개 ${intro.sequence}번`}
-                        className='border-border-alternative-dark block h-[29rem] w-full border object-cover'
+                        className='border-border-alternative-dark block h-[29rem] w-full border object-contain'
                       />
                     ))
                 ) : (

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -40,10 +40,13 @@ const ProjectDetail = () => {
 
   const project = projectDetailData.data;
 
-  const frontendDevelopers = project.teamMemberNames?.frontendDevelopers ?? [];
-  const backendDevelopers = project.teamMemberNames?.backendDevelopers ?? [];
-  const productManagers = project.teamMemberNames?.productManagers ?? [];
-  const productDesigners = project.teamMemberNames?.productDesigners ?? [];
+  const teamRoles = [
+    { id: 'fe', title: 'FE', members: project.teamMemberNames?.frontendDevelopers ?? [] },
+    { id: 'be', title: 'BE', members: project.teamMemberNames?.backendDevelopers ?? [] },
+    { id: 'pm', title: 'PM', members: project.teamMemberNames?.productManagers ?? [] },
+    { id: 'pd', title: 'PD', members: project.teamMemberNames?.productDesigners ?? [] },
+  ];
+
   const techStack = project.techStack ?? [];
 
   return (
@@ -63,10 +66,11 @@ const ProjectDetail = () => {
           </div>
           <div className='gap-md flex w-full flex-col items-start'>
             <div className='gap-md flex w-full content-start items-start'>
-              <CalloutInformation title='FE' labels={frontendDevelopers} />
-              <CalloutInformation title='BE' labels={backendDevelopers} />
-              <CalloutInformation title='PM' labels={productManagers} />
-              <CalloutInformation title='PD' labels={productDesigners} />
+              {teamRoles
+                .filter(role => role.members.length > 0)
+                .map(role => (
+                  <CalloutInformation key={role.id} title={role.title} labels={role.members} />
+                ))}
             </div>
             <CalloutInformation title='플랫폼 및 기술' labels={techStack} />
           </div>

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -16,13 +16,25 @@ import { useProjectDetailQuery } from '@/hooks/useProjectDetailQuery';
 const ProjectDetail = () => {
   const { id } = useParams<{ id: string }>();
 
-  const { data: projectDetailData, isError } = useProjectDetailQuery(id ?? '');
+  const {
+    data: projectDetailData,
+    isError,
+    isSuccess,
+    isPending,
+  } = useProjectDetailQuery(id ?? '');
+
+  if (isPending) {
+    return null;
+  }
 
   if (isError) {
     return <Navigate to={PATH.nonSpecificError} replace />;
   }
 
-  if (projectDetailData?.status === 'PROJECT_NOT_FOUND' || !projectDetailData?.data) {
+  if (
+    isSuccess &&
+    (projectDetailData?.status === 'PROJECT_NOT_FOUND' || !projectDetailData?.data)
+  ) {
     return <Navigate to={PATH.notFoundError} replace />;
   }
 

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -30,7 +30,7 @@ const ProjectDetail = () => {
 
   const frontendDevelopers = project.teamMemberNames?.frontendDevelopers ?? [];
   const backendDevelopers = project.teamMemberNames?.backendDevelopers ?? [];
-  const projectManagers = project.teamMemberNames?.projectManagers ?? [];
+  const productManagers = project.teamMemberNames?.productManagers ?? [];
   const productDesigners = project.teamMemberNames?.productDesigners ?? [];
   const techStack = project.techStack ?? [];
 
@@ -53,7 +53,7 @@ const ProjectDetail = () => {
             <div className='gap-md flex w-full content-start items-start'>
               <CalloutInformation title='FE' labels={frontendDevelopers} />
               <CalloutInformation title='BE' labels={backendDevelopers} />
-              <CalloutInformation title='PM' labels={projectManagers} />
+              <CalloutInformation title='PM' labels={productManagers} />
               <CalloutInformation title='PD' labels={productDesigners} />
             </div>
             <CalloutInformation title='플랫폼 및 기술' labels={techStack} />

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -18,15 +18,15 @@ const ProjectDetail = () => {
 
   const { data: projectDetailData, isError } = useProjectDetailQuery(id ?? '');
 
-  const project = projectDetailData?.data;
-
   if (isError) {
     return <Navigate to={PATH.nonSpecificError} replace />;
   }
 
-  if (projectDetailData?.status === 'PROJECT_NOT_FOUND' || !projectDetailData || !project) {
+  if (projectDetailData?.status === 'PROJECT_NOT_FOUND' || !projectDetailData?.data) {
     return <Navigate to={PATH.notFoundError} replace />;
   }
+
+  const project = projectDetailData.data;
 
   const frontendDevelopers = project.teamMemberNames?.frontendDevelopers ?? [];
   const backendDevelopers = project.teamMemberNames?.backendDevelopers ?? [];

--- a/src/types/apis/project.ts
+++ b/src/types/apis/project.ts
@@ -44,7 +44,7 @@ export interface ProjectListResponse {
 }
 
 export interface ProjectListQueryParams {
-  semesterId: number;
+  semesterId?: number;
   category: ProjectCategory;
   page: number;
   size: number;

--- a/src/types/apis/project.ts
+++ b/src/types/apis/project.ts
@@ -56,7 +56,7 @@ export interface ProjectDetailResponse {
   startDate: string;
   endDate: string;
   teamMemberNames: {
-    projectManagers: string[];
+    productManagers: string[];
     productDesigners: string[];
     frontendDevelopers: string[];
     backendDevelopers: string[];


### PR DESCRIPTION
## 💡 작업 내용

- [x] 프로젝트 목록 페이지 3기 선택 시 `EmptyData` 대신 지정된 멘트로 변경
- [x] 프로젝트 목록 페이지에서 기수 목록 미선택 시 프로젝트 상세조회로 이동하지 않는 문제
- [x] 프로젝트 목록 페이지 내부 Tab 제거
- [x] 프로젝트 후기 리스트 제거
- [x] 프로젝트 상세 조회 페이지 에서 새로고침 시 404로 이동하는 문제
- [x] 프로젝트 상세 조회 페이지에 PM 항목의 props 네이밍 수정
- [x] 프로젝트 조회 Select 요소 수정
- [x] 프로젝트 조회 시 semesterId를 옵셔널로 수정
- [x] 프로젝트 상세 조회 시 직군 데이터가 없으면 해당 컴포넌트 렌더링 제외
- [x] 프로젝트 상세 조회 시 하단 사진 스타일 속성 변경
- [x] 프로젝트 목록 란에 Select 동작을 커스텀 훅으로 추가 제어

## 💡 자세한 설명

### ✅ 작업 의도
-  [실제 배포 사이트](ject.kr) 에서 QA 시 발견한 버그들과 추가 요구사항을 반영합니다.
- 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [ ] 머지할 브랜치 확인했나요?
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 기능이 잘 동작하나요?
- [ ] 불필요한 코드는 제거했나요?

closes #160 
