### PR TITLE
chore: seo 개선 작업

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,13 +3,39 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="robots" content="index, follow" />
+    <meta
+      name="keywords"
+      content="IT 사이드 프로젝트 동아리,협업,프론트엔드 개발자,백엔드 개발자,프로덕트 매니저(PM),프로덕트 디자이너"
+    />
+
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
+
     <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.1-min.js.gz"></script>
     <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.8.0-min.js.gz"></script>
-    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('457f8eb444034cfcdc61d49a23168db9', {"autocapture":{"elementInteractions":true}});</script>
-    <title>JECT</title>
+    <script>
+      window.amplitude.add(window.sessionReplay.plugin({ sampleRate: 1 }));
+      window.amplitude.init('457f8eb444034cfcdc61d49a23168db9', {
+        autocapture: { elementInteractions: true },
+      });
+    </script>
+
+    <title>젝트</title>
+    <meta
+      name="description"
+      content="젝트(JECT)는 다양한 포지션 멤버들과 협업할 수 있는 IT 사이드 프로젝트 동아리예요. 홈페이지에서 더 자세한 내용을 확인해보세요!"
+    />
+
+    <!--Open Graph-->
+    <meta property="og:type" content="website" />
+    <meta property="og:title" content="젝트" />
+    <meta
+      property="og:description"
+      content="젝트(JECT)는 다양한 포지션 멤버들과 협업할 수 있는 IT 사이드 프로젝트 동아리예요. 홈페이지에서 더 자세한 내용을 확인해보세요!"
+    />
+    <meta property="og:url" content="https://ject.kr/" />
   </head>
   <body>
     <div id="root"></div>

--- a/index.html
+++ b/index.html
@@ -15,12 +15,6 @@
 
     <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.1-min.js.gz"></script>
     <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.8.0-min.js.gz"></script>
-    <script>
-      window.amplitude.add(window.sessionReplay.plugin({ sampleRate: 1 }));
-      window.amplitude.init('457f8eb444034cfcdc61d49a23168db9', {
-        autocapture: { elementInteractions: true },
-      });
-    </script>
 
     <title>젝트</title>
     <meta

--- a/public/naver3ccdef7b530e1d116875864d53670f69.html
+++ b/public/naver3ccdef7b530e1d116875864d53670f69.html
@@ -1,0 +1,1 @@
+naver-site-verification: naver3ccdef7b530e1d116875864d53670f69.html

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,8 @@
+User-agent: *
+Allow: /
+Disallow: /admin
+Disallow: /admin/
+Disallow: /maintenance
+Disallow: /service-unavailable
+Disallow: /not-found
+Sitemap: https://ject.kr/sitemap.xml

--- a/public/sitemap.xml
+++ b/public/sitemap.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://ject.kr/</loc>
+    <priority>1.0</priority>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
+    <loc>https://ject.kr/project</loc>
+    <priority>0.8</priority>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
+    <loc>https://ject.kr/activity</loc>
+    <priority>0.7</priority>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
+    <loc>https://ject.kr/apply</loc>
+    <priority>0.7</priority>
+    <changefreq>weekly</changefreq>
+  </url>
+  <url>
+    <loc>https://ject.kr/faq</loc>
+    <priority>0.5</priority>
+    <changefreq>monthly</changefreq>
+  </url>
+</urlset>


### PR DESCRIPTION
## 💡 작업 내용

- [x] 네이버 사이트 소유 확인 html 문서 추가
- [x] robots.txt 추가
- [x] sitemap.xml 추가 
- [x] seo 메타 태그 추가

## 💡 자세한 설명

### 1️⃣ 네이버 사이트 소유 확인 html 문서 추가

네이버 서치 어드바이저에 사이트를 등록하고 소유 확인을 위한 html 문서를 추가했습니다. 

### 2️⃣ robots.txt

에러 페이지(점검 페이지 포함)와 어드민 페이지는 제외한 페이지에 접근하도록 설정했습니다.

### 3️⃣ sitemap.xml

사이트맵은 웹사이트의 구조를 검색 엔진과 사용자에게 알려주는 파일로, 웹사이트의 페이지를 검색 엔진이 쉽게 찾고 크롤링할 수 있도록 돕습니다. 네비게이션으로 접근할 수 있는 페이지로 설정해두었습니다. 

원래는 https://www.xml-sitemaps.com/ 사이트를 통해서 자동 생성하려고 했는데 해당 사이트에서 점검페이지만 크롤링하는 것 같아서 수동으로 작성해두었습니다..! 왜 점검페이지만 나오는지는 원인을 좀 더 알아봐야할 것 같습니다 🤔

### 4️⃣ seo 메타 태그 추가

기본적인 메타 태그들만 추가해두었습니다
title이 `JECT` -> `젝트` 로 수정되었습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #148 
