### PR TITLE
fix: 미니 스터디/라이브 세션 레이아웃 및 API 스펙 반영

### DIFF
--- a/apps/web/src/pages/Activity.tsx
+++ b/apps/web/src/pages/Activity.tsx
@@ -40,10 +40,10 @@ function Activity() {
             {jectalks.map(jectalk => (
               <Card
                 key={jectalk.id}
-                to={jectalk.youtubeUrl}
-                title={jectalk.name}
+                to={jectalk.contentUrl}
+                title={jectalk.title}
                 label={jectalk.summary}
-                imgUrl={jectalk.imageUrl}
+                imgUrl={jectalk.thumbnailUrl}
                 isDescriptionVisible={false}
                 target='_blank'
                 rel='noopener noreferrer'

--- a/apps/web/src/pages/LiveSession.tsx
+++ b/apps/web/src/pages/LiveSession.tsx
@@ -8,8 +8,8 @@ const LiveSession = () => {
   const { jectalks, isError, isPending } = useJectalksQuery();
 
   return (
-    <div className='bg-(--semantic-surface-standard) pt-(--semantic-spacing-64) flex min-h-dvh flex-col items-center py-(--semantic-margin-2xl)'>
-      <section className='flex w-full max-w-[922px] flex-col items-center gap-(--semantic-spacing-32) px-(--semantic-margin-lg) pb-(--semantic-spacing-80) pt-(--semantic-margin-xl)'>
+    <div className='flex min-h-dvh flex-col items-center bg-(--semantic-surface-standard) px-(--semantic-margin-lg) py-(--semantic-margin-2xl) pt-(--semantic-spacing-64)'>
+      <section className='flex w-full max-w-[922px] flex-col items-center gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-spacing-80)'>
         <div className='flex w-full flex-col items-start gap-(--semantic-spacing-16)'>
           <Hero size='xs' textAlign='left'>
             라이브 세션
@@ -48,16 +48,16 @@ const LiveSession = () => {
                 <Card.Preset.Post.Link
                   key={session.id}
                   layout='horizontal'
-                  title={session.name}
-                  body=''
+                  title={session.title}
+                  body={session.description}
                   author={session.summary}
-                  date='YouTube'
-                  href={session.youtubeUrl}
+                  date={session.contentType}
+                  href={session.contentUrl}
                   target='_blank'
                   rel='noopener noreferrer'
                   image={{
-                    src: session.imageUrl,
-                    alt: session.name,
+                    src: session.thumbnailUrl,
+                    alt: session.title,
                   }}
                 />
               ))}

--- a/apps/web/src/pages/MiniStudy.tsx
+++ b/apps/web/src/pages/MiniStudy.tsx
@@ -8,10 +8,12 @@ const MiniStudy = () => {
   const { miniStudies, isError, isPending } = useMiniStudiesQuery();
 
   return (
-    <div className='bg-(--semantic-surface-standard) flex min-h-dvh flex-col items-center pt-(--semantic-spacing-64) py-(--semantic-margin-2xl)'>
-      <section className='gap-(--semantic-spacing-32) flex w-full max-w-[922px] flex-col items-center pt-(--semantic-margin-xl) pb-(--semantic-spacing-80) px-(--semantic-margin-lg)'>
-        <div className='gap-(--semantic-spacing-16) flex w-full flex-col items-start'>
-          <Hero size='xs' textAlign='left'>미니 스터디</Hero>
+    <div className='flex min-h-dvh flex-col items-center bg-(--semantic-surface-standard) px-(--semantic-margin-lg) py-(--semantic-margin-2xl) pt-(--semantic-spacing-64)'>
+      <section className='flex w-full max-w-[922px] flex-col items-center gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-spacing-80)'>
+        <div className='flex w-full flex-col items-start gap-(--semantic-spacing-16)'>
+          <Hero size='xs' textAlign='left'>
+            미니 스터디
+          </Hero>
           <Title size='xs' textAlign='left'>
             활동 중 팀 프로젝트와 병행할 수 있는, 성장을 위한 스터디입니다.
           </Title>
@@ -33,14 +35,14 @@ const MiniStudy = () => {
               </Label>
             </div>
           ) : (
-            <div className='gap-(--semantic-spacing-16) flex w-full flex-col'>
+            <div className='flex w-full flex-col gap-(--semantic-spacing-16)'>
               {miniStudies.map(study => (
                 <Card.Preset.Post.Link
                   key={study.id}
                   layout='horizontal'
                   title={study.name}
-                  body=''
-                  author={study.summary}
+                  body={study.summary}
+                  author={study.tag}
                   date=''
                   href={study.linkUrl}
                   target='_blank'

--- a/apps/web/src/types/apis/jectalk.ts
+++ b/apps/web/src/types/apis/jectalk.ts
@@ -2,9 +2,11 @@ import type { Sort } from "./sort";
 
 export interface Jectalk {
   id: number;
-  name: string;
-  youtubeUrl: string;
-  imageUrl: string;
+  title: string;
+  description: string;
+  contentUrl: string;
+  contentType: string;
+  thumbnailUrl: string;
   summary: string;
 }
 

--- a/apps/web/src/types/apis/miniStudy.ts
+++ b/apps/web/src/types/apis/miniStudy.ts
@@ -6,6 +6,7 @@ export interface MiniStudy {
   linkUrl: string;
   imageUrl: string;
   summary: string;
+  tag: string;
 }
 
 export interface MiniStudiesResponse {


### PR DESCRIPTION
## 💡 작업 내용
- [x] /mini-studies API 스펙 변경에 따른 설명(summary) 및 태그(tag) 필드 추가
- [x] /jectalks API 스펙 변경에 따른 필드명 변경 및 description, contentType 추가
- [x] 미니 스터디, 라이브 세션 페이지 레이아웃 너비 수정
- [x] Activity 페이지(레거시) 타입 에러 수정

<img width="1470" height="760" alt="스크린샷 2026-01-07 오후 7 53 56" src="https://github.com/user-attachments/assets/f0861028-be0e-468a-a279-b3a163efae51" />

## 💡 자세한 설명

### 레이아웃 수정
- section에 패딩이 적용되어 있어 실제 콘텐츠 너비가 922px보다 작아지는 문제가 있었습니다.
- 패딩 (px-(--semantic-margin-lg))을 외부 div로 이동하여 section이 정확히 922px 너비를 유지하도록 수정했습니다.

### 미니 스터디 API 스펙 변경 반영
- 기존 API 스펙 변경으로 누락되었던 summary와 tag 필드를 반영했습니다.
- MiniStudy 타입에 tag: string 속성 추가
- 카드 컴포넌트 매핑 변경
  - body ← study.summary (설명)
  - author ← study.tag (태그)

### 라이브 세션 API 스펙 변경 반영
- Jectalk 타입 필드명 변경 및 새 필드 추가
  - name → title
  - youtubeUrl → contentUrl
  - imageUrl → thumbnailUrl
  - description, contentType 추가

### 카드 컴포넌트 매핑 변경
  - body ← session.description (설명)
  - date ← session.contentType (콘텐츠 타입)

### Activity 페이지(레거시)
- Jectalk 타입 변경에 따른 빌드 에러 수정

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #365