### PR TITLE
feat: Callout 컴포넌트 구현 ( 아직 콜아웃 버튼 구현 X ) 

### DIFF
--- a/packages/jds/src/components/Callout/Callout.stories.tsx
+++ b/packages/jds/src/components/Callout/Callout.stories.tsx
@@ -1,0 +1,91 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { Callout } from './Callout';
+
+const meta = {
+  title: 'Components/Callout',
+  component: Callout,
+  parameters: {
+    layout: 'centered',
+  },
+  argTypes: {
+    children: {
+      control: 'text',
+      defaultValue: 'Callout',
+    },
+  },
+} satisfies Meta<typeof Callout>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const BasicHierarchy: StoryObj<typeof Callout> = {
+  name: 'Basic Callout',
+  argTypes: {
+    type: { control: 'radio', options: ['basic'] },
+    variant: { control: 'radio' },
+    hierarchy: { control: 'radio', options: ['accent', 'primary', 'secondary'] },
+    size: { control: 'radio', options: ['lg', 'md', 'sm', 'xs', '2xs'] },
+    titleVisible: { control: 'boolean' },
+    extraButtonVisible: { control: 'boolean' },
+  },
+  args: {
+    type: 'basic',
+    hierarchy: 'accent',
+    variant: 'hero',
+    size: 'md',
+    titleVisible: true,
+    extraButtonVisible: false,
+    title: '베이직 콜아웃 타이틀',
+    children:
+      '콜아웃 텍스트의 최대 입력 글자수 제한은 없지만, 너무 많은 글자수는 핵심적인 내용을 효과적으로 전달하는 데에 적절치 않다는 점을 유의합니다.',
+  },
+  render: args => (
+    <Callout
+      title={args.title}
+      type='basic'
+      hierarchy={args.hierarchy}
+      variant={args.variant}
+      size={args.size}
+      titleVisible={args.titleVisible}
+      extraButtonVisible={args.extraButtonVisible}
+    >
+      {args.children}
+    </Callout>
+  ),
+};
+
+export const FeedbackHierarchy: StoryObj<typeof Callout> = {
+  name: 'Feedback Callout',
+  argTypes: {
+    type: { control: 'radio', options: ['feedback'] },
+    variant: { control: 'radio' },
+    hierarchy: { control: 'radio', options: ['positive', 'destructive', 'notifying'] },
+    size: { control: 'radio', options: ['lg', 'md', 'sm', 'xs', '2xs'] },
+    titleVisible: { control: 'boolean' },
+    extraButtonVisible: { control: 'boolean' },
+  },
+  args: {
+    type: 'feedback',
+    hierarchy: 'positive',
+    variant: 'hero',
+    size: 'md',
+    titleVisible: true,
+    extraButtonVisible: false,
+    title: '피드백 콜아웃 타이틀',
+    children:
+      '콜아웃 텍스트의 최대 입력 글자수 제한은 없지만, 너무 많은 글자수는 핵심적인 내용을 효과적으로 전달하는 데에 적절치 않다는 점을 유의합니다.',
+  },
+  render: args => (
+    <Callout
+      title={args.title}
+      type='feedback'
+      hierarchy={args.hierarchy}
+      variant={args.variant}
+      size={args.size}
+      titleVisible={args.titleVisible}
+      extraButtonVisible={args.extraButtonVisible}
+    >
+      {args.children}
+    </Callout>
+  ),
+};

--- a/packages/jds/src/components/Callout/Callout.style.ts
+++ b/packages/jds/src/components/Callout/Callout.style.ts
@@ -1,0 +1,77 @@
+import styled from '@emotion/styled';
+import { textStyle } from 'utils';
+import { BasicHierarchy, CalloutSize, CalloutVariant, FeedbackHierarchy } from './Callout.types';
+import { CALLOUT_BASIC_STYLE, CALLOUT_FEEDBACK_STYLE, CALLOUT_SIZE } from './Callout.variants';
+
+interface BasicCalloutDivProps {
+  hierarchy: BasicHierarchy;
+  variant: CalloutVariant;
+  size: CalloutSize;
+}
+
+interface FeedbackCalloutDivProps {
+  hierarchy: FeedbackHierarchy;
+  variant: CalloutVariant;
+  size: CalloutSize;
+}
+
+export const BasicCalloutDiv = styled.div<BasicCalloutDivProps>(
+  ({ theme, hierarchy, variant, size }) => {
+    const style = CALLOUT_BASIC_STYLE(theme)[variant][hierarchy];
+    const border = variant === 'hero' ? 'none' : `1px solid ${style.border}`;
+    const borderLeft = variant === 'hero' ? `6px solid ${style.border}` : 'none';
+    const borderRadius = variant === 'hero' ? 'none' : '6px';
+
+    return {
+      width: '300px',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      padding: CALLOUT_SIZE[size].padding,
+      gap: CALLOUT_SIZE[size].gap,
+      border,
+      borderLeft,
+      borderRadius,
+      backgroundColor: style.bg,
+      color: style.color,
+    };
+  },
+);
+
+export const FeedbackCalloutDiv = styled.div<FeedbackCalloutDivProps>(
+  ({ theme, hierarchy, variant, size }) => {
+    const style = CALLOUT_FEEDBACK_STYLE(theme)[variant][hierarchy];
+
+    return {
+      width: '300px',
+      display: 'flex',
+      flexDirection: 'column',
+      alignItems: 'flex-start',
+      padding: CALLOUT_SIZE[size].padding,
+      gap: CALLOUT_SIZE[size].gap,
+      borderLeft: `6px solid ${style.border}`,
+      backgroundColor: style.bg,
+      color: style.color,
+    };
+  },
+);
+
+interface CalloutPProps {
+  size: CalloutSize;
+}
+
+export const CalloutTitleP = styled.p<CalloutPProps>(({ theme, size }) => {
+  return {
+    [theme.breakPoint.mobile]: { ...textStyle(theme, 'mobile', CALLOUT_SIZE[size].title) },
+    [theme.breakPoint.tablet]: { ...textStyle(theme, 'tablet', CALLOUT_SIZE[size].title) },
+    [theme.breakPoint.desktop]: { ...textStyle(theme, 'desktop', CALLOUT_SIZE[size].title) },
+  };
+});
+
+export const CalloutContentP = styled.p<CalloutPProps>(({ theme, size }) => {
+  return {
+    [theme.breakPoint.mobile]: { ...textStyle(theme, 'mobile', CALLOUT_SIZE[size].content) },
+    [theme.breakPoint.tablet]: { ...textStyle(theme, 'tablet', CALLOUT_SIZE[size].content) },
+    [theme.breakPoint.desktop]: { ...textStyle(theme, 'desktop', CALLOUT_SIZE[size].content) },
+  };
+});

--- a/packages/jds/src/components/Callout/Callout.tsx
+++ b/packages/jds/src/components/Callout/Callout.tsx
@@ -1,0 +1,54 @@
+import { ReactNode } from 'react';
+import {
+  BasicCalloutDiv,
+  CalloutContentP,
+  CalloutTitleP,
+  FeedbackCalloutDiv,
+} from './Callout.style';
+import {
+  BasicHierarchy,
+  CalloutSize,
+  CalloutType,
+  CalloutVariant,
+  FeedbackHierarchy,
+} from './Callout.types';
+
+interface CalloutProps {
+  type: CalloutType;
+  variant: CalloutVariant;
+  hierarchy: BasicHierarchy | FeedbackHierarchy;
+  size: CalloutSize;
+  titleVisible: boolean;
+  extraButtonVisible: boolean;
+  title: string;
+  children: ReactNode;
+}
+
+export const Callout = ({
+  type = 'basic',
+  hierarchy,
+  variant = 'hero',
+  size = 'md',
+  titleVisible = false,
+  extraButtonVisible = false,
+  title,
+  children,
+}: CalloutProps) => {
+  if (type === 'basic') {
+    return (
+      <BasicCalloutDiv hierarchy={hierarchy as BasicHierarchy} variant={variant} size={size}>
+        {titleVisible && <CalloutTitleP size={size}>{title}</CalloutTitleP>}
+        <CalloutContentP size={size}>{children}</CalloutContentP>
+      </BasicCalloutDiv>
+    );
+  } else if (type === 'feedback') {
+    return (
+      <FeedbackCalloutDiv hierarchy={hierarchy as FeedbackHierarchy} variant={variant} size={size}>
+        {titleVisible && <CalloutTitleP size={size}>{title}</CalloutTitleP>}
+        <CalloutContentP size={size}>{children}</CalloutContentP>
+      </FeedbackCalloutDiv>
+    );
+  }
+};
+
+Callout.displayName = 'Callout';

--- a/packages/jds/src/components/Callout/Callout.tsx
+++ b/packages/jds/src/components/Callout/Callout.tsx
@@ -14,20 +14,20 @@ import {
 } from './Callout.types';
 
 interface CalloutProps {
-  type: CalloutType;
-  variant: CalloutVariant;
+  type?: CalloutType;
+  variant?: CalloutVariant;
   hierarchy: BasicHierarchy | FeedbackHierarchy;
-  size: CalloutSize;
-  titleVisible: boolean;
-  extraButtonVisible: boolean;
-  title: string;
+  size?: CalloutSize;
+  titleVisible?: boolean;
+  extraButtonVisible?: boolean;
+  title?: string;
   children: ReactNode;
 }
 
 export const Callout = ({
   type = 'basic',
-  hierarchy,
   variant = 'hero',
+  hierarchy,
   size = 'md',
   titleVisible = false,
   extraButtonVisible = false,

--- a/packages/jds/src/components/Callout/Callout.types.ts
+++ b/packages/jds/src/components/Callout/Callout.types.ts
@@ -1,0 +1,5 @@
+export type CalloutType = 'basic' | 'feedback';
+export type BasicHierarchy = 'accent' | 'primary' | 'secondary';
+export type FeedbackHierarchy = 'positive' | 'destructive' | 'notifying';
+export type CalloutVariant = 'hero' | 'hint';
+export type CalloutSize = 'lg' | 'md' | 'sm' | 'xs' | '2xs';

--- a/packages/jds/src/components/Callout/Callout.variants.ts
+++ b/packages/jds/src/components/Callout/Callout.variants.ts
@@ -1,0 +1,94 @@
+import { Theme } from '@emotion/react';
+import { BasicHierarchy, CalloutVariant, FeedbackHierarchy } from './Callout.types';
+
+type BasicStyle = Record<
+  CalloutVariant,
+  Record<BasicHierarchy, { bg: string; border: string; color: string }>
+>;
+
+export const CALLOUT_BASIC_STYLE = (theme: Theme): BasicStyle => ({
+  hero: {
+    accent: {
+      bg: theme.color.accent.alpha.subtler,
+      border: theme.color.accent.neutral,
+      color: theme.color.accent.bold,
+    },
+    primary: {
+      bg: theme.color.fill.subtler,
+      border: theme.color.stroke.bold,
+      color: theme.color.object.bolder,
+    },
+    secondary: {
+      bg: theme.color.fill.subtlest,
+      border: theme.color.stroke.neutral,
+      color: theme.color.object.bold,
+    },
+  },
+  hint: {
+    accent: {
+      bg: theme.color.accent.alpha.inverse.subtlest,
+      border: theme.color.accent.alpha.subtle,
+      color: theme.color.accent.normal,
+    },
+    primary: {
+      bg: theme.color.surface.deep,
+      border: theme.color.stroke.alpha.assistive,
+      color: theme.color.object.bold,
+    },
+    secondary: {
+      bg: theme.color.surface.deep,
+      border: theme.color.stroke.alpha.subtler,
+      color: theme.color.object.normal,
+    },
+  },
+});
+
+type FeedbackStyle = Record<
+  CalloutVariant,
+  Record<FeedbackHierarchy, { bg: string; border: string; color: string }>
+>;
+
+export const CALLOUT_FEEDBACK_STYLE = (theme: Theme): FeedbackStyle => ({
+  hero: {
+    positive: {
+      bg: theme.color.feedback.positive.alpha.subtler,
+      border: theme.color.feedback.positive.neutral,
+      color: theme.color.feedback.positive.bold,
+    },
+    destructive: {
+      bg: theme.color.feedback.destructive.alpha.subtler,
+      border: theme.color.feedback.destructive.neutral,
+      color: theme.color.feedback.destructive.bold,
+    },
+    notifying: {
+      bg: theme.color.feedback.notifying.alpha.subtler,
+      border: theme.color.feedback.notifying.neutral,
+      color: theme.color.feedback.notifying.bold,
+    },
+  },
+  hint: {
+    positive: {
+      bg: theme.color.feedback.positive.alpha.subtlest,
+      border: theme.color.feedback.positive.alpha.subtler,
+      color: theme.color.feedback.positive.normal,
+    },
+    destructive: {
+      bg: theme.color.feedback.destructive.alpha.subtlest,
+      border: theme.color.feedback.destructive.alpha.subtler,
+      color: theme.color.feedback.destructive.normal,
+    },
+    notifying: {
+      bg: theme.color.feedback.notifying.alpha.subtlest,
+      border: theme.color.feedback.notifying.alpha.subtler,
+      color: theme.color.feedback.notifying.normal,
+    },
+  },
+});
+
+export const CALLOUT_SIZE = {
+  lg: { padding: '16px 24px', gap: '16px', title: 'title.2', content: 'body.lg.bold' },
+  md: { padding: '16px 24px', gap: '16px', title: 'title.1', content: 'body.md.bold' },
+  sm: { padding: '16px 24px', gap: '16px', title: 'label.lg.bold', content: 'body.sm.bold' },
+  xs: { padding: '12px 20px', gap: '12px', title: 'label.md.bold', content: 'body.xs.bold' },
+  '2xs': { padding: '12px 20px', gap: '12px', title: 'label.sm.bold', content: 'body.2xs.bold' },
+} as const;


### PR DESCRIPTION
## 💡 작업 내용

- [x] Callout 컴포넌트 구현

## 💡 자세한 설명

### Callout 컴포넌트 
Callout 컴포넌트는 `basic`, `feedback` 2가지 종류가 있으며 type 속성을 통해 조정할 수 있습니다. (기본값 basic)   
Callout 컴포넌트에서는 버튼을 추가하거나 제거할 수 있는데 이는 버튼 컴포넌트가 구현되면 추가할 예정입니다.    
또한 Callout 제목 요소로 Title, Label 컴포넌트를 활용할 수 있는데 (아직은 활용하지 않음) 이는 Title 컴포넌트 PR이 머지되면 활용할 예정입니다. 
 

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [ ] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

#221 
