### PR TITLE
hotfix: 임시 저장 지원서를 직군 전체가 공유하는 문제

### DIFF
--- a/apps/web/src/apis/apply/api.ts
+++ b/apps/web/src/apis/apply/api.ts
@@ -3,12 +3,12 @@ import axios from "axios";
 
 import {
   applicationStatusResponseSchema,
-  memberProfileResponseSchema,
+  memberMeResponseSchema,
   memberProfileInitialStatusResponseSchema,
   questionResponseSchema,
   answersResponseSchema,
   type ApplicationStatusResponseSchema,
-  type MemberProfileResponseSchema,
+  type MemberMeResponseSchema,
   type MemberProfileInitialStatusResponseSchema,
   type QuestionResponseSchema,
   type AnswersResponseSchema,
@@ -45,10 +45,10 @@ export const applyApi = {
       applicationStatusResponseSchema,
     ),
 
-  getProfile: () =>
-    httpClient.get<MemberProfileResponseSchema>(
-      API_ENDPOINT.memberProfile,
-      memberProfileResponseSchema,
+  getMe: () =>
+    httpClient.get<MemberMeResponseSchema>(
+      API_ENDPOINT.memberMe,
+      memberMeResponseSchema,
     ),
 
   updateProfile: (data: MemberProfilePayload) =>

--- a/apps/web/src/apis/apply/api.ts
+++ b/apps/web/src/apis/apply/api.ts
@@ -39,13 +39,11 @@ export const applyApi = {
       memberProfileInitialStatusResponseSchema,
     ),
 
-  getStatus: (email: string) => {
-    const params = new URLSearchParams({ email });
-    return httpClient.get<ApplicationStatusResponseSchema>(
-      `${API_ENDPOINT.applyStatus}?${params.toString()}`,
+  getStatus: () =>
+    httpClient.get<ApplicationStatusResponseSchema>(
+      API_ENDPOINT.applyStatus,
       applicationStatusResponseSchema,
-    );
-  },
+    ),
 
   getProfile: () =>
     httpClient.get<MemberProfileResponseSchema>(

--- a/apps/web/src/apis/apply/api.ts
+++ b/apps/web/src/apis/apply/api.ts
@@ -64,10 +64,8 @@ export const applyApi = {
 
   getDraft: () => httpClient.get<AnswersResponseSchema>(API_ENDPOINT.draft, answersResponseSchema),
 
-  saveDraft: (jobFamily: JobFamily, answers: AnswersPayload) => {
-    const params = new URLSearchParams({ jobFamily });
-    return httpClient.post<null>(`${API_ENDPOINT.draft}?${params.toString()}`, answers);
-  },
+  saveDraft: (answers: AnswersPayload) =>
+    httpClient.post<null>(API_ENDPOINT.draft, answers),
 
   deleteDraft: () => httpClient.delete<null>(API_ENDPOINT.draft),
 

--- a/apps/web/src/apis/apply/index.ts
+++ b/apps/web/src/apis/apply/index.ts
@@ -10,13 +10,13 @@ export {
 export {
   // 스키마
   applicationStatusResponseSchema,
-  memberProfileResponseSchema,
+  memberMeResponseSchema,
   memberProfileInitialStatusResponseSchema,
   questionResponseSchema,
   answersResponseSchema,
   // 스키마 타입
   type ApplicationStatusResponseSchema,
-  type MemberProfileResponseSchema,
+  type MemberMeResponseSchema,
   type MemberProfileInitialStatusResponseSchema,
   type QuestionResponseSchema,
   type AnswersResponseSchema,

--- a/apps/web/src/apis/apply/queryKeys.ts
+++ b/apps/web/src/apis/apply/queryKeys.ts
@@ -7,7 +7,7 @@ export const applyQueryKeys = {
   all: ["apply"] as const,
   status: {
     all: () => [...applyQueryKeys.all, "status"] as const,
-    byEmail: (email: string) => [...applyQueryKeys.status.all(), "email", email] as const,
+    current: () => [...applyQueryKeys.status.all(), "current"] as const,
   },
   questions: {
     all: () => [...applyQueryKeys.all, "questions"] as const,
@@ -49,9 +49,9 @@ export const applyMutationKeys = {
 
 export const applyQueries = {
   status: {
-    byEmail: (email: string) => ({
-      queryKey: applyQueryKeys.status.byEmail(email),
-      queryFn: () => applyApi.getStatus(email),
+    current: () => ({
+      queryKey: applyQueryKeys.status.current(),
+      queryFn: () => applyApi.getStatus(),
     }),
   },
   profile: {

--- a/apps/web/src/apis/apply/queryKeys.ts
+++ b/apps/web/src/apis/apply/queryKeys.ts
@@ -57,7 +57,7 @@ export const applyQueries = {
   profile: {
     me: () => ({
       queryKey: applyQueryKeys.profile.me(),
-      queryFn: applyApi.getProfile,
+      queryFn: applyApi.getMe,
     }),
     initialStatus: () => ({
       queryKey: applyQueryKeys.profile.initialStatus(),

--- a/apps/web/src/apis/apply/schemas.ts
+++ b/apps/web/src/apis/apply/schemas.ts
@@ -65,16 +65,16 @@ export const interestedDomainSchema = z.enum([
   "HR",
 ]);
 
-export const memberProfileResponseSchema = z.object({
+export const memberMeResponseSchema = z.object({
+  id: z.number(),
   name: z.string(),
-  phoneNumber: z.string(),
   careerDetails: careerDetailsSchema,
   region: regionSchema,
   experiencePeriod: experiencePeriodSchema,
   interestedDomains: z.array(interestedDomainSchema),
 });
 
-export type MemberProfileResponseSchema = z.infer<typeof memberProfileResponseSchema>;
+export type MemberMeResponseSchema = z.infer<typeof memberMeResponseSchema>;
 
 export const questionInputTypeSchema = z.enum(["TEXT", "URL", "FILE", "SELECT"]);
 

--- a/apps/web/src/constants/apiEndpoint.ts
+++ b/apps/web/src/constants/apiEndpoint.ts
@@ -5,7 +5,7 @@ export const API_ENDPOINT = {
   verifyEmailCode: "/auth/code",
   checkEmailExists: "/auth/login/exist",
   applyMember: "/members/apply",
-  memberProfile: "/members/profile",
+  memberMe: "/members/me",
   memberProfileInitialStatus: "/members/profile/initial/status",
   pinLogin: "/auth/login/pin",
   registerMember: "/members/apply",

--- a/apps/web/src/constants/applyMessages.tsx
+++ b/apps/web/src/constants/applyMessages.tsx
@@ -67,4 +67,16 @@ export const APPLY_DIALOG = {
     ),
     primaryAction: "확인",
   },
+  jobFamilyMismatch: (savedJobFamilyKorean: string, currentJobFamilyKorean: string) => ({
+    header: `${savedJobFamilyKorean} 지원서가 임시저장되어 있어요`,
+    body: (
+      <>
+        {currentJobFamilyKorean}로 새로 지원하시면
+        <br />
+        기존 {savedJobFamilyKorean} 지원서는 사라져요.
+      </>
+    ),
+    primaryAction: `${savedJobFamilyKorean} 지원서 이어서 작성하기`,
+    secondaryAction: `${currentJobFamilyKorean}로 새로 지원하기`,
+  }),
 };

--- a/apps/web/src/constants/applyMessages.tsx
+++ b/apps/web/src/constants/applyMessages.tsx
@@ -76,7 +76,7 @@ export const APPLY_DIALOG = {
         기존 {savedJobFamilyKorean} 지원서는 사라져요.
       </>
     ),
-    primaryAction: `${savedJobFamilyKorean} 지원서 이어서 작성하기`,
-    secondaryAction: `${currentJobFamilyKorean}로 새로 지원하기`,
+    primaryAction: `지원서 이어서 작성하기`,
+    secondaryAction: `새로 지원하기`,
   }),
 };

--- a/apps/web/src/features/apply/steps/IdentityVerificationStep.tsx
+++ b/apps/web/src/features/apply/steps/IdentityVerificationStep.tsx
@@ -44,10 +44,7 @@ interface JobFamilyMismatchDialog {
   savedJobFamily: JobFamily | null;
 }
 
-export function IdentityVerificationStep({
-  context,
-  dispatch,
-}: IdentityVerificationStepProps) {
+export function IdentityVerificationStep({ context, dispatch }: IdentityVerificationStepProps) {
   const location = useLocation();
   const navigate = useNavigate();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -88,11 +85,14 @@ export function IdentityVerificationStep({
     toastController.basic("PIN 재설정 완료", "새로운 PIN을 입력해 본인 확인을 다시 진행해주세요.");
 
     // 3. URL 파라미터 정리
-    setSearchParams(prev => {
-      prev.delete("pinReset");
-      prev.delete("email");
-      return prev;
-    }, { replace: true });
+    setSearchParams(
+      prev => {
+        prev.delete("pinReset");
+        prev.delete("email");
+        return prev;
+      },
+      { replace: true },
+    );
   }, [isPinResetSuccess, prefillEmail, setEmailValue, setSearchParams]);
 
   const email = watchEmail("email");
@@ -100,7 +100,8 @@ export function IdentityVerificationStep({
 
   const [isChangingJobFamily, setIsChangingJobFamily] = useState(false);
 
-  const { mutate: checkApplyStatusMutate, isPending: isCheckingStatus } = useCheckApplyStatusMutation();
+  const { mutate: checkApplyStatusMutate, isPending: isCheckingStatus } =
+    useCheckApplyStatusMutation();
   const { mutateAsync: deleteDraftAsync } = useDeleteDraftMutation();
   const { mutateAsync: updateProfileAsync } = useMemberProfileMutation();
 
@@ -196,7 +197,7 @@ export function IdentityVerificationStep({
       // 3. 프로필 복원 (새로운 jobFamily로)
       await updateProfileAsync({
         name: profile.name,
-        phoneNumber: "", // TODO: getMe 응답에 phoneNumber가 없어서 임시 처리
+        phoneNumber: "01012345678", // TODO: getMe 응답에 phoneNumber가 없어서 임시 처리
         careerDetails: profile.careerDetails,
         region: profile.region,
         experiencePeriod: profile.experiencePeriod,
@@ -308,7 +309,11 @@ export function IdentityVerificationStep({
       {mismatchDialogContent && (
         <Dialog
           open={mismatchDialog.isOpen || isChangingJobFamily}
-          onOpenChange={open => !open && !isChangingJobFamily && setMismatchDialog({ isOpen: false, savedJobFamily: null })}
+          onOpenChange={open =>
+            !open &&
+            !isChangingJobFamily &&
+            setMismatchDialog({ isOpen: false, savedJobFamily: null })
+          }
           header={mismatchDialogContent.header}
           body={mismatchDialogContent.body}
           primaryAction={{

--- a/apps/web/src/features/apply/steps/IdentityVerificationStep.tsx
+++ b/apps/web/src/features/apply/steps/IdentityVerificationStep.tsx
@@ -85,7 +85,7 @@ export function IdentityVerificationStep({
   const { mutate: checkApplyStatusMutate, isPending: isCheckingStatus } = useCheckApplyStatusMutation();
 
   const handleCheckApplyStatus = (userEmail: string) => {
-    checkApplyStatusMutate(userEmail, {
+    checkApplyStatusMutate(undefined, {
       onSuccess: data => {
         if (data.result === "PROFILE_NOT_REGISTERED") {
           dispatch("goToProfile", userEmail);

--- a/apps/web/src/features/apply/steps/registration/RegistrationStep.tsx
+++ b/apps/web/src/features/apply/steps/registration/RegistrationStep.tsx
@@ -79,11 +79,8 @@ export function RegistrationStep({ context, onNext, onBack }: RegistrationStepPr
 
   //지원서 임시 저장
   const handleSaveDraft = useCallback(() => {
-    saveDraftMutate({
-      jobFamily,
-      answers: { answers, portfolios: formattedPortfolios },
-    });
-  }, [saveDraftMutate, answers, formattedPortfolios, jobFamily]);
+    saveDraftMutate({ answers, portfolios: formattedPortfolios });
+  }, [saveDraftMutate, answers, formattedPortfolios]);
 
   //지원서 제출
   const handleSubmit = useCallback(() => {

--- a/apps/web/src/features/apply/steps/registration/useRegistrationFormWithDraft.ts
+++ b/apps/web/src/features/apply/steps/registration/useRegistrationFormWithDraft.ts
@@ -1,14 +1,10 @@
 import type { Dispatch, SetStateAction } from "react";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 
 import { formatDraftPortfolios } from "./utils";
 
 import type { JobFamily, Question } from "@/apis/apply";
-import {
-  useDeleteDraftMutation,
-  useDraftSuspenseQuery,
-  useQuestionsSuspenseQuery,
-} from "@/hooks/apply";
+import { useDraftSuspenseQuery, useQuestionsSuspenseQuery } from "@/hooks/apply";
 import type { AnswersByQuestionId, PortfolioFile } from "@/types/apis/application";
 
 interface UseRegistrationFormWithDraftReturn {
@@ -42,11 +38,11 @@ export function useRegistrationFormWithDraft(
 ): UseRegistrationFormWithDraftReturn {
   const { data: questionsData } = useQuestionsSuspenseQuery(jobFamily);
   const { data: draftData } = useDraftSuspenseQuery();
-  const { mutate: deleteDraft } = useDeleteDraftMutation();
 
   const questions: Question[] = questionsData.questionResponses;
 
-  // draft의 jobFamily와 현재 선택한 jobFamily가 다르면 draft 무시
+  // draft의 jobFamily와 현재 선택한 jobFamily가 다르면 클라이언트에서만 초기화
+  // (서버 draft는 유지 - DELETE /apply/temp는 프로필까지 삭제하므로 호출하지 않음)
   const isJobFamilyMismatch =
     draftData?.jobFamily != null && draftData.jobFamily !== jobFamily;
 
@@ -62,13 +58,6 @@ export function useRegistrationFormWithDraft(
     }
     return formatDraftPortfolios(draftData.portfolios);
   });
-
-  // jobFamily 불일치 시 서버의 draft 삭제
-  useEffect(() => {
-    if (isJobFamilyMismatch) {
-      deleteDraft();
-    }
-  }, [isJobFamilyMismatch, deleteDraft]);
 
   return {
     questions,

--- a/apps/web/src/hooks/apply/useCheckApplyStatusMutation.ts
+++ b/apps/web/src/hooks/apply/useCheckApplyStatusMutation.ts
@@ -9,7 +9,7 @@ type CheckApplyStatusResult =
 
 export function useCheckApplyStatusMutation() {
   return useMutation({
-    mutationFn: async (email: string): Promise<CheckApplyStatusResult> => {
+    mutationFn: async (): Promise<CheckApplyStatusResult> => {
       // 1. 프로필 등록 여부 확인
       const isProfileRegistered = await applyApi.getProfileInitialStatus();
 
@@ -18,7 +18,7 @@ export function useCheckApplyStatusMutation() {
       }
 
       // 2. 프로필 등록된 경우에만 지원 상태 확인
-      const { status } = await applyApi.getStatus(email);
+      const { status } = await applyApi.getStatus();
 
       if (status === "SUBMITTED") {
         return { result: "SUBMITTED" };

--- a/apps/web/src/hooks/apply/useSaveDraftMutation.ts
+++ b/apps/web/src/hooks/apply/useSaveDraftMutation.ts
@@ -2,16 +2,11 @@ import { toastController } from "@ject/jds";
 import { captureException } from "@sentry/react";
 import { useMutation, useQueryClient, type UseMutationOptions } from "@tanstack/react-query";
 
-import { applyApi, applyMutationKeys, applyQueryKeys, type JobFamily } from "@/apis/apply";
+import { applyApi, applyMutationKeys, applyQueryKeys } from "@/apis/apply";
 import type { AnswersPayload } from "@/types/apis/application";
 
-interface SaveDraftVariables {
-  jobFamily: JobFamily;
-  answers: AnswersPayload;
-}
-
 type UseSaveDraftMutationOptions = Omit<
-  UseMutationOptions<null, Error, SaveDraftVariables, unknown>,
+  UseMutationOptions<null, Error, AnswersPayload, unknown>,
   "mutationKey" | "mutationFn"
 >;
 
@@ -21,7 +16,7 @@ export function useSaveDraftMutation(options?: UseSaveDraftMutationOptions) {
 
   return useMutation({
     mutationKey: applyMutationKeys.draft.save,
-    mutationFn: ({ jobFamily, answers }: SaveDraftVariables) => applyApi.saveDraft(jobFamily, answers),
+    mutationFn: (answers: AnswersPayload) => applyApi.saveDraft(answers),
     retry: 1,
     ...restOptions,
     onSuccess: (data, variables, onMutateResult, mutationContext) => {

--- a/packages/jds/src/components/Input/TagField/tagField.styles.ts
+++ b/packages/jds/src/components/Input/TagField/tagField.styles.ts
@@ -292,6 +292,12 @@ export const StyledTagInput = styled("input", {
     "&::placeholder": {
       color: theme.color.semantic.object.assistive,
     },
+
+    "&:-webkit-autofill, &:-webkit-autofill:hover, &:-webkit-autofill:focus, &:-webkit-autofill:active": {
+      WebkitTextFillColor: textColor,
+      WebkitBoxShadow: `0 0 0 1000px ${theme.color.semantic.surface.standard} inset`,
+      transition: "background-color 5000s ease-in-out 0s",
+    },
   };
 });
 

--- a/packages/jds/src/components/Input/TextField/textField.styles.ts
+++ b/packages/jds/src/components/Input/TextField/textField.styles.ts
@@ -265,6 +265,12 @@ export const StyledInput = styled("input", {
     "&::placeholder": {
       color: theme.color.semantic.object.assistive,
     },
+
+    "&:-webkit-autofill, &:-webkit-autofill:hover, &:-webkit-autofill:focus, &:-webkit-autofill:active": {
+      WebkitTextFillColor: textColor,
+      WebkitBoxShadow: `0 0 0 1000px ${theme.color.semantic.surface.standard} inset`,
+      transition: "background-color 5000s ease-in-out 0s",
+    },
   };
 });
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] /apply/status 가 잘못된 params를 가지는 문제 해결
- [x] /apply/temp 가 잘못된 params를 가지는 문제 해결
- [x] 임시 저장 지원서를 받아오는 플로우 변경
- [x] 타 직군 지원시 현재 로그인한 회원의 프로필를 조회하는 API 추가(지원자 정보 백업용)

## 💡 자세한 설명

구현한 의도를 설명해주세요. 
수정 사항이 있다면 수정한 이유를 적어주세요.
필요하다면 스크린샷 또는 코드 조각을 사용해주세요.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #339 
