### PR TITLE
chore: 스토리북 다크/라이트 모드 기능 설정

### DIFF
--- a/packages/jds/.storybook/preview.tsx
+++ b/packages/jds/.storybook/preview.tsx
@@ -32,6 +32,7 @@ const preview: Preview = {
       const backgroundColor = context.globals.theme === 'light' ? '#ffffff' : '#191B24';
       document.body.style.background = backgroundColor;
 
+      // TODO: 모드 전환 시 깜박임 현상 해결하기 (Global 요소 활용, 설정 조작 등 방법 이용)
       const docsStories = document.querySelectorAll('.docs-story');
       docsStories.forEach(el => {
         (el as HTMLElement).style.background = backgroundColor;


### PR DESCRIPTION
## 💡 작업 내용

- [x] 모드에 따라 스토리북 배경색 전환

## 💡 자세한 설명

### preview.tsx 수정 사항  
parameters에 있던 backgrounds 기본 속성을 제거하고    
decorators에서 툴바의 테마 전환 아이콘을 클릭했을 때 토큰 및 배경색이 전환되도록 수정했습니다.    
차선책으로 document에 직접 배경색을 변경하는 식으로 작성했습니다.  (docs 페이지에서 살짝 렌더링 버벅임)  
추후 addon이나 기타 방식으로 전환되게끔 하는 쪽으로 수정해보겠습니다! 
배경색은 피그마에서 기본으로 사용되는 배경색을 사용합니다.   


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #235 
