### PR TITLE
fix: 지원서 작성 페이지 벗어날 경우 다이얼로그 표시 

### DIFF
--- a/src/constants/dialog.tsx
+++ b/src/constants/dialog.tsx
@@ -65,4 +65,17 @@ export const dialogTypes: Record<DialogTypes, DialogContent> = {
     ),
     primaryBtnLabel: '확인',
   },
+  leaveConfirm: {
+    btnLayout: 'horizontal',
+    title: '다른 페이지로 이동하시겠어요?',
+    content: (
+      <>
+        작성 중인 지원서 내용이 유실될 수 있어요.
+        <br />
+        임시 저장 여부를 한번 더 확인해주세요.
+      </>
+    ),
+    primaryBtnLabel: '이동하기',
+    secondaryBtnLabel: '취소',
+  },
 };

--- a/src/constants/dialog.tsx
+++ b/src/constants/dialog.tsx
@@ -65,7 +65,7 @@ export const dialogTypes: Record<DialogTypes, DialogContent> = {
     ),
     primaryBtnLabel: '확인',
   },
-  leaveConfirm: {
+  dirtyCheck: {
     btnLayout: 'horizontal',
     title: '다른 페이지로 이동하시겠어요?',
     content: (

--- a/src/hooks/useDirtyCheckDialog.ts
+++ b/src/hooks/useDirtyCheckDialog.ts
@@ -3,14 +3,16 @@ import { useBlocker } from 'react-router-dom';
 
 import { useDialogActions } from '@/stores/dialogStore';
 
-const useLeaveConfirmDialog = (when: boolean) => {
-  const blocker = useBlocker(when);
+const useDirtyCheckDialog = (when: boolean) => {
   const { openDialog } = useDialogActions();
+  const blocker = useBlocker(({ currentLocation, nextLocation }) => {
+    return when && currentLocation.pathname !== nextLocation.pathname;
+  });
 
   useEffect(() => {
     if (blocker.state === 'blocked') {
       openDialog({
-        type: 'leaveConfirm',
+        type: 'dirtyCheck',
         onPrimaryBtnClick: () => blocker.proceed(),
         onSecondaryBtnClick: () => blocker.reset(),
       });
@@ -18,4 +20,4 @@ const useLeaveConfirmDialog = (when: boolean) => {
   }, [blocker, openDialog]);
 };
 
-export default useLeaveConfirmDialog;
+export default useDirtyCheckDialog;

--- a/src/hooks/useLeaveConfirmDialog.ts
+++ b/src/hooks/useLeaveConfirmDialog.ts
@@ -1,0 +1,21 @@
+import { useEffect } from 'react';
+import { useBlocker } from 'react-router-dom';
+
+import { useDialogActions } from '@/stores/dialogStore';
+
+const useLeaveConfirmDialog = (when: boolean) => {
+  const blocker = useBlocker(when);
+  const { openDialog } = useDialogActions();
+
+  useEffect(() => {
+    if (blocker.state === 'blocked') {
+      openDialog({
+        type: 'leaveConfirm',
+        onPrimaryBtnClick: () => blocker.proceed(),
+        onSecondaryBtnClick: () => blocker.reset(),
+      });
+    }
+  }, [blocker, openDialog]);
+};
+
+export default useLeaveConfirmDialog;

--- a/src/pages/ApplyRegistration.tsx
+++ b/src/pages/ApplyRegistration.tsx
@@ -14,8 +14,8 @@ import { APPLY_TITLE } from '@/constants/applyPageData';
 import { PATH } from '@/constants/path';
 import useApplicationState from '@/hooks/useApplicationState';
 import useDeleteDraftMutation from '@/hooks/useDeleteDraftMutation';
+import useDirtyCheckDialog from '@/hooks/useDirtyCheckDialog';
 import useDraftQuery from '@/hooks/useDraftQuery';
-import useLeaveConfirmDialog from '@/hooks/useLeaveConfirmDialog';
 import useSaveDraftMutation from '@/hooks/useSaveDraftMutation';
 import useSubmitAnswerMutation from '@/hooks/useSubmitAnswerMutation';
 import { useDialogActions } from '@/stores/dialogStore';
@@ -62,7 +62,7 @@ function ApplyRegistration() {
   const { mutate: submitAnswerMutate, isPending: isSubmitAnswerPending } =
     useSubmitAnswerMutation();
 
-  useLeaveConfirmDialog(!!selectedJob);
+  useDirtyCheckDialog(!!selectedJob);
 
   const saveDraftServerAndLocal = useCallback(() => {
     if (!selectedJob) return;

--- a/src/pages/ApplyRegistration.tsx
+++ b/src/pages/ApplyRegistration.tsx
@@ -15,6 +15,7 @@ import { PATH } from '@/constants/path';
 import useApplicationState from '@/hooks/useApplicationState';
 import useDeleteDraftMutation from '@/hooks/useDeleteDraftMutation';
 import useDraftQuery from '@/hooks/useDraftQuery';
+import useLeaveConfirmDialog from '@/hooks/useLeaveConfirmDialog';
 import useSaveDraftMutation from '@/hooks/useSaveDraftMutation';
 import useSubmitAnswerMutation from '@/hooks/useSubmitAnswerMutation';
 import { useDialogActions } from '@/stores/dialogStore';
@@ -60,6 +61,8 @@ function ApplyRegistration() {
   const { mutate: deleteDraftMutate } = useDeleteDraftMutation(); // TODO: 삭제 isPending 추가 여부 및 방식 논의 필요
   const { mutate: submitAnswerMutate, isPending: isSubmitAnswerPending } =
     useSubmitAnswerMutation();
+
+  useLeaveConfirmDialog(!!selectedJob);
 
   const saveDraftServerAndLocal = useCallback(() => {
     if (!selectedJob) return;

--- a/src/types/ui/dialog.ts
+++ b/src/types/ui/dialog.ts
@@ -4,4 +4,5 @@ export type DialogTypes =
   | 'submitAnswer'
   | 'expiredSession'
   | 'continueWriting'
-  | 'failedUploadFile';
+  | 'failedUploadFile'
+  | 'leaveConfirm';

--- a/src/types/ui/dialog.ts
+++ b/src/types/ui/dialog.ts
@@ -5,4 +5,4 @@ export type DialogTypes =
   | 'expiredSession'
   | 'continueWriting'
   | 'failedUploadFile'
-  | 'leaveConfirm';
+  | 'dirtyCheck';


### PR DESCRIPTION
## 💡 작업 내용

- [x] 다이얼로그 `dirtyCheck` 객체 데이터 추가 
- [x] useDirtyCheckDialog 훅 생성 
- [x] ApplyRegistration 컴포넌트 내 훅 적용

## 💡 자세한 설명

### 1️⃣ useDirtyCheckDialog 훅

```ts
const useDirtyCheckDialog = (when: boolean) => {
  const { openDialog } = useDialogActions();
  const blocker = useBlocker(({ currentLocation, nextLocation }) => { 
    return when && currentLocation.pathname !== nextLocation.pathname;
  }); // props로 받은 when이 true 여야하며, 현재페이지 pathname, 이동할 페이지 pathname이 다를 때 `blocked` 상태로 반환

  useEffect(() => {
    if (blocker.state === 'blocked') {
      openDialog({
        type: 'dirtyCheck',
        onPrimaryBtnClick: () => blocker.proceed(), // 다른 페이지 이동
        onSecondaryBtnClick: () => blocker.reset(), // 현재 페이지 남음
      });
    }
  }, [blocker, openDialog]);
};
```
 react router의 `useBlocker` 를 사용하여 구현했습니다. 

공식 문서에서 설명하는 useBlocker 기능은 이렇습니다. 

> "이 기능은 SPA(단일 페이지 애플리케이션) 내에서의 페이지 이동을 차단하고, 사용자가 이동을 시도할 때 확인 다이얼로그를 띄워주는 기능을 허용합니다. 주로 입력 중인 폼 데이터가 손실되는 것을 방지하기 위해 사용됩니다. 단, 새로고침(hard reload)이나 외부 사이트로의 이동(cross-origin navigation)은 처리하지 않습니다."

ApplyRegistration에서는 직군을 선택하지 않았을 때에는 해당 다이얼로그가 나오지 않도록 처리했습니다. 
정확한 테스트는 배포 환경에서 가능합니다.

## 📗 참고 자료 (선택)
useBlocker 공식 문서 : https://reactrouter.com/api/hooks/useBlocker

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #169 
