### PR TITLE
feat: 지원 마감 UI 처리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import { isMobile } from 'react-device-detect';
 import { RouterProvider } from 'react-router-dom';
 
-import { PATH } from './constants/path';
+import { disabledPage, PATH } from './constants/path';
 import { useGlobalErrorHandler } from './hooks/useGlobalErrorHandler';
 import useRedirectMaintenance from './hooks/useRedirectMaintenance';
 import TempMobile from './pages/TempMobile';
@@ -31,6 +31,10 @@ function App() {
 
   if (isMobile) {
     return <TempMobile />;
+  }
+
+  if (disabledPage.includes(window.location.pathname)) {
+    return void router.navigate(PATH.apply);
   }
 
   return (

--- a/src/constants/path.ts
+++ b/src/constants/path.ts
@@ -13,3 +13,10 @@ export const PATH = {
   applyRegistration: '/apply/registration',
   applyComplete: '/apply/complete',
 } as const;
+
+export const disabledPage: string[] = [
+  PATH.applyVerify,
+  PATH.applicantInfo,
+  PATH.applyRegistration,
+  PATH.applyComplete,
+];

--- a/src/pages/Activity.tsx
+++ b/src/pages/Activity.tsx
@@ -1,8 +1,6 @@
-import ApplySnackBar from '@/components/apply/ApplySnackBar';
 import { Card } from '@/components/common/card/Card';
 import EmptyData from '@/components/common/emptyState/EmptyData';
 import Title from '@/components/common/title/Title';
-import { APPLY_SNACKBAR } from '@/constants/applyMessages';
 import useJectalks from '@/hooks/useJectalksQuery';
 import useMiniStudies from '@/hooks/useMiniStudiesQuery';
 
@@ -58,7 +56,6 @@ function Activity() {
           <EmptyData />
         )}
       </section>
-      <ApplySnackBar message={APPLY_SNACKBAR.default} width='w-[31.25rem]' />
     </div>
   );
 }

--- a/src/pages/Apply.tsx
+++ b/src/pages/Apply.tsx
@@ -1,5 +1,4 @@
 import { Fragment } from 'react/jsx-runtime';
-import { useNavigate } from 'react-router-dom';
 
 import BlockButton from '@/components/common/button/BlockButton';
 import Icon from '@/components/common/icon/Icon';
@@ -7,12 +6,10 @@ import ProgressItem from '@/components/common/progress/ProgressItem';
 import ProgressVerticalBridge from '@/components/common/progress/ProgressVerticalBridge';
 import Title from '@/components/common/title/Title';
 import { APPLY_TITLE, applyInfoList, applyProcedureList } from '@/constants/applyPageData';
-import { PATH } from '@/constants/path';
 
 function Apply() {
   // TODO: 개인정보 맟 이용 동의서, 회비 링크 걸기
   const currentDate = new Date();
-  const navigate = useNavigate();
 
   return (
     <div className='gap-12xl flex flex-col items-center py-(--gap-12xl)'>
@@ -56,14 +53,12 @@ function Apply() {
         </div>
       </section>
       <BlockButton
+        disabled
         size='lg'
         style='solid'
         hierarchy='accent'
-        rightIcon={
-          <Icon name='forward' size='md' fillColor='fill-object-static-inverse-hero-dark' />
-        }
+        rightIcon={<Icon name='forward' size='md' fillColor='fill-accent-trans-hero-dark' />}
         className='min-w-[26.25rem] cursor-pointer'
-        onClick={() => void navigate(PATH.applyVerify)}
       >
         젝트 3기 지원하기
       </BlockButton>

--- a/src/pages/Faq.tsx
+++ b/src/pages/Faq.tsx
@@ -1,8 +1,6 @@
-import ApplySnackBar from '@/components/apply/ApplySnackBar';
 import { Accordion } from '@/components/common/accordion/Accordion';
 import { Tab, TabHeader, TabItem, TabPanel } from '@/components/common/tab/Tab';
 import Title from '@/components/common/title/Title';
-import { APPLY_SNACKBAR } from '@/constants/applyMessages';
 import { faqActivity, faqApply, faqJect, faqProject } from '@/constants/faqPageData';
 import { useFaqNavigation } from '@/hooks/useFaqNavigation';
 
@@ -80,7 +78,6 @@ function Faq() {
           </Tab>
         </section>
       </div>
-      <ApplySnackBar message={APPLY_SNACKBAR.default} width='w-[31.25rem]' />
     </div>
   );
 }

--- a/src/pages/Main.tsx
+++ b/src/pages/Main.tsx
@@ -2,7 +2,6 @@ import { gsap } from 'gsap';
 import { ScrollTrigger } from 'gsap/ScrollTrigger';
 import { useEffect, useRef } from 'react';
 
-import ApplySnackBar from '@/components/apply/ApplySnackBar';
 import CalloutNumerical from '@/components/common/callout/CalloutNumerical';
 import Hero from '@/components/common/callout/Hero';
 import HeroIndex from '@/components/common/callout/HeroIndex';
@@ -10,7 +9,6 @@ import { Tab, TabHeader, TabItem, TabPanel } from '@/components/common/tab/Tab';
 import Title from '@/components/common/title/Title';
 import AnimatedSection from '@/components/main/animatedSection/AnimatedSection';
 import RoleHero from '@/components/main/role/RoleHero';
-import { APPLY_SNACKBAR } from '@/constants/applyMessages';
 import { corePrincipleData, positionData, timelineData } from '@/constants/mainPageData';
 
 const sectionClassName =
@@ -182,7 +180,6 @@ const Main = () => {
           </div>
         </div>
       </section>
-      <ApplySnackBar message={APPLY_SNACKBAR.main} width='w-[33.5rem]' />
     </div>
   );
 };

--- a/src/pages/Project.tsx
+++ b/src/pages/Project.tsx
@@ -3,7 +3,6 @@ import { useEffect, useRef, useState } from 'react';
 
 import cardSampleImage from '@/assets/CardSample.png';
 import loadingSpinner from '@/assets/lottie/ject-loadingSpinner.json';
-import ApplySnackBar from '@/components/apply/ApplySnackBar';
 import LabelButton from '@/components/common/button/LabelButton';
 import { Card } from '@/components/common/card/Card';
 import EmptyData from '@/components/common/emptyState/EmptyData';
@@ -11,7 +10,6 @@ import Icon from '@/components/common/icon/Icon';
 import Label from '@/components/common/label/Label';
 import { Select } from '@/components/common/select/Select';
 import Title from '@/components/common/title/Title';
-import { APPLY_SNACKBAR } from '@/constants/applyMessages';
 import { PATH } from '@/constants/path';
 import useCloseOutside from '@/hooks/useCloseOutside';
 import { useInfiniteScroll } from '@/hooks/useInfiniteScroll';
@@ -125,7 +123,6 @@ const Project = () => {
           </div>
         </div>
       </section>
-      <ApplySnackBar message={APPLY_SNACKBAR.default} width='w-[31.25rem]' />
     </div>
   );
 };

--- a/src/pages/ProjectDetail.tsx
+++ b/src/pages/ProjectDetail.tsx
@@ -1,7 +1,6 @@
 import { Navigate, useParams } from 'react-router-dom';
 
 import cardSampleImage from '@/assets/CardSample.png';
-import ApplySnackBar from '@/components/apply/ApplySnackBar';
 import BlockButton from '@/components/common/button/BlockButton';
 import CalloutInformation from '@/components/common/callout/CalloutInformation';
 import EmptyData from '@/components/common/emptyState/EmptyData';
@@ -9,7 +8,6 @@ import Icon from '@/components/common/icon/Icon';
 import Label from '@/components/common/label/Label';
 import { Tab, TabHeader, TabItem, TabPanel } from '@/components/common/tab/Tab';
 import Title from '@/components/common/title/Title';
-import { APPLY_SNACKBAR } from '@/constants/applyMessages';
 import { PATH } from '@/constants/path';
 import { useProjectDetailQuery } from '@/hooks/useProjectDetailQuery';
 
@@ -135,7 +133,6 @@ const ProjectDetail = () => {
           </div>
         </Tab>
       </section>
-      <ApplySnackBar message={APPLY_SNACKBAR.default} width='w-[31.25rem]' />
     </div>
   );
 };


### PR DESCRIPTION
## 💡 작업 내용

- [x] 페이지에서 ApplySnackBar 컴포넌트 제거
- [x] Apply 컴포넌트 `젝트 3기 지원하기` 버튼 disabled 처리

## 💡 자세한 설명

### 1️⃣ 변경된 UI
메인 페이지, 프로젝트 목록 및 상세 페이지, 활동 페이지, faq 페이지에 있던 지원 스낵바를 제거했습니다. 
또한 지원 페이지에서 `젝트 3기 지원하기` 버튼을 비활성화했습니다.
버튼은 혹시 몰라 click 이벤트도 제거했습니다.

해당 코드는 5월 8일 오전 12:00에 배포 진행될 예정입니다!

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #208 
