### PR TITLE
feat: 4기 모집 마감

### DIFF
--- a/apps/web/src/pages/ApplyGuidePage.tsx
+++ b/apps/web/src/pages/ApplyGuidePage.tsx
@@ -136,13 +136,13 @@ function ApplyGuidePage() {
     setSearchParams(newParams, { replace: true });
   };
 
-  const handleApply = () => {
-    void navigate(`${PATH.applyFunnel}/${jobFamily}`);
-  };
+  // const handleApply = () => {
+  //   void navigate(`${PATH.applyFunnel}/${jobFamily}`);
+  // };
 
-  const handleContinue = () => {
-    void navigate(`${PATH.applyContinue}/${jobFamily}`);
-  };
+  // const handleContinue = () => {
+  //   void navigate(`${PATH.applyContinue}/${jobFamily}`);
+  // };
 
   const handleBack = () => {
     void navigate(PATH.applyList);
@@ -194,7 +194,6 @@ function ApplyGuidePage() {
             variant='solid'
             hierarchy='accent'
             size='lg'
-            onClick={handleApply}
             className='flex-1'
             disabled
           >

--- a/apps/web/src/pages/ApplyGuidePage.tsx
+++ b/apps/web/src/pages/ApplyGuidePage.tsx
@@ -191,22 +191,14 @@ function ApplyGuidePage() {
 
         <div className='flex gap-3 self-stretch'>
           <BlockButton.Basic
-            variant='outlined'
-            hierarchy='secondary'
-            size='lg'
-            onClick={handleContinue}
-          >
-            이어서 작성하기
-          </BlockButton.Basic>
-          <BlockButton.Basic
             variant='solid'
             hierarchy='accent'
             size='lg'
-            suffixIcon='arrow-right-line'
             onClick={handleApply}
             className='flex-1'
+            disabled
           >
-            지원서 작성하기
+            모집이 마감되었습니다
           </BlockButton.Basic>
         </div>
       </section>


### PR DESCRIPTION
## 💡 작업 내용

- [x] 4기 모집 마감 처리

## 💡 자세한 설명

4기 모집이 1월 18일까지이기 때문에 포지션 별 지원 안내 페이지를 수정합니다. 
- `이어서 작성하기` 버튼 제거 
- `지원서 작성하기` 버튼 `모집이 마감되었습니다`로 변경 후 비활성화 처리

<img width="895" height="474" alt="image" src="https://github.com/user-attachments/assets/f344a613-48e8-47e2-b5ad-9e33264c4e77" />



## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #375 
