### PR TITLE
refactor: 점검 시간 기준을 KST으로 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "axios": "^1.8.1",
         "clsx": "^2.1.1",
         "crypto-js": "^4.2.0",
+        "date-fns-tz": "^3.2.0",
         "gsap": "^3.12.7",
         "lottie-react": "^2.4.1",
         "react": "^18.3.1",
@@ -4422,6 +4423,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/date-fns-tz": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/date-fns-tz/-/date-fns-tz-3.2.0.tgz",
+      "integrity": "sha512-sg8HqoTEulcbbbVXeg84u5UnlsQa8GS5QXMqjjYIhS4abEVVKIUwe0/l/UhrZdKaL/W5eWZNlbTeEIiOXTcsBQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "date-fns": "^3.0.0 || ^4.0.0"
       }
     },
     "node_modules/debug": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "axios": "^1.8.1",
     "clsx": "^2.1.1",
     "crypto-js": "^4.2.0",
+    "date-fns-tz": "^3.2.0",
     "gsap": "^3.12.7",
     "lottie-react": "^2.4.1",
     "react": "^18.3.1",

--- a/src/hooks/useRedirectMaintenance.ts
+++ b/src/hooks/useRedirectMaintenance.ts
@@ -14,7 +14,7 @@ const useRedirectMaintenance = (startHours: number, endHours: number, redirectPa
     const checkAndRedirect = () => {
       const now = new Date();
       const kstDate = toZonedTime(now, 'Asia/Seoul');
-      const nextTime = new Date(kstDate);
+      const nextKstTime = new Date(kstDate);
       const hours = kstDate.getHours();
       const isInMaintenance = hours >= startHours && hours < endHours;
       const isOnMaintenancePage = location.pathname === redirectPath;
@@ -32,15 +32,15 @@ const useRedirectMaintenance = (startHours: number, endHours: number, redirectPa
       }
 
       if (hours < startHours) {
-        nextTime.setHours(startHours, 0, 0, 0);
+        nextKstTime.setHours(startHours, 0, 0, 0);
       } else if (hours >= endHours) {
-        nextTime.setDate(nextTime.getDate() + 1);
-        nextTime.setHours(startHours, 0, 0, 0);
+        nextKstTime.setDate(nextKstTime.getDate() + 1);
+        nextKstTime.setHours(startHours, 0, 0, 0);
       } else {
-        nextTime.setHours(endHours, 0, 0, 0);
+        nextKstTime.setHours(endHours, 0, 0, 0);
       }
 
-      const delay = nextTime.getTime() - kstDate.getTime();
+      const delay = nextKstTime.getTime() - kstDate.getTime();
 
       const timerTime = TIME_THRESHOLD < delay ? delay - TIME_THRESHOLD : delay;
 

--- a/src/hooks/useRedirectMaintenance.ts
+++ b/src/hooks/useRedirectMaintenance.ts
@@ -1,3 +1,4 @@
+import { toZonedTime } from 'date-fns-tz';
 import { useEffect, useRef } from 'react';
 
 import { PATH } from '@/constants/path';
@@ -12,8 +13,9 @@ const useRedirectMaintenance = (startHours: number, endHours: number, redirectPa
   useEffect(() => {
     const checkAndRedirect = () => {
       const now = new Date();
-      const nextTime = new Date(now);
-      const hours = now.getHours();
+      const kstDate = toZonedTime(now, 'Asia/Seoul');
+      const nextTime = new Date(kstDate);
+      const hours = kstDate.getHours();
       const isInMaintenance = hours >= startHours && hours < endHours;
       const isOnMaintenancePage = location.pathname === redirectPath;
 
@@ -38,7 +40,7 @@ const useRedirectMaintenance = (startHours: number, endHours: number, redirectPa
         nextTime.setHours(endHours, 0, 0, 0);
       }
 
-      const delay = nextTime.getTime() - now.getTime();
+      const delay = nextTime.getTime() - kstDate.getTime();
 
       const timerTime = TIME_THRESHOLD < delay ? delay - TIME_THRESHOLD : delay;
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] `date-fns-tz` 라이브러리 설치 
- [x] 점검 시간 계산 기준을 `Asia/Seoul` 타임존 기준으로 수정

## 💡 자세한 설명

`date-fns-tz` 라이브러리를 선택한 이유는 다음과 같습니다. 
- 가벼운 크기 
- 타임존 처리만 필요한 경우이기 때문

```ts
      const now = new Date();
      const kstDate = toZonedTime(now, 'Asia/Seoul');
      const nextTime = new Date(kstDate);
```
`toZonedTime` 메서드 사용하여 점검 시간을 계산하기 전에 한국을 기준으로 계산되도록 수정했습니다. 
이미 로컬 시간이 한국인 경우에도 잘 적용됨 확인하였습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #196 
