### PR TITLE
bug: 토큰 재발급 후 기존 api 호출이 수행되지 않는 문제 해결

### DIFF
--- a/src/apis/auth.ts
+++ b/src/apis/auth.ts
@@ -10,6 +10,11 @@ const BASE_URL = import.meta.env.PROD
 
 export const refreshAccessToken = async (): Promise<ApiResponse<RefreshTokenResponse>> => {
   return await axios
-    .post<ApiResponse<RefreshTokenResponse>>(`${BASE_URL}${API_ENDPOINT.refreshToken}`)
+    .post<ApiResponse<RefreshTokenResponse>>(`${BASE_URL}${API_ENDPOINT.refreshToken}`, null, {
+      withCredentials: true,
+      headers: {
+        'Content-Type': 'application/json',
+      },
+    })
     .then(response => response.data);
 };

--- a/src/utils/interceptor.ts
+++ b/src/utils/interceptor.ts
@@ -37,7 +37,7 @@ export const createClient = (config?: AxiosRequestConfig): AxiosInstance => {
           try {
             const refreshResponse = await refreshAccessToken();
 
-            if (refreshResponse.status === 'SUCCESS' && refreshResponse.data) {
+            if (refreshResponse.status === 'SUCCESS') {
               return instance(originalRequest);
             }
           } catch (refreshError) {

--- a/src/utils/interceptor.ts
+++ b/src/utils/interceptor.ts
@@ -37,7 +37,7 @@ export const createClient = (config?: AxiosRequestConfig): AxiosInstance => {
           try {
             const refreshResponse = await refreshAccessToken();
 
-            if (refreshResponse.status === 'SUCCESS') {
+            if (refreshResponse.status === 'SUCCESS' && refreshResponse.data) {
               return instance(originalRequest);
             }
           } catch (refreshError) {


### PR DESCRIPTION
## 💡 작업 내용

- [x] interceptor에서 토큰 재발급 요청 후 기존 api를 재시도하지 않는 문제 해결

## 💡 자세한 설명

### ✅ 문제

```typescript
    try {
      const refreshResponse = await refreshAccessToken();

      if (refreshResponse.status === 'SUCCESS' && refreshResponse.data) {
        return instance(originalRequest);
      }
```
에서  `refreshAccessToken()` 만 수행되고 이후 기존 요청 재요청이 수행되지 않는 문제를 발견했습니다.

### ✅ 해결

(thanks to. 채연님)

```typescript
  export const refreshAccessToken = async (): Promise<ApiResponse<RefreshTokenResponse>> => {
    return await axios
      .post<ApiResponse<RefreshTokenResponse>>(`${BASE_URL}${API_ENDPOINT.refreshToken}`)
      .then(response => response.data);
  };
```
에서 기본 axios 호출인데 쿠키 기반 인증에서 필수적으로 기입해야 하는 `withCredentials: true` 와 `Content-Type` Header 가 누락되어 있었습니다!!!

```typescirpt
export const refreshAccessToken = async (): Promise<ApiResponse<RefreshTokenResponse>> => {
  return await axios
    .post<ApiResponse<RefreshTokenResponse>>(`${BASE_URL}${API_ENDPOINT.refreshToken}`, null, {
      withCredentials: true,
      headers: {
        'Content-Type': 'application/json',
      },
    })
    .then(response => response.data);
};
```
와 같이 요구되는 파라미터를 기입하여 refresh가 잘 처리됨을 확인할 수 있었습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #180 
