### PR TITLE
feat: 지원서 작성 페이지 내 데이터 필드 추가

### DIFF
--- a/apps/web/src/apis/apply/schemas.ts
+++ b/apps/web/src/apis/apply/schemas.ts
@@ -85,6 +85,7 @@ export const questionSchema = z.object({
   inputType: questionInputTypeSchema,
   isRequired: z.boolean(),
   title: z.string(),
+  subtitle: z.string().nullable(),
   label: z.string(),
   selectOptions: z.array(z.string()).nullable(),
   inputHint: z.string(),

--- a/apps/web/src/features/apply/steps/registration/components/FileQuestionField.tsx
+++ b/apps/web/src/features/apply/steps/registration/components/FileQuestionField.tsx
@@ -119,7 +119,7 @@ export function FileQuestionField({
   };
 
   return (
-    <QuestionFieldWrapper title={question.title} isRequired={question.isRequired}>
+    <QuestionFieldWrapper title={question.title} subtitle={question.subtitle} isRequired={question.isRequired}>
       <div className='flex flex-col items-start gap-(--semantic-spacing-16) self-stretch rounded-(--semantic-radius-6) border border-(--semantic-stroke-alpha-subtle) bg-(--semantic-surface-standard) p-(--semantic-spacing-12)'>
         {portfolios.length > 0 && (
           <div className='flex flex-col gap-(--semantic-spacing-8) self-stretch'>

--- a/apps/web/src/features/apply/steps/registration/components/QuestionFieldWrapper.tsx
+++ b/apps/web/src/features/apply/steps/registration/components/QuestionFieldWrapper.tsx
@@ -3,21 +3,34 @@ import type { ReactNode } from "react";
 
 interface QuestionFieldWrapperProps {
   title: string;
+  subtitle?: string | null;
   isRequired?: boolean;
   children: ReactNode;
 }
 
-export function QuestionFieldWrapper({ title, isRequired, children }: QuestionFieldWrapperProps) {
+export function QuestionFieldWrapper({
+  title,
+  subtitle,
+  isRequired,
+  children,
+}: QuestionFieldWrapperProps) {
   return (
     <fieldset className='flex flex-col gap-(--semantic-spacing-16) self-stretch'>
-      <Title size='xs' textAlign='left'>
-        {title}
-        {isRequired && (
-          <span className='text-feedback-notifying-neutral-light dark:text-feedback-notifying-neutral-dark'>
-            *
-          </span>
+      <div className='flex flex-col items-start gap-(--semantic-spacing-8) self-stretch'>
+        <Title size='xs' textAlign='left'>
+          {title}
+          {isRequired && (
+            <span className='text-feedback-notifying-neutral-light dark:text-feedback-notifying-neutral-dark'>
+              *
+            </span>
+          )}
+        </Title>
+        {subtitle && (
+          <p className='text-(--semantic-object-alternative) text-[0.875rem] font-normal leading-[1.375rem] tracking-[0.0035rem]'>
+            {subtitle}
+          </p>
         )}
-      </Title>
+      </div>
       {children}
     </fieldset>
   );

--- a/apps/web/src/features/apply/steps/registration/components/TextQuestionField.tsx
+++ b/apps/web/src/features/apply/steps/registration/components/TextQuestionField.tsx
@@ -22,7 +22,7 @@ export function TextQuestionField({ question, value, onChange }: TextQuestionFie
   const helperText = hasError ? APPLY_MESSAGE.invalid.exceedText : "";
 
   return (
-    <QuestionFieldWrapper title={question.title} isRequired={question.isRequired}>
+    <QuestionFieldWrapper title={question.title} subtitle={question.subtitle} isRequired={question.isRequired}>
       <InputArea
         placeholder={question.inputHint}
         maxLength={question.maxTextLength ?? undefined}

--- a/apps/web/src/features/apply/steps/registration/components/UrlQuestionField.tsx
+++ b/apps/web/src/features/apply/steps/registration/components/UrlQuestionField.tsx
@@ -42,7 +42,7 @@ export function UrlQuestionField({ question, value, onChange }: UrlQuestionField
   const helperText = hasUrlError ? APPLY_MESSAGE.invalid.url : "";
 
   return (
-    <QuestionFieldWrapper title={question.title} isRequired={question.isRequired}>
+    <QuestionFieldWrapper title={question.title} subtitle={question.subtitle} isRequired={question.isRequired}>
       <TextField
         placeholder={question.inputHint}
         value={value}


### PR DESCRIPTION
## 💡 작업 내용

- [x] [GET] /apply/questions 지원서 문항 목록 조회 에서 받아오는 객체에 subTitle 추가(API 스펙 변경)
- [x] 문항 폼 컴포넌트에 subtitle prop 추가

## 💡 자세한 설명
### ✅ 지원서 문항 목록 조회 스키마 변경
```typescript
//schema.ts
export const questionSchema = z.object({
  id: z.number(),
  sequence: z.number(),
  inputType: questionInputTypeSchema,
  isRequired: z.boolean(),
  title: z.string(),
  subtitle: z.string().nullable(),
...
```

- [GET] /apply/questions에 받아오는 객체 데이터의 구조가 subtitle이 비어있을 경우 null로 보내줍니다. 따라서 스키마 정의 시 subtitle을 추가하고 nullable로 null 일 수 있다는 점을 명시하였습니다.

### ✅ 지원 문항 폼 구조 변경
- 디자인 의도에 맞춰 Title과 subtitle을 감싸는 `<div>` 를 생성하여 해당 태그안에 Title과 subtitle이 들어가도록 변경하였습니다. 해당 작업은 폼 필드가 공통적으로 사용하는 `QuestionFieldWrapper`래퍼 컴포넌트에 수행하였습니다.

<img width="1154" height="746" alt="스크린샷 2026-01-15 오후 8 21 57" src="https://github.com/user-attachments/assets/52426ff2-e596-4205-a3ab-36a7686ee2ef" />



## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #271 
