### PR TITLE
feat: 젝트 비전 스토리 버튼 클릭 시 /vision 이동 기능 추가

### DIFF
--- a/apps/web/src/components/main/sections/IntroSection.tsx
+++ b/apps/web/src/components/main/sections/IntroSection.tsx
@@ -1,4 +1,5 @@
 import { Callout, ContentBadge, EmptyState, Hero, Icon, Image, Label, LabelButton, Title as JdsTitle } from "@ject/jds";
+import { useNavigate } from "react-router-dom";
 
 import introTeamMeetingImage from "@/assets/images/intro-team-meeting.png";
 import { positionData, programData, statData } from "@/constants/mainPageData";
@@ -13,6 +14,8 @@ const positionCardStyles = {
 } as const;
 
 const IntroSection = () => {
+  const navigate = useNavigate();
+
   return (
     <section className='bg-(--semantic-surface-standard) px-0 py-(--semantic-margin-5xl)'>
       <div className='flex w-full flex-col items-center gap-(--semantic-spacing-128) px-(--semantic-margin-lg) pt-(--semantic-margin-xl) pb-(--semantic-spacing-80)'>
@@ -67,6 +70,7 @@ const IntroSection = () => {
               hierarchy='accent'
               size='lg'
               suffixIcon='arrow-right-line'
+              onClick={() => void navigate("/vision")}
             >
               젝트의 비전과 스토리에 대해
             </LabelButton.Basic>


### PR DESCRIPTION
## 💡 작업 내용

- [x] 젝트 비전 스토리 버튼 클릭 시 /vision 이동 기능 추가

![Dec-29-2025 18-10-23](https://github.com/user-attachments/assets/d6133c7d-69b2-4ed5-9349-8cec3d4d59d7)

## 💡 자세한 설명

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [ ] 머지할 브랜치 확인했나요?
- [ ] 이슈는 close 했나요?
- [ ] Reviewers, Labels, Projects를 등록했나요?
- [ ] 기능이 잘 동작하나요?
- [ ] 불필요한 코드는 제거했나요?

closes #이슈번호
