### PR TITLE
fix: 지원 페이지 progress 날짜 버그 해결

### DIFF
--- a/src/constants/applyPageData.tsx
+++ b/src/constants/applyPageData.tsx
@@ -30,7 +30,7 @@ interface Procedure {
 export const applyProcedureList: Procedure[] = [
   {
     id: 1,
-    startDate: '2025-04-18',
+    startDate: '2025-04-18T00:00:00',
     period: '4월 18일(금) ~ 5월 7일(수)',
     subTitle: '지원 접수 기간',
     content: (
@@ -48,21 +48,21 @@ export const applyProcedureList: Procedure[] = [
   },
   {
     id: 2,
-    startDate: '2025-05-08',
+    startDate: '2025-05-08T00:00:00',
     period: '5월 8일(목) ~ 5월 11일(일)',
     subTitle: '지원서 검토 기간',
     content: '소중한 지원자분들의 서류를 검토해요.',
   },
   {
     id: 3,
-    startDate: '2025-05-12',
+    startDate: '2025-05-12T00:00:00',
     period: '5월 12일(월)',
     subTitle: '합격자 발표',
     content: '젝트와 함께 몰입해 프로젝트를 진행할 분들을 최종적으로 발표드려요.',
   },
   {
     id: 4,
-    startDate: '2025-05-18',
+    startDate: '2025-05-18T00:00:00',
     period: '5월 18일(일)',
     subTitle: '온보딩',
     content: '오프라인으로 온보딩 행사를 진행해요. 필수적으로 참여해 주세요. ',


### PR DESCRIPTION
## 💡 작업 내용

- [x] applyProcedureList startDate ISO 8601 형식으로 변경

## 💡 자세한 설명

### 문제
![image](https://github.com/user-attachments/assets/4aed2294-54d7-40a6-b832-02e6b4877672)
5월 8일 12시가 조금 지난 지금 2번 progress가 active 스타일로 변경되고 있지 않습니다. 

### 원인 
applyProcedureList 객체 데이터의  startDate가 날짜만 표현되고 있어 
apply 페이지의 `new Date(startDate) <= currentDate` 조건 비교 시 new Date(startDate)의 시간이 00:00:00가 아닌
09:00:00으로 비교되고 있어서 발생한 문제입니다. 

### 해결 
applyProcedureList 객체 데이터의  startDate 형식을 시간데이터를 포함하는 ISO 8601 형식으로 변경했습니다 `YYYY-MM-DDT00:00:00`

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #210 
