### PR TITLE
chore: 버저닝 워크플로우 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,63 +20,87 @@ jobs:
       - name: Get latest tag
         id: get_latest_tag
         run: |
-          # 가장 최근 태그 가져오기
           LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
           echo "latest_tag=$LATEST_TAG" >> $GITHUB_OUTPUT
           echo "Latest tag: $LATEST_TAG"
 
-      - name: Calculate next version
-        id: next_version
+      - name: Check for changes
+        id: check_changes
         run: |
           LATEST_TAG=${{ steps.get_latest_tag.outputs.latest_tag }}
 
-          # v 접두사 제거
-          VERSION=${LATEST_TAG#v}
+          if [ "$LATEST_TAG" = "v0.0.0" ]; then
+            COMMIT_COUNT=$(git rev-list --count HEAD)
+          else
+            COMMIT_COUNT=$(git rev-list --count $LATEST_TAG..HEAD)
+          fi
 
-          # 버전 파싱 (major.minor.patch)
+          if [ "$COMMIT_COUNT" -eq 0 ]; then
+            echo "has_changes=false" >> $GITHUB_OUTPUT
+            echo "No changes since last tag"
+          else
+            echo "has_changes=true" >> $GITHUB_OUTPUT
+            echo "Found $COMMIT_COUNT commits since last tag"
+          fi
+
+      - name: Calculate next version
+        id: next_version
+        if: steps.check_changes.outputs.has_changes == 'true'
+        run: |
+          LATEST_TAG=${{ steps.get_latest_tag.outputs.latest_tag }}
+
+          VERSION=${LATEST_TAG#v}
           IFS='.' read -r MAJOR MINOR PATCH <<< "$VERSION"
 
-          # 커밋 메시지 분석하여 버전 증가 결정
-          COMMITS=$(git log $LATEST_TAG..HEAD --pretty=format:"%s" 2>/dev/null || git log --pretty=format:"%s")
+          # 커밋 메시지 분석 (release, deploy, merge 커밋 제외)
+          COMMITS=$(git log $LATEST_TAG..HEAD --pretty=format:"%s" 2>/dev/null | grep -viE "^(release|deploy|Merge)" || echo "")
 
           if echo "$COMMITS" | grep -qiE "^(feat|feature)(\(.+\))?!:|BREAKING CHANGE"; then
-            # Breaking change -> major 버전 증가
             MAJOR=$((MAJOR + 1))
             MINOR=0
             PATCH=0
           elif echo "$COMMITS" | grep -qiE "^(feat|feature)(\(.+\))?:"; then
-            # 새 기능 -> minor 버전 증가
             MINOR=$((MINOR + 1))
             PATCH=0
           else
-            # 버그 수정, hotfix, 기타 -> patch 버전 증가
             PATCH=$((PATCH + 1))
           fi
 
           NEW_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+
+          # 중복 태그 확인
+          if git tag -l | grep -q "^${NEW_VERSION}$"; then
+            echo "Tag $NEW_VERSION already exists, skipping"
+            echo "skip_release=true" >> $GITHUB_OUTPUT
+          else
+            echo "skip_release=false" >> $GITHUB_OUTPUT
+          fi
+
           echo "new_version=$NEW_VERSION" >> $GITHUB_OUTPUT
           echo "New version: $NEW_VERSION"
 
       - name: Generate changelog
         id: changelog
+        if: steps.check_changes.outputs.has_changes == 'true' && steps.next_version.outputs.skip_release != 'true'
         run: |
           LATEST_TAG=${{ steps.get_latest_tag.outputs.latest_tag }}
 
-          # 이전 태그부터 현재까지의 커밋 로그 생성
           if [ "$LATEST_TAG" = "v0.0.0" ]; then
             COMMITS=$(git log --pretty=format:"- %s (%h)" --reverse)
           else
             COMMITS=$(git log $LATEST_TAG..HEAD --pretty=format:"- %s (%h)" --reverse)
           fi
 
-          # 커밋을 카테고리별로 분류
           FEATURES=""
           FIXES=""
           CHORES=""
           OTHERS=""
 
           while IFS= read -r line; do
-            if echo "$line" | grep -qiE "^- (feat|feature)(\(.+\))?:"; then
+            # release, deploy, merge 커밋 제외
+            if echo "$line" | grep -qiE "^- (release|deploy)(\(.+\))?:|^- Merge "; then
+              continue
+            elif echo "$line" | grep -qiE "^- (feat|feature)(\(.+\))?:"; then
               FEATURES="$FEATURES$line"$'\n'
             elif echo "$line" | grep -qiE "^- (fix|hotfix)(\(.+\))?:"; then
               FIXES="$FIXES$line"$'\n'
@@ -87,7 +111,6 @@ jobs:
             fi
           done <<< "$COMMITS"
 
-          # Changelog 생성
           CHANGELOG=""
 
           if [ -n "$FEATURES" ]; then
@@ -106,13 +129,13 @@ jobs:
             CHANGELOG="$CHANGELOG## Other Changes"$'\n'"$OTHERS"$'\n'
           fi
 
-          # 멀티라인 출력을 위한 처리
           EOF=$(dd if=/dev/urandom bs=15 count=1 status=none | base64)
           echo "changelog<<$EOF" >> $GITHUB_OUTPUT
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "$EOF" >> $GITHUB_OUTPUT
 
       - name: Create Release
+        if: steps.check_changes.outputs.has_changes == 'true' && steps.next_version.outputs.skip_release != 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.next_version.outputs.new_version }}


### PR DESCRIPTION
## 💡 작업 내용

- [x] release:, deploy: prefix changelog에서 제외
- [x] 중복 태그 방지 및 변경사항이 없으면 release 스킵

## 💡 자세한 설명

### ✅ 개선 사항
- release/deploy 제외
 `release:`, `deploy:` prefix 커밋은 changelog와 버전 계산에서 제외하도록 변경하였습니다.

-  Merge 커밋 제외
merge 시에 발생하는 `Merge branch...` 와 같은 기본 커밋 메시지도 버전 계산에서 제외하였습니다.

- 중복 태그 방지
이미 존재하는 버전은 스킵하고, 커밋이 없으면 release를 생성하지 않도록 변경하였습니다.


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #358 
