### PR TITLE
fix: 임시 모바일 UI 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,10 +6,12 @@ import { useState } from 'react';
 import { RouterProvider } from 'react-router-dom';
 
 import { useGlobalErrorHandler } from './hooks/useGlobalErrorHandler';
+import TempMobile from './pages/TempMobile';
 import router from './router';
 
 function App() {
   const handleGlobalError = useGlobalErrorHandler();
+  const isMobile = window.innerWidth <= 768;
 
   const [queryClient] = useState(
     () =>
@@ -22,6 +24,10 @@ function App() {
         }),
       }),
   );
+
+  if (isMobile) {
+    return <TempMobile />;
+  }
 
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/components/common/footer/Footer.tsx
+++ b/src/components/common/footer/Footer.tsx
@@ -6,20 +6,22 @@ import { JECT_EMAIL, JECT_FOOTER_INFO } from '@/constants/footer';
 
 function Footer() {
   return (
-    <footer className='bg-surface-standard-dark text-object-alternative-dark body-2xs gap-xl flex h-[4.875rem] items-center px-(--gap-5xl)'>
-      <Logo height={20} fillColor='fill-object-normal-dark' />
-      <div className='border-border-trans-alternative-dark h-[2rem] border-r'></div>
-      <p className='grow'>{JECT_FOOTER_INFO}</p>
-      <p>{JECT_EMAIL}</p>
-      <div className='gap-xl flex'>
-        <NewTabLink href='https://github.com/JECT-Study'>
-          <Icon name='github' size='2xl' fillColor='fill-object-alternative-dark' />
-        </NewTabLink>
-        <NewTabLink href='https://www.youtube.com/@ject_it_club'>
-          <Youtube />
-        </NewTabLink>
-      </div>
-    </footer>
+    <div className='bg-surface-standard-dark'>
+      <footer className='bg-surface-tinted-dark text-object-alternative-dark body-2xs gap-xl flex h-[4.875rem] items-center px-(--gap-5xl)'>
+        <Logo height={20} fillColor='fill-object-normal-dark' />
+        <div className='border-border-trans-alternative-dark h-[2rem] border-r'></div>
+        <p className='grow'>{JECT_FOOTER_INFO}</p>
+        <p>{JECT_EMAIL}</p>
+        <div className='gap-xl flex'>
+          <NewTabLink href='https://github.com/JECT-Study'>
+            <Icon name='github' size='2xl' fillColor='fill-object-alternative-dark' />
+          </NewTabLink>
+          <NewTabLink href='https://www.youtube.com/@ject_it_club'>
+            <Youtube />
+          </NewTabLink>
+        </div>
+      </footer>
+    </div>
   );
 }
 

--- a/src/components/common/navigation/Navigation.tsx
+++ b/src/components/common/navigation/Navigation.tsx
@@ -9,7 +9,7 @@ interface NavigationProps {
 
 function Navigation({ children }: NavigationProps) {
   return (
-    <header className='bg-surface-standard-dark gap-6xl fixed z-49 flex h-[3.68rem] w-dvw items-center pl-(--gap-5xl)'>
+    <header className='border-border-assistive-dark bg-surface-standard-dark gap-6xl fixed z-49 flex h-[3.68rem] w-dvw items-center border-b pl-(--gap-5xl)'>
       <Link
         to='/'
         className='focus-visible:shadow-focus-visible radius-4xs cursor-pointer p-(--gap-5xs) outline-none'

--- a/src/components/layout/PagesContainer.tsx
+++ b/src/components/layout/PagesContainer.tsx
@@ -5,7 +5,7 @@ interface PagesContainerProps {
 }
 
 function PagesContainer({ children }: PagesContainerProps) {
-  return <main className='bg-surface-standard-dark min-h-dvh'>{children}</main>;
+  return <main className='bg-surface-standard-dark min-h-dvh pt-[3.75rem]'>{children}</main>;
 }
 
 export default PagesContainer;

--- a/src/pages/TempMobile.tsx
+++ b/src/pages/TempMobile.tsx
@@ -1,0 +1,49 @@
+import coneImage from '@/assets/images/cone.png';
+import Youtube from '@/assets/svg/footerYoutube.svg?react';
+import Github from '@/assets/svg/github.svg?react';
+import NewTabLink from '@/components/apply/NewTabLink';
+import Logo from '@/components/common/logo/Logo';
+import { JECT_EMAIL } from '@/constants/footer';
+
+function TempMobile() {
+  return (
+    <div className='relative'>
+      <header className='bg-surface-standard-dark border-border-assistive-dark border-b px-(--gap-md) py-(--gap-xs)'>
+        <Logo height={18} fillColor='fill-object-hero-dark' />
+      </header>
+      <div className='gap-2xl bg-surface-standard-dark flex min-h-dvh flex-col items-center justify-center *:-translate-y-[4.875rem]'>
+        <img src={coneImage} alt='물음표 이미지' className='w-[6rem]' />
+        <div className='gap-3xs flex flex-col text-center'>
+          <p className='title-02 text-object-hero-dark'>
+            젝트 웹사이트는 <br /> PC로 이용해주세요
+          </p>
+          <p className='label-sm text-object-neutral-dark'>
+            현재 모바일에서는 접근할 수 없어요. <br /> 불편함을 드려 죄송합니다.
+          </p>
+        </div>
+      </div>
+      <footer className='bg-surface-tinted-dark text-object-alternative-dark gap-md absolute bottom-0 left-0 flex h-[8.875rem] w-dvw flex-col p-(--gap-md)'>
+        <div>
+          <Logo height={16} fillColor='fill-object-normal-dark' />
+        </div>
+        <p className='body-2xs'>
+          젝트는 IT 사이드 프로젝트 동아리입니다.
+          <br /> 몰입하며 진행하는 즐거운 프로젝트를 지향하고 있어요.
+        </p>
+        <div className='flex items-center'>
+          <p className='body-2xs flex-1'>{JECT_EMAIL}</p>
+          <div className='flex h-[1.5rem] gap-[1.25rem]'>
+            <NewTabLink href='https://github.com/JECT-Study'>
+              <Github width={24} />
+            </NewTabLink>
+            <NewTabLink href='https://www.youtube.com/@ject_it_club'>
+              <Youtube height={24} />
+            </NewTabLink>
+          </div>
+        </div>
+      </footer>
+    </div>
+  );
+}
+
+export default TempMobile;

--- a/src/pages/TempMobile.tsx
+++ b/src/pages/TempMobile.tsx
@@ -11,7 +11,7 @@ function TempMobile() {
       <header className='bg-surface-standard-dark border-border-assistive-dark border-b px-(--gap-md) py-(--gap-xs)'>
         <Logo height={18} fillColor='fill-object-hero-dark' />
       </header>
-      <div className='gap-2xl bg-surface-standard-dark flex min-h-dvh flex-col items-center justify-center *:-translate-y-[4.875rem]'>
+      <div className='gap-2xl bg-surface-standard-dark flex min-h-dvh flex-col items-center justify-center'>
         <img src={coneImage} alt='물음표 이미지' className='w-[6rem]' />
         <div className='gap-3xs flex flex-col text-center'>
           <p className='title-02 text-object-hero-dark'>
@@ -22,26 +22,28 @@ function TempMobile() {
           </p>
         </div>
       </div>
-      <footer className='bg-surface-tinted-dark text-object-alternative-dark gap-md absolute bottom-0 left-0 flex h-[8.875rem] w-dvw flex-col p-(--gap-md)'>
-        <div>
-          <Logo height={16} fillColor='fill-object-normal-dark' />
-        </div>
-        <p className='body-2xs'>
-          젝트는 IT 사이드 프로젝트 동아리입니다.
-          <br /> 몰입하며 진행하는 즐거운 프로젝트를 지향하고 있어요.
-        </p>
-        <div className='flex items-center'>
-          <p className='body-2xs flex-1'>{JECT_EMAIL}</p>
-          <div className='flex h-[1.5rem] gap-[1.25rem]'>
-            <NewTabLink href='https://github.com/JECT-Study'>
-              <Github width={24} />
-            </NewTabLink>
-            <NewTabLink href='https://www.youtube.com/@ject_it_club'>
-              <Youtube height={24} />
-            </NewTabLink>
+      <div className='bg-surface-standard-dark'>
+        <footer className='bg-surface-tinted-dark text-object-alternative-dark gap-md flex min-h-[8.875rem] flex-col p-(--gap-md)'>
+          <div>
+            <Logo height={16} fillColor='fill-object-normal-dark' />
           </div>
-        </div>
-      </footer>
+          <p className='body-2xs'>
+            젝트는 IT 사이드 프로젝트 동아리입니다.
+            <br /> 몰입하며 진행하는 즐거운 프로젝트를 지향하고 있어요.
+          </p>
+          <div className='flex items-center'>
+            <p className='body-2xs flex-1'>{JECT_EMAIL}</p>
+            <div className='flex h-[1.5rem] gap-[1.25rem]'>
+              <NewTabLink href='https://github.com/JECT-Study'>
+                <Github width={24} />
+              </NewTabLink>
+              <NewTabLink href='https://www.youtube.com/@ject_it_club'>
+                <Youtube height={24} />
+              </NewTabLink>
+            </div>
+          </div>
+        </footer>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] 헤더 border bottom 추가 
- [x] 푸터 잘못 들어간 배경 색상 수정
- [x] 모바일 UI 구현 및 모바일 사이즈일 경우 적용

## 💡 자세한 설명

### 1️⃣ 모바일 UI
보통 모바일 기기라고 판단하는 768px 기준으로 모바일 UI가 보여지도록 했습니다.

![2025-04-17 17;39;28](https://github.com/user-attachments/assets/e28427e6-36d7-4396-b7f8-74eab164612d)

추가로 헤더에 UI 추가된 border 스타일과 푸터에 잘못들어가있던 색상 값을 변경했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #170 
