### PR TITLE
fix: GNB 모바일 뷰 지원하기 cta 추가 및 레이아웃 구조 변경

### DIFF
--- a/apps/web/src/components/gnb/GlobalNavigationBar.tsx
+++ b/apps/web/src/components/gnb/GlobalNavigationBar.tsx
@@ -118,7 +118,7 @@ const GlobalNavigationBar = () => {
               지원하기
             </BlockButton.Basic>
           </GlobalNavigation.Item>
-          <div className='w-[120px]'>
+          <div className='w-30'>
             {variant === "solid" && (
               <SegmentedControl.Root value={theme} size='xs' onValueChange={handleThemeChange}>
                 <SegmentedControl.Item value='light'>라이트</SegmentedControl.Item>
@@ -127,10 +127,23 @@ const GlobalNavigationBar = () => {
             )}
           </div>
         </GlobalNavigation.List>
-        <GlobalNavigation.MobileMenuButton
-          className={`z-51 ${textColor}`}
-          onClick={handleOpenSidebar}
-        />
+        <div className='flex items-center gap-(--semantic-spacing-16)'>
+          {isMobile && (
+            <BlockButton.Basic
+              hierarchy='primary'
+              size='xs'
+              onClick={handleApplyClick}
+              className={`${blockButtonColor}`}
+            >
+              지원하기
+            </BlockButton.Basic>
+          )}
+          <GlobalNavigation.MobileMenuButton
+            className={`z-51 ${textColor}`}
+            onClick={handleOpenSidebar}
+          />
+        </div>
+
         <Sidebar isOpenSidebar={isOpenSidebar} setIsOpenSidebar={setIsOpenSidebar} />
       </GlobalNavigation.Root>
     </div>

--- a/apps/web/src/components/gnb/GlobalNavigationBar.tsx
+++ b/apps/web/src/components/gnb/GlobalNavigationBar.tsx
@@ -118,33 +118,36 @@ const GlobalNavigationBar = () => {
               지원하기
             </BlockButton.Basic>
           </GlobalNavigation.Item>
-          <div className='w-30'>
-            {variant === "solid" && (
-              <SegmentedControl.Root value={theme} size='xs' onValueChange={handleThemeChange}>
-                <SegmentedControl.Item value='light'>라이트</SegmentedControl.Item>
-                <SegmentedControl.Item value='dark'>다크</SegmentedControl.Item>
-              </SegmentedControl.Root>
-            )}
-          </div>
         </GlobalNavigation.List>
-        <div className='flex items-center gap-(--semantic-spacing-16)'>
-          {isMobile && (
-            <BlockButton.Basic
-              hierarchy='primary'
-              size='xs'
-              onClick={handleApplyClick}
-              className={`${blockButtonColor}`}
-            >
-              지원하기
-            </BlockButton.Basic>
-          )}
-          <GlobalNavigation.MobileMenuButton
-            className={`z-51 ${textColor}`}
-            onClick={handleOpenSidebar}
-          />
-        </div>
 
-        <Sidebar isOpenSidebar={isOpenSidebar} setIsOpenSidebar={setIsOpenSidebar} />
+        {!isMobile && variant === "solid" && (
+          <div className='w-30'>
+            <SegmentedControl.Root value={theme} size='xs' onValueChange={handleThemeChange}>
+              <SegmentedControl.Item value='light'>라이트</SegmentedControl.Item>
+              <SegmentedControl.Item value='dark'>다크</SegmentedControl.Item>
+            </SegmentedControl.Root>
+          </div>
+        )}
+
+        {isMobile && (
+          <>
+            <div className='flex items-center gap-(--semantic-spacing-16)'>
+              <BlockButton.Basic
+                hierarchy='primary'
+                size='xs'
+                onClick={handleApplyClick}
+                className={`${blockButtonColor}`}
+              >
+                지원하기
+              </BlockButton.Basic>
+              <GlobalNavigation.MobileMenuButton
+                className={`z-51 ${textColor}`}
+                onClick={handleOpenSidebar}
+              />
+            </div>
+            <Sidebar isOpenSidebar={isOpenSidebar} setIsOpenSidebar={setIsOpenSidebar} />
+          </>
+        )}
       </GlobalNavigation.Root>
     </div>
   );


### PR DESCRIPTION
## 💡 작업 내용

- [x] GNB 모바일 뷰 지원하기 cta 버튼 추가
- [x] GNB 스크롤 되지 않았을 경우, 너비 수정

## 💡 자세한 설명

GNB 모바일 뷰에서 cta 버튼이 보이도록 수정했습니다. 
또한 스크롤하지 않았을 경우, 922px 너비에 테마스위처의 공간까지 차지되도록 되어있었는데 테마스위처가 차지하던 공간 없이 922px 채워지도록 수정했습니다. 
(브랜치 번호를 355인데 335로 잘못 생성했네요..!)

<img width="431" height="612" alt="image" src="https://github.com/user-attachments/assets/0b539b10-4df8-4937-867e-9a7b4b7f989a" />

<img width="1918" height="570" alt="image" src="https://github.com/user-attachments/assets/2f125cdd-af93-4b92-8dd7-d89f3ba168dc" />


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #355 
