### PR TITLE
bug: Faq 페이지 내 탭 이동 시 히스토리가 유지되는 문제 해결

### DIFF
--- a/src/hooks/useFaqNavigation.ts
+++ b/src/hooks/useFaqNavigation.ts
@@ -35,9 +35,9 @@ export const useFaqNavigation = (): UseFaqNavigationResult => {
     setOpenAccordionId(null);
 
     if (tabId !== 1) {
-      void navigate(`${PATH.faq}/${tabId}`);
+      void navigate(`${PATH.faq}/${tabId}`, { replace: true });
     } else {
-      void navigate(`${PATH.faq}`);
+      void navigate(`${PATH.faq}`, { replace: true });
     }
   };
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] Faq 페이지의 Tab 네비게이션 로직 변경

## 💡 자세한 설명

### ✅ 문제

- handleTabChange 함수에서 URL은 변경되지만 실제 탭 상태는 동기화되지 않는 문제가 발생하였습니다.


### ✅ 원인

- { replace: true } 없이 navigate를 사용하면, 새로운 URL이 브라우저 히스토리 스택에 추가됩니다. 하지만 activeTabId(탭의 state)는 자동으로 업데이트되지 않습니다. 

### ✅ 해결

- UseEffect로 activeTabId를 동기화 해주기 보다,
```typescript
    if (tabId !== 1) {
      void navigate(`${PATH.faq}/${tabId}`, { replace: true });
    } else {
      void navigate(`${PATH.faq}`, { replace: true });
    }
  };
```

와 같이 navigate 시에 `{replace: true}` 를 사용해 히스토리 스택에 새 항목을 추가하지 않도록 처리하였습니다.

https://github.com/user-attachments/assets/8fceca88-8bbf-4917-a168-9c7d1424eb43


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #163 
