### PR TITLE
feat: 지원하기 페이지에서 모집 마감 페이지로 변경

### DIFF
--- a/src/pages/Apply.tsx
+++ b/src/pages/Apply.tsx
@@ -60,7 +60,7 @@ function Apply() {
         rightIcon={<Icon name='forward' size='md' fillColor='fill-accent-trans-hero-dark' />}
         className='min-w-[26.25rem] cursor-pointer'
       >
-        젝트 3기 지원하기
+        젝트 3기 모집 마감됨
       </BlockButton>
     </div>
   );

--- a/src/pages/RecruitmentComplete.tsx
+++ b/src/pages/RecruitmentComplete.tsx
@@ -4,12 +4,14 @@ import Label from '@/components/common/label/Label';
 import Title from '@/components/common/title/Title';
 
 function RecruitmentComplete() {
+  const GENERATION = 3;
+
   return (
     <div className='flex h-dvh translate-y-[-3.75rem] flex-col items-center justify-center'>
       <section className='gap-8xl flex flex-col'>
         <div className='gap-7xl flex flex-col text-center'>
           <Title hierarchy='strong' textColor='text-object-hero-dark'>
-            3기 모집 완료
+            {`${GENERATION}기 모집 완료`}
           </Title>
           <Label hierarchy='stronger' weight='bold' textColor='text-object-neutral-dark'>
             지금은 모집 기간이 아니에요.
@@ -28,7 +30,7 @@ function RecruitmentComplete() {
             window.open('https://forms.gle/NB3bBYYgBVN9cV4M7', '_blank', 'noopener,noreferrer')
           }
         >
-          4기 모집 알림 신청
+          {`${GENERATION + 1}기 모집 알림 신청`}
         </BlockButton>
       </section>
     </div>

--- a/src/pages/RecruitmentComplete.tsx
+++ b/src/pages/RecruitmentComplete.tsx
@@ -1,0 +1,38 @@
+import BlockButton from '@/components/common/button/BlockButton';
+import Icon from '@/components/common/icon/Icon';
+import Label from '@/components/common/label/Label';
+import Title from '@/components/common/title/Title';
+
+function RecruitmentComplete() {
+  return (
+    <div className='flex h-dvh translate-y-[-3.75rem] flex-col items-center justify-center'>
+      <section className='gap-8xl flex flex-col'>
+        <div className='gap-7xl flex flex-col text-center'>
+          <Title hierarchy='strong' textColor='text-object-hero-dark'>
+            3기 모집 완료
+          </Title>
+          <Label hierarchy='stronger' weight='bold' textColor='text-object-neutral-dark'>
+            지금은 모집 기간이 아니에요.
+            <br /> 다음 기수 모집 알림을 희망하시면, 버튼을 눌러 신청해주세요!
+          </Label>
+        </div>
+        <BlockButton
+          size='lg'
+          style='solid'
+          hierarchy='accent'
+          rightIcon={
+            <Icon name='northEast' size='md' fillColor='fill-object-static-inverse-hero-dark' />
+          }
+          className='min-w-[26.25rem] cursor-pointer'
+          onClick={() =>
+            window.open('https://forms.gle/NB3bBYYgBVN9cV4M7', '_blank', 'noopener,noreferrer')
+          }
+        >
+          4기 모집 알림 신청
+        </BlockButton>
+      </section>
+    </div>
+  );
+}
+
+export default RecruitmentComplete;

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -6,7 +6,6 @@ import NotFoundError from './pages/NotFoundError';
 
 import Layout from '@/components/layout/Layout';
 import Activity from '@/pages/Activity';
-import Apply from '@/pages/Apply';
 import ApplyApplicantInfo from '@/pages/ApplyApplicationInfo';
 import ApplyComplete from '@/pages/ApplyComplete';
 import ApplyRegistration from '@/pages/ApplyRegistration';
@@ -15,6 +14,7 @@ import Faq from '@/pages/Faq';
 import Main from '@/pages/Main';
 import Project from '@/pages/Project';
 import ProjectDetail from '@/pages/ProjectDetail';
+import RecruitmentComplete from '@/pages/RecruitmentComplete';
 
 const router = sentryCreateBrowserRouter([
   {
@@ -24,7 +24,7 @@ const router = sentryCreateBrowserRouter([
       { path: PATH.project, element: <Project /> },
       { path: `${PATH.project}/:id`, element: <ProjectDetail /> },
       { path: PATH.activity, element: <Activity /> },
-      { path: PATH.apply, element: <Apply /> },
+      { path: PATH.apply, element: <RecruitmentComplete /> },
       { path: `${PATH.faq}/:tabId?/:questionId?`, element: <Faq /> },
       { path: PATH.applyVerify, element: <ApplyVerify /> },
       { path: PATH.applicantInfo, element: <ApplyApplicantInfo /> },


### PR DESCRIPTION
## 💡 작업 내용

- [x] ~~지원 페이지 cta 버튼 문구 변경~~
- [x] 3기 모집 마감 페이지 생성 및 적용
- [x] cta 버튼(4기 모집 알림 신청) 클릭 시 새탭으로 구글폼 링크 열림

## 💡 자세한 설명

GNB의 `지원하기` 탭 클릭 시 RecruitmentComplete 컴포넌트 페이지로 이동됩니다. 
해당 페이지의 cta 버튼 클릭 시 4기 신청 알림을 신청하는 구글폼이 새탭으로 열립니다. 


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #212 
