### PR TITLE
chore: gtm 이벤트 트래킹을 위한 전역 설정

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,15 +3,38 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- Google Tag Manager -->
+    <script>
+      (function(w,d,s,l,i){
+        w[l]=w[l]||[]; w[l].push({'gtm.start': new Date().getTime(), event:'gtm.js'});
+        var f=d.getElementsByTagName(s)[0],
+          j=d.createElement(s), dl=l!='dataLayer'?'&l='+l:'';
+        j.async=true; j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
+        f.parentNode.insertBefore(j,f);
+      })(window,document,'script','dataLayer','GTM-TMPMTHJ3');
+    </script>
+    <!-- End Google Tag Manager -->
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
     <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.1-min.js.gz"></script>
     <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.8.0-min.js.gz"></script>
-    <script>window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));window.amplitude.init('457f8eb444034cfcdc61d49a23168db9', {"autocapture":{"elementInteractions":true}});</script>
+    <script>
+      window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));
+      window.amplitude.init('457f8eb444034cfcdc61d49a23168db9', {"autocapture":{"elementInteractions":true}});
+    </script>
     <title>JECT</title>
   </head>
   <body>
+  <!-- Google Tag Manager (noscript) -->
+  <noscript>
+    <iframe
+      src="https://www.googletagmanager.com/ns.html?id=GTM-TMPMTHJ3"
+      height="0" width="0"
+      style="display:none;visibility:hidden"
+    ></iframe>
+  </noscript>
+  <!-- End Google Tag Manager (noscript) -->
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/index.html
+++ b/index.html
@@ -21,7 +21,15 @@
     <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.8.0-min.js.gz"></script>
     <script>
       window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));
-      window.amplitude.init('457f8eb444034cfcdc61d49a23168db9', {"autocapture":{"elementInteractions":true}});
+      window.amplitude.init(
+        '457f8eb444034cfcdc61d49a23168db9',
+        null,
+        {
+          autocapture: { elementInteractions: true },
+          includeUtm: true,
+          includeReferrer: true
+        }
+      );
     </script>
     <title>JECT</title>
   </head>

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       (function(w,d,s,l,i){
         w[l]=w[l]||[]; w[l].push({'gtm.start': new Date().getTime(), event:'gtm.js'});
         var f=d.getElementsByTagName(s)[0],
-          j=d.createElement(s), dl=l!=='dataLayer'?'&l='+l:'';
+          j=d.createElement(s), dl=l!='dataLayer'?'&l='+l:'';
         j.async=true; j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
         f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','GTM-TMPMTHJ3');

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
       (function(w,d,s,l,i){
         w[l]=w[l]||[]; w[l].push({'gtm.start': new Date().getTime(), event:'gtm.js'});
         var f=d.getElementsByTagName(s)[0],
-          j=d.createElement(s), dl=l!='dataLayer'?'&l='+l:'';
+          j=d.createElement(s), dl=l!=='dataLayer'?'&l='+l:'';
         j.async=true; j.src='https://www.googletagmanager.com/gtm.js?id='+i+dl;
         f.parentNode.insertBefore(j,f);
       })(window,document,'script','dataLayer','GTM-TMPMTHJ3');

--- a/index.html
+++ b/index.html
@@ -17,20 +17,6 @@
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png" />
     <link rel="icon" type="image/png" sizes="32x32" href="/favicon-32x32.png" />
     <link rel="icon" type="image/png" sizes="16x16" href="/favicon-16x16.png" />
-    <script src="https://cdn.amplitude.com/libs/analytics-browser-2.11.1-min.js.gz"></script>
-    <script src="https://cdn.amplitude.com/libs/plugin-session-replay-browser-1.8.0-min.js.gz"></script>
-    <script>
-      window.amplitude.add(window.sessionReplay.plugin({sampleRate: 1}));
-      window.amplitude.init(
-        '457f8eb444034cfcdc61d49a23168db9',
-        null,
-        {
-          autocapture: { elementInteractions: true },
-          includeUtm: true,
-          includeReferrer: true
-        }
-      );
-    </script>
     <title>JECT</title>
   </head>
   <body>

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "ject-official-website-client",
       "version": "0.0.0",
       "dependencies": {
+        "@amplitude/analytics-browser": "^2.17.2",
+        "@amplitude/plugin-session-replay-browser": "^1.16.4",
         "@hookform/resolvers": "^4.1.3",
         "@sentry/react": "^9.12.0",
         "@sentry/vite-plugin": "^3.3.1",
@@ -68,6 +70,220 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.1.tgz",
       "integrity": "sha512-12WGKBQzjUAI4ayyF4IAtfw2QR/IDoqk6jTddXDhtYTJF9ASmoE1zst7cVtP0aL/F1jUJL5r+JxKXKEgHNbEUQ==",
       "dev": true
+    },
+    "node_modules/@amplitude/analytics-browser": {
+      "version": "2.17.2",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.17.2.tgz",
+      "integrity": "sha512-RE+JFvmBlHtu4W1rXpiEH1uPvt4XgZFcYBRrfwSrWMceXjdgxxd6871YI4FnJ7D9rA9dhKyqQUsEzfDb9zXpnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "^2.11.1",
+        "@amplitude/analytics-remote-config": "^0.4.0",
+        "@amplitude/plugin-autocapture-browser": "^1.2.2",
+        "@amplitude/plugin-network-capture-browser": "^1.1.2",
+        "@amplitude/plugin-page-view-tracking-browser": "^2.3.23",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/analytics-client-common": {
+      "version": "2.3.19",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.3.19.tgz",
+      "integrity": "sha512-/kg34UOLfjar/ZHIj17yturNDKIUubfDcYXVAG44DMiyfZxKN3DVdM3y2s1qYqjo/FwJg4jS7ImacF1XIrbS2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-connector": "^1.4.8",
+        "@amplitude/analytics-core": "^2.11.1",
+        "@amplitude/analytics-types": "^2.9.2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/analytics-connector": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.6.4.tgz",
+      "integrity": "sha512-SpIv0IQMNIq6SH3UqFGiaZyGSc7PBZwRdq7lvP0pBxW8i4Ny+8zwI0pV+VMfMHQwWY3wdIbWw5WQphNjpdq1/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@amplitude/analytics-core": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.11.1.tgz",
+      "integrity": "sha512-2LLnGcnMihsqV7lmOE/+vxhyowcRsp9dMpPgys83yl6aqEAVIozGr9aAcVmYEJGeUMGuIVeVqed7pdPeBKAqYw==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-connector": "^1.6.4",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/analytics-remote-config": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-remote-config/-/analytics-remote-config-0.4.1.tgz",
+      "integrity": "sha512-BYl6kQ9qjztrCACsugpxO+foLaQIC0aSEzoXEAb/gwOzInmqkyyI+Ub+aWTBih4xgB/lhWlOcidWHAmNiTJTNw==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-client-common": ">=1 <3",
+        "@amplitude/analytics-core": ">=1 <3",
+        "@amplitude/analytics-types": ">=1 <3",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/analytics-types": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.9.2.tgz",
+      "integrity": "sha512-juhTz396dDP/jLJYP9zDOEAZBtJM0JVvP8G10p1OxUDBVwVIprpQL598F9GRQwVFyqV4CEhDmNyAY0HqqU5bhA==",
+      "license": "MIT"
+    },
+    "node_modules/@amplitude/plugin-autocapture-browser": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-autocapture-browser/-/plugin-autocapture-browser-1.2.2.tgz",
+      "integrity": "sha512-aZ2ZhLLaC6A6Gd8vKnSUBAE2j4cXVruSdwhetDIbJq4aVhBDxfhcI1yKCBYmYZtehxa2Fm8mQhQuD/8JGRiWvg==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "^2.11.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/plugin-network-capture-browser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-network-capture-browser/-/plugin-network-capture-browser-1.1.2.tgz",
+      "integrity": "sha512-2lJtxQBvhLuoeKkCTUDzm1zGetmAHfeynPwB9gG8BVKmg46tnoqYdIMrd6lZeAFZsMtwL3Vez3zfKZJB3lyQMg==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "^2.11.1",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/plugin-page-view-tracking-browser": {
+      "version": "2.3.23",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.3.23.tgz",
+      "integrity": "sha512-gpxFIbYKPXceUSSg+S7G6RpsHcQqlcjXJ5bArQKn5zfonyJVmyne+PL5c6vMZbpB/09Ri7ko/jfQ0rnfgz9HOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-client-common": "^2.3.19",
+        "@amplitude/analytics-types": "^2.9.2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/plugin-session-replay-browser": {
+      "version": "1.16.4",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-session-replay-browser/-/plugin-session-replay-browser-1.16.4.tgz",
+      "integrity": "sha512-iSxi29a0zcATih/7MGEIO2V/Y/QMkc887NA9vlggw+RKiR2qxAVbidokK3vezC5i4NSr0C2kxgXmfulsI/WTkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "^2.11.1",
+        "@amplitude/session-replay-browser": "^1.22.2",
+        "idb-keyval": "^6.2.1",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/rrdom": {
+      "version": "2.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@amplitude/rrdom/-/rrdom-2.0.0-alpha.29.tgz",
+      "integrity": "sha512-g1YCIor5iCAxTcHxikLHj0KdW1Rt6tKXzzYSR0IQTw/wcNERxRseILRq6LppSTcFN0q6CyWHUtNrWA2Eh2XmkQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/rrweb-snapshot": "^2.0.0-alpha.29"
+      }
+    },
+    "node_modules/@amplitude/rrweb": {
+      "version": "2.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@amplitude/rrweb/-/rrweb-2.0.0-alpha.29.tgz",
+      "integrity": "sha512-UZgo7Y+5RpNdplIRzqc7WJXn0jgqpx6/hjW3vxr1QACJQPgL25zIfrO7FUe9SBOodOsG42bgv9DHEVEwCOC8Bg==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/rrdom": "^2.0.0-alpha.29",
+        "@amplitude/rrweb-snapshot": "^2.0.0-alpha.29",
+        "@amplitude/rrweb-types": "^2.0.0-alpha.29",
+        "@amplitude/rrweb-utils": "^2.0.0-alpha.29",
+        "@types/css-font-loading-module": "0.0.7",
+        "@xstate/fsm": "^1.4.0",
+        "base64-arraybuffer": "^1.0.1",
+        "mitt": "^3.0.0"
+      }
+    },
+    "node_modules/@amplitude/rrweb-packer": {
+      "version": "2.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@amplitude/rrweb-packer/-/rrweb-packer-2.0.0-alpha.29.tgz",
+      "integrity": "sha512-OzxD2iyZ7f0XBQsBPeRzUSg2yGSNM1fihY6NgS6caagwmi/BN9F8e10dMe0/4Ykob6T/TGMJ91RDFeVv3Wpo6A==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/rrweb-types": "^2.0.0-alpha.29",
+        "fflate": "^0.4.4"
+      }
+    },
+    "node_modules/@amplitude/rrweb-plugin-console-record": {
+      "version": "2.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@amplitude/rrweb-plugin-console-record/-/rrweb-plugin-console-record-2.0.0-alpha.29.tgz",
+      "integrity": "sha512-PnbPpdyxRoS9VU7GZ0vH82QWysBJ63fp2KbmaoA6XC4OK/fg7i2woHCAhdDUa0Q3aCzf6iOVcEOcfhn1JnJf0A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@amplitude/rrweb": "^2.0.0-alpha.29"
+      }
+    },
+    "node_modules/@amplitude/rrweb-snapshot": {
+      "version": "2.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@amplitude/rrweb-snapshot/-/rrweb-snapshot-2.0.0-alpha.29.tgz",
+      "integrity": "sha512-V8ff1MyUUFMcj1ckqXtiQluM4fjQVJMWeWjZ2kIDfx26cCHBrKnQ19VpBjundjU+ViwI5ckATlfWxix7281fAg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss": "^8.4.38"
+      }
+    },
+    "node_modules/@amplitude/rrweb-types": {
+      "version": "2.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@amplitude/rrweb-types/-/rrweb-types-2.0.0-alpha.29.tgz",
+      "integrity": "sha512-dhHKBFvXFEA97x34xp3ZDXFbJR0+yza9UdEckrU99uWtp/7oOwD6nJPynu2AqcCSVfoAsMol3idYw941FQAXCQ==",
+      "license": "MIT"
+    },
+    "node_modules/@amplitude/rrweb-utils": {
+      "version": "2.0.0-alpha.29",
+      "resolved": "https://registry.npmjs.org/@amplitude/rrweb-utils/-/rrweb-utils-2.0.0-alpha.29.tgz",
+      "integrity": "sha512-0DV25KDlA3pQjRZGIgaDAoUsY6PjaGufZrpOF9rCv3r6yn8yFcckAxCVz0blNwgI1w0COyaiytaT1UEhT3bK7A==",
+      "license": "MIT"
+    },
+    "node_modules/@amplitude/session-replay-browser": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/@amplitude/session-replay-browser/-/session-replay-browser-1.22.2.tgz",
+      "integrity": "sha512-QcvsN9k2zhP9zZXlY4/YaKDCsxlN5Dd/gKOJ+I9HVtKVtF+/RV6eptNIOjIkVO9gANlj0s/td6T42wxibZ68ig==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": "^2.11.1",
+        "@amplitude/analytics-remote-config": "^0.6.2",
+        "@amplitude/rrweb": "2.0.0-alpha.29",
+        "@amplitude/rrweb-packer": "2.0.0-alpha.29",
+        "@amplitude/rrweb-plugin-console-record": "2.0.0-alpha.29",
+        "@amplitude/rrweb-snapshot": "2.0.0-alpha.29",
+        "@rollup/plugin-replace": "^6.0.1",
+        "idb": "8.0.0",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/session-replay-browser/node_modules/@amplitude/analytics-remote-config": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-remote-config/-/analytics-remote-config-0.6.2.tgz",
+      "integrity": "sha512-TsJ8u/R1Yi+Q+pEb4xi3Y5C2V4+1zHS0BjmbpS94fnCG7mkSIKp4O4c23rQlyBGyCddrYZbWnZnMdKSUmFKpcA==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-core": ">=1 <2",
+        "@amplitude/analytics-types": ">=1 <2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/session-replay-browser/node_modules/@amplitude/analytics-remote-config/node_modules/@amplitude/analytics-core": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-1.2.7.tgz",
+      "integrity": "sha512-SM9jdQ+l2q+hy+DdCQm5vtfOTiI+53c+alSSc7fwiuFnTExllXHf9RUK6kKhw3ky+N2o6yqbo+0OGoepLhNf6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@amplitude/analytics-types": "^1.3.5",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/session-replay-browser/node_modules/@amplitude/analytics-types": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-1.3.5.tgz",
+      "integrity": "sha512-IpncCNTZZ6VoGe4fNwTTZtpi+ZNm3mtsocdbCHtIwmKg2wmOF2E09CAwvyF7mK5aRlMIrSAKQyR3GwraATghSw==",
+      "license": "MIT"
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -1262,11 +1478,31 @@
         "node": ">=14"
       }
     },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-6.0.2.tgz",
+      "integrity": "sha512-7QaYCf8bqF04dOy7w/eHmJeNExxTYwvKAmlSAH/EaWWUzbT0h5sbF6bktFoX/0F/0qwng5/dWFMyf3gzaM8DsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@rollup/pluginutils": "^5.0.1",
+        "magic-string": "^0.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "5.1.4",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.1.4.tgz",
       "integrity": "sha512-USm05zrsFxYLPdWWq+K3STlWiT/3ELn3RcV5hJMghpeAIhxfsUIg6mt12CBJBInWMV4VneoV7SfGv8xIwo2qNQ==",
-      "dev": true,
       "dependencies": {
         "@types/estree": "^1.0.0",
         "estree-walker": "^2.0.2",
@@ -1288,7 +1524,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
       "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
-      "dev": true,
       "engines": {
         "node": ">=12"
       },
@@ -3114,6 +3349,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/css-font-loading-module": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "license": "MIT"
+    },
     "node_modules/@types/doctrine": {
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/@types/doctrine/-/doctrine-0.0.9.tgz",
@@ -3530,6 +3771,12 @@
         "url": "https://opencollective.com/vitest"
       }
     },
+    "node_modules/@xstate/fsm": {
+      "version": "1.6.5",
+      "resolved": "https://registry.npmjs.org/@xstate/fsm/-/fsm-1.6.5.tgz",
+      "integrity": "sha512-b5o1I6aLNeYlU/3CPlj/Z91ybk1gUsKT+5NAJI+2W4UjvS5KLG28K9v5UvNoFVjHV8PajVZ00RH3vnjyQO7ZAw==",
+      "license": "MIT"
+    },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@yarnpkg/lockfile/-/lockfile-1.1.0.tgz",
@@ -3863,6 +4110,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/base64-arraybuffer": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/base64-arraybuffer/-/base64-arraybuffer-1.0.2.tgz",
+      "integrity": "sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6.0"
+      }
     },
     "node_modules/base64-js": {
       "version": "1.5.1",
@@ -5199,8 +5455,7 @@
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
-      "dev": true
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
     },
     "node_modules/esutils": {
       "version": "2.0.3",
@@ -5282,6 +5537,12 @@
       "dependencies": {
         "reusify": "^1.0.4"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
@@ -5814,6 +6075,18 @@
       "engines": {
         "node": ">=10.18"
       }
+    },
+    "node_modules/idb": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-8.0.0.tgz",
+      "integrity": "sha512-l//qvlAKGmQO31Qn7xdzagVPPaHTxXx199MhrAFuVBTPqydcPYBWjkrbv4Y0ktB+GmWOiwHl237UUOrLmQxLvw==",
+      "license": "ISC"
+    },
+    "node_modules/idb-keyval": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/idb-keyval/-/idb-keyval-6.2.1.tgz",
+      "integrity": "sha512-8Sb3veuYCyrZL+VBt9LJfZjLUPWVvqn8tG28VqYNFCo43KHcKuq+b4EiXGeuaLAQWL2YmyDgMp2aSpH9JHsEQg==",
+      "license": "Apache-2.0"
     },
     "node_modules/ieee754": {
       "version": "1.2.1",
@@ -6905,7 +7178,6 @@
       "version": "0.30.17",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
       "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/sourcemap-codec": "^1.5.0"
       }
@@ -7039,6 +7311,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -8198,6 +8476,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
+      "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.3.tgz",
@@ -8958,7 +9245,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/turbo-stream": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "chromatic": "npx chromatic --project-token=$CHROMATIC_TOKEN"
   },
   "dependencies": {
+    "@amplitude/analytics-browser": "^2.17.2",
+    "@amplitude/plugin-session-replay-browser": "^1.16.4",
     "@hookform/resolvers": "^4.1.3",
     "@sentry/react": "^9.12.0",
     "@sentry/vite-plugin": "^3.3.1",

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,5 +1,6 @@
 import './instrument';
-
+import * as amplitude from '@amplitude/analytics-browser';
+import { sessionReplayPlugin } from '@amplitude/plugin-session-replay-browser';
 import { gsap } from 'gsap';
 import { ScrollToPlugin } from 'gsap/ScrollToPlugin';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
@@ -11,6 +12,12 @@ import '@/styles/global.css';
 import App from './App';
 
 gsap.registerPlugin(ScrollTrigger, ScrollToPlugin);
+
+amplitude.init(import.meta.env.VITE_AMPLITUDE_API_KEY, undefined, {
+  autocapture: { elementInteractions: true },
+});
+
+amplitude.add(sessionReplayPlugin({ sampleRate: 1 }));
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/vite-env.d.ts
+++ b/vite-env.d.ts
@@ -9,6 +9,7 @@ interface ImportMetaEnv {
   readonly VITE_SENTRY_PROJECT: string;
   readonly VITE_SENTRY_AUTH_TOKEN: string;
   readonly VITE_SECRET_KEY: string;
+  readonly VITE_AMPLITUDE_API_KEY: string;
   readonly DEV: boolean;
   readonly PROD: boolean;
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] gtm 트래킹 전역 코드 추가

## 💡 자세한 설명
(수동으로 트래킹 훅을 짜기 위해 feat 브랜치로 열었는데, 전역 설정 후 gtm 내부에서 설정을 추가하는 방향성으로 변경 되었습니다. chore 브랜치라고 생각해주셔도 좋아요!) 

### ✅ 전역 환경 설정 (index.html)
- 현재 요구되는 지원 페이지, 랜딩 페이지에 대한 이벤트 트래킹은 단순 페이지 유입 경로 트래킹 용도로 사용될 예정입니다. 따라 context api나 [gtm 관련 라이브러리](https://www.npmjs.com/package/react-gtm-module) 를 사용하기 보다 index.html에 단순 주입후 **GTM 관리 화면에서 추가 설정을 제어하는 방향**으로 방향성을 선회하였습니다.

### ✅ Amplitude 초기화 설정 변경
- 기존 index.html 에 스크립트 형태로 선언한 amplitude의 경우 amplitude 키가 직접 노출되어있는 문제가 있었습니다. 따라서 Main.tsx 에 gsap, sentry를 초기화한 것과 동일한 방식으로 Amplitude를 초기화하였습니다.
```typescript
amplitude.init(import.meta.env.VITE_AMPLITUDE_API_KEY, undefined, {
  autocapture: { elementInteractions: true },
});

amplitude.add(sessionReplayPlugin({ sampleRate: 1 }));
```
undefined 위치에는 userId를 입력하는 부분인데, 저희 웹사이트 특성상 특정한 유저를 트래킹할 필요가 없기 때문에 해당 값은 undefined로 처리하였습니다. 이외의 설정은 기존 스크립트와 동일합니다.

### ✅ 발견한 문제
- 스크립트 내부 gtm 설정 값에서 
```typescript
          j=d.createElement(s), dl=l!='dataLayer'?'&l='+l:'';
```
로 되어있는 구문을 느슨 비교가 아닌 엄격 비교로 처리하게되면(Qodana 권고 사항) GTM 스크립트 URL에 &l=dataLayer 파라미터가 붙지 않아 gtm 이벤트 트래킹 자체가 되지 않던 문제가 있었습니다. (참고)

JECT 어드민 구글 계정으로 로그인 후 [gtm 태그](https://tagmanager.google.com/#/container/accounts/6291525697/containers/218048050/workspaces/2/tags) 를 확인하시면 정상적으로 이벤트가 트래킹 됨을 보실 수 있습니다 :)

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #205 
