### PR TITLE
fix: 지원 플로우 QA 버그(하) 수정

### DIFF
--- a/apps/web/src/features/apply/steps/ApplicantInfoStep.tsx
+++ b/apps/web/src/features/apply/steps/ApplicantInfoStep.tsx
@@ -17,6 +17,7 @@ import { APPLY_TITLE } from "@/constants/applyPageData";
 import { ApplyStepLayout } from "@/features/shared/components";
 import { useMemberProfileMutation } from "@/hooks/apply";
 import { useApplyApplicantInfoForm } from "@/hooks/useApplyApplicantInfoForm";
+import { phoneNumberCompleteSchema } from "@/schema/applySchema";
 import type { ApplicantInfoContext, ProfileData } from "@/types/funnel";
 import {
   CAREER_DETAILS_OPTIONS,
@@ -42,7 +43,7 @@ interface ApplicantInfoStepProps {
 }
 
 export function ApplicantInfoStep({ context, onNext, onBack }: ApplicantInfoStepProps) {
-  const { control, handleSubmit, formState } = useApplyApplicantInfoForm();
+  const { control, handleSubmit, formState, setError } = useApplyApplicantInfoForm();
 
   const [openSelect, setOpenSelect] = useState<SelectFieldName | null>(null);
 
@@ -127,7 +128,21 @@ export function ApplicantInfoStep({ context, onNext, onBack }: ApplicantInfoStep
                 placeholder='01012345678'
                 helperText={fieldState.error?.message ?? ""}
                 value={field.value ?? ""}
-                onChange={field.onChange}
+                onChange={e => {
+                  const filtered = e.target.value.replace(/[^0-9-]/g, "");
+                  field.onChange(filtered);
+                }}
+                onBlur={() => {
+                  field.onBlur();
+
+                  const result = phoneNumberCompleteSchema.safeParse(field.value);
+
+                  if (!result.success) {
+                    setError("phoneNumber", {
+                      message: result.error.issues[0].message,
+                    });
+                  }
+                }}
               />
             )}
           />

--- a/apps/web/src/features/apply/steps/applicationInfo/ApplicantInfoStep.tsx
+++ b/apps/web/src/features/apply/steps/applicationInfo/ApplicantInfoStep.tsx
@@ -1,16 +1,7 @@
-import {
-  BlockButton,
-  Checkbox,
-  Icon,
-  Label,
-  Select,
-  SelectField,
-  TextField,
-  toastController,
-  Tooltip,
-} from "@ject/jds";
-import { useState } from "react";
+import { BlockButton, Checkbox, Icon, Label, TextField, toastController, Tooltip } from "@ject/jds";
 import { Controller } from "react-hook-form";
+
+import { SelectController } from "./components/SelectController";
 
 import { APPLY_MESSAGE } from "@/constants/applyMessages";
 import { APPLY_TITLE } from "@/constants/applyPageData";
@@ -24,15 +15,9 @@ import {
   EXPERIENCE_PERIOD_OPTIONS,
   INTERESTED_DOMAIN_OPTIONS,
   REGION_OPTIONS,
-  findLabelByValue,
-  type CareerDetails,
-  type ExperiencePeriod,
   type InterestedDomain,
-  type Region,
 } from "@/types/funnel";
 import { deriveInputValidation } from "@/utils/validationHelpers";
-
-type SelectFieldName = "careerDetails" | "region" | "experiencePeriod";
 
 const MAX_SELECTABLE_DOMAINS = 3;
 
@@ -45,8 +30,6 @@ interface ApplicantInfoStepProps {
 export function ApplicantInfoStep({ context, onNext, onBack }: ApplicantInfoStepProps) {
   const { control, handleSubmit, formState, setError } = useApplyApplicantInfoForm();
 
-  const [openSelect, setOpenSelect] = useState<SelectFieldName | null>(null);
-
   const { mutate: saveProfile } = useMemberProfileMutation({
     onSuccess: () => {
       onNext();
@@ -58,14 +41,6 @@ export function ApplicantInfoStep({ context, onNext, onBack }: ApplicantInfoStep
 
   const onSubmit = (data: ProfileData) => {
     saveProfile({ ...data, jobFamily: context.jobFamily });
-  };
-
-  const toggleSelect = (name: SelectFieldName) => {
-    setOpenSelect(prev => (prev === name ? null : name));
-  };
-
-  const closeSelect = () => {
-    setOpenSelect(null);
   };
 
   return (
@@ -150,39 +125,18 @@ export function ApplicantInfoStep({ context, onNext, onBack }: ApplicantInfoStep
             name='careerDetails'
             control={control}
             render={({ field }) => (
-              <div className='relative flex flex-col'>
-                <SelectField
-                  label={
-                    <>
-                      지원자 신분
-                      <span className='text-feedback-notifying-neutral-light dark:text-feedback-notifying-neutral-dark'>
-                        *
-                      </span>
-                    </>
-                  }
-                  placeholder='현재 신분을 선택해주세요'
-                  value={findLabelByValue(CAREER_DETAILS_OPTIONS, field.value)}
-                  isOpen={openSelect === "careerDetails"}
-                  onClick={() => toggleSelect("careerDetails")}
-                />
-                {openSelect === "careerDetails" && (
-                  <div className='absolute top-[calc(100%+8px)] right-0 left-0 z-10'>
-                    <Select
-                      value={field.value}
-                      onChange={value => {
-                        field.onChange(value as CareerDetails);
-                        closeSelect();
-                      }}
-                    >
-                      {CAREER_DETAILS_OPTIONS.map(option => (
-                        <Select.Label key={option.value} value={option.value}>
-                          {option.label}
-                        </Select.Label>
-                      ))}
-                    </Select>
-                  </div>
-                )}
-              </div>
+              <SelectController
+                label={
+                  <>
+                    지원자 신분
+                    <span className='text-feedback-notifying-neutral-light'>*</span>
+                  </>
+                }
+                placeholder='현재 신분을 선택해주세요'
+                value={field.value}
+                options={CAREER_DETAILS_OPTIONS}
+                onChange={value => field.onChange(value)}
+              />
             )}
           />
 
@@ -190,39 +144,20 @@ export function ApplicantInfoStep({ context, onNext, onBack }: ApplicantInfoStep
             name='region'
             control={control}
             render={({ field }) => (
-              <div className='relative flex flex-col'>
-                <SelectField
-                  label={
-                    <>
-                      거주 지역
-                      <span className='text-feedback-notifying-neutral-light dark:text-feedback-notifying-neutral-dark'>
-                        *
-                      </span>
-                    </>
-                  }
-                  placeholder='현재 거주하는 지역을 선택해주세요'
-                  value={field.value ? findLabelByValue(REGION_OPTIONS, field.value) : ""}
-                  isOpen={openSelect === "region"}
-                  onClick={() => toggleSelect("region")}
-                />
-                {openSelect === "region" && (
-                  <div className='absolute top-[calc(100%+8px)] right-0 left-0 z-10'>
-                    <Select
-                      value={field.value ?? ""}
-                      onChange={value => {
-                        field.onChange(value as Region);
-                        closeSelect();
-                      }}
-                    >
-                      {REGION_OPTIONS.map(option => (
-                        <Select.Label key={option.value} value={option.value}>
-                          {option.label}
-                        </Select.Label>
-                      ))}
-                    </Select>
-                  </div>
-                )}
-              </div>
+              <SelectController
+                label={
+                  <>
+                    거주 지역
+                    <span className='text-feedback-notifying-neutral-light dark:text-feedback-notifying-neutral-dark'>
+                      *
+                    </span>
+                  </>
+                }
+                placeholder='현재 신분을 선택해주세요'
+                value={field.value}
+                options={REGION_OPTIONS}
+                onChange={value => field.onChange(value)}
+              />
             )}
           />
 
@@ -230,46 +165,25 @@ export function ApplicantInfoStep({ context, onNext, onBack }: ApplicantInfoStep
             name='experiencePeriod'
             control={control}
             render={({ field }) => (
-              <div className='relative flex flex-col'>
-                <SelectField
-                  label={
-                    <div className='flex items-center gap-(--semantic-spacing-4) text-(--semantic-object-normal)'>
-                      직무 관련 경험 기간
-                      <Tooltip.Provider>
-                        <Tooltip.Root>
-                          <Tooltip.Trigger className='text-(--semantic-object-alternative)'>
-                            <Icon name='information-fill' size='2xs' color='inherit' />
-                          </Tooltip.Trigger>
-                          <Tooltip.Content>학습과 경력을 모두 포함한 기간</Tooltip.Content>
-                        </Tooltip.Root>
-                      </Tooltip.Provider>
-                    </div>
-                  }
-                  placeholder='직무 관련 경험 기간을 선택해주세요'
-                  value={
-                    field.value ? findLabelByValue(EXPERIENCE_PERIOD_OPTIONS, field.value) : ""
-                  }
-                  isOpen={openSelect === "experiencePeriod"}
-                  onClick={() => toggleSelect("experiencePeriod")}
-                />
-                {openSelect === "experiencePeriod" && (
-                  <div className='absolute top-[calc(100%+8px)] right-0 left-0 z-10'>
-                    <Select
-                      value={field.value ?? ""}
-                      onChange={value => {
-                        field.onChange(value as ExperiencePeriod);
-                        closeSelect();
-                      }}
-                    >
-                      {EXPERIENCE_PERIOD_OPTIONS.map(option => (
-                        <Select.Label key={option.value} value={option.value}>
-                          {option.label}
-                        </Select.Label>
-                      ))}
-                    </Select>
+              <SelectController
+                label={
+                  <div className='flex items-center gap-(--semantic-spacing-4) text-(--semantic-object-normal)'>
+                    직무 관련 경험 기간
+                    <Tooltip.Provider>
+                      <Tooltip.Root>
+                        <Tooltip.Trigger className='text-(--semantic-object-alternative)'>
+                          <Icon name='information-fill' size='2xs' color='inherit' />
+                        </Tooltip.Trigger>
+                        <Tooltip.Content>학습과 경력을 모두 포함한 기간</Tooltip.Content>
+                      </Tooltip.Root>
+                    </Tooltip.Provider>
                   </div>
-                )}
-              </div>
+                }
+                placeholder='현재 신분을 선택해주세요'
+                value={field.value}
+                options={EXPERIENCE_PERIOD_OPTIONS}
+                onChange={value => field.onChange(value)}
+              />
             )}
           />
 

--- a/apps/web/src/features/apply/steps/applicationInfo/components/SelectController.tsx
+++ b/apps/web/src/features/apply/steps/applicationInfo/components/SelectController.tsx
@@ -1,0 +1,64 @@
+import { Select, SelectField } from "@ject/jds";
+import type { ReactNode } from "react";
+import { useRef } from "react";
+
+import useCloseOutside from "@/hooks/useCloseOutside";
+import { findLabelByValue } from "@/types/profile";
+
+type SelectOption = {
+  value: string;
+  label: string;
+};
+
+interface SelectControllerProps<TOptions extends readonly SelectOption[]> {
+  label: ReactNode;
+  placeholder: string;
+  options: TOptions;
+  value?: TOptions[number]["value"];
+  onChange: (value: TOptions[number]["value"]) => void;
+}
+// TODO: Select 키보드 접근성
+export function SelectController<TOptions extends readonly SelectOption[]>({
+  label,
+  placeholder,
+  options,
+  value,
+  onChange,
+}: SelectControllerProps<TOptions>) {
+  const inputRef = useRef<HTMLDivElement>(null);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const { isOpen, onToggle, onClose } = useCloseOutside([inputRef, dropdownRef]);
+
+  return (
+    <div className='relative flex flex-col'>
+      <SelectField
+        ref={inputRef}
+        label={label}
+        placeholder={placeholder}
+        value={value ? findLabelByValue(options, value) : ""}
+        isOpen={isOpen}
+        onClick={onToggle}
+      />
+
+      {isOpen && (
+        <div className='absolute top-[calc(100%+8px)] right-0 left-0 z-10'>
+          <Select
+            ref={dropdownRef}
+            value={value ?? ""}
+            onChange={v => {
+              onChange(v as TOptions[number]["value"]);
+              onClose();
+            }}
+          >
+            {options.map(option => (
+              <Select.Label key={option.value} value={option.value}>
+                {option.label}
+              </Select.Label>
+            ))}
+          </Select>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/features/apply/steps/applicationInfo/index.ts
+++ b/apps/web/src/features/apply/steps/applicationInfo/index.ts
@@ -1,0 +1,1 @@
+export { ApplicantInfoStep } from "./ApplicantInfoStep";

--- a/apps/web/src/features/apply/steps/index.ts
+++ b/apps/web/src/features/apply/steps/index.ts
@@ -1,8 +1,5 @@
 // ApplyFunnel (신규 유저)
-export {
-  EmailVerificationStep,
-  type EmailVerificationEvents,
-} from "./EmailVerificationStep";
+export { EmailVerificationStep, type EmailVerificationEvents } from "./EmailVerificationStep";
 export { PinSetupStep } from "./PinSetupStep";
 
 // ContinueWritingFunnel (이어쓰기)
@@ -12,6 +9,6 @@ export {
 } from "./IdentityVerificationStep";
 
 // 공통 (두 Funnel에서 공유)
-export { ApplicantInfoStep } from "./ApplicantInfoStep";
+export { ApplicantInfoStep } from "./applicationInfo";
 export { RegistrationStep } from "./registration";
 export { CompleteStep } from "./CompleteStep";

--- a/apps/web/src/features/shared/components/AuthCodeForm.tsx
+++ b/apps/web/src/features/shared/components/AuthCodeForm.tsx
@@ -76,7 +76,14 @@ export function AuthCodeForm({
             timer.start(180);
           }
         },
-        onError: () => {
+        onError: e => {
+          const errorStatus = e.response?.data.status;
+
+          if (errorStatus === "TOO_MANY_EMAIL_REQUESTS") {
+            toastController.destructive("인증번호 발송 실패", "잠시 후 다시 시도해주세요.");
+            return;
+          }
+
           toastController.destructive(
             "인증번호 발송 실패",
             "일시적 오류일 수 있으니 다시 시도해주세요.",

--- a/apps/web/src/features/shared/components/AuthCodeForm.tsx
+++ b/apps/web/src/features/shared/components/AuthCodeForm.tsx
@@ -11,6 +11,7 @@ import {
 } from "@/hooks/apply";
 import { useApplyEmailForm } from "@/hooks/useApplyEmailForm";
 import { useCountdownTimer } from "@/hooks/useCountdownTimer";
+import { handleError } from "@/utils/errorLogger";
 import { deriveInputValidation } from "@/utils/validationHelpers";
 
 const formatTime = (seconds: number) => {
@@ -76,16 +77,18 @@ export function AuthCodeForm({
             timer.start(180);
           }
         },
-        onError: e => {
-          const errorStatus = e.response?.data.status;
+        onError: error => {
+          const errorStatus = error.response?.data.status;
 
           if (errorStatus === "TOO_MANY_EMAIL_REQUESTS") {
-            toastController.destructive("인증번호 발송 실패", "잠시 후 다시 시도해주세요.");
+            handleError(error, "인증번호 발송 제한");
+            toastController.destructive("인증번호 발송 제한", "잠시 후 다시 시도해주세요.");
             return;
           }
 
+          handleError(error, "인증 시도 실패");
           toastController.destructive(
-            "인증번호 발송 실패",
+            "인증 시도 실패",
             "일시적 오류일 수 있으니 다시 시도해주세요.",
           );
         },

--- a/apps/web/src/hooks/apply/useSendAuthCodeMutation.ts
+++ b/apps/web/src/hooks/apply/useSendAuthCodeMutation.ts
@@ -1,11 +1,13 @@
 import { toastController } from "@ject/jds";
 import { useMutation, type UseMutationOptions } from "@tanstack/react-query";
+import type { AxiosError } from "axios";
 
 import { applyApi, applyMutationKeys } from "@/apis/apply";
 import type { EmailAuthPayload } from "@/types/apis/apply";
+import type { ApiResponse } from "@/types/apis/response";
 
 type UseSendAuthCodeMutationOptions = Omit<
-  UseMutationOptions<null, Error, EmailAuthPayload, unknown>,
+  UseMutationOptions<null, AxiosError<ApiResponse<string[]>>, EmailAuthPayload, unknown>,
   "mutationKey" | "mutationFn"
 >;
 

--- a/apps/web/src/hooks/useCloseOutside.ts
+++ b/apps/web/src/hooks/useCloseOutside.ts
@@ -4,6 +4,14 @@ import { useEffect, useState } from "react";
 const useCloseOutside = <T extends HTMLElement>(refs: RefObject<T>[] | RefObject<T>) => {
   const [isOpen, setIsOpen] = useState(false);
 
+  const onClose = () => {
+    setIsOpen(false);
+  };
+
+  const onToggle = () => {
+    setIsOpen(prev => !prev);
+  };
+
   useEffect(() => {
     if (!isOpen) return;
 
@@ -26,7 +34,7 @@ const useCloseOutside = <T extends HTMLElement>(refs: RefObject<T>[] | RefObject
     return () => document.removeEventListener("mousedown", outsideClick);
   }, [refs, isOpen]);
 
-  return { isOpen, setIsOpen };
+  return { isOpen, setIsOpen, onClose, onToggle };
 };
 
 export default useCloseOutside;

--- a/apps/web/src/hooks/useCountdownTimer.ts
+++ b/apps/web/src/hooks/useCountdownTimer.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 interface UseCountdownTimerReturn {
   seconds: number;
@@ -8,18 +8,24 @@ interface UseCountdownTimerReturn {
 
 export function useCountdownTimer(): UseCountdownTimerReturn {
   const [seconds, setSeconds] = useState(0);
+  const endTimeRef = useRef<number | null>(null);
 
   useEffect(() => {
-    if (seconds <= 0) return;
+    if (!endTimeRef.current) return;
 
     const timer = setTimeout(() => {
-      setSeconds(prev => prev - 1);
+      const remainingSeconds = Math.max(0, Math.ceil((endTimeRef.current! - Date.now()) / 1000));
+
+      setSeconds(remainingSeconds);
     }, 1000);
 
     return () => clearTimeout(timer);
   }, [seconds]);
 
-  const start = (s: number) => setSeconds(s);
+  const start = (s: number) => {
+    endTimeRef.current = Date.now() + s * 1000;
+    setSeconds(s);
+  };
 
   return { seconds, isActive: seconds > 0, start };
 }

--- a/apps/web/src/schema/applySchema.ts
+++ b/apps/web/src/schema/applySchema.ts
@@ -74,6 +74,21 @@ const interestedDomainEnum = z.enum([
   "HR",
 ]);
 
+export const phoneNumberSchema = z
+  .string()
+  .min(1, "휴대폰 번호를 입력해주세요.")
+  .transform(val => val.replace(/[\s-]/g, ""))
+  .refine(val => val.length <= 2 || val.startsWith("010"), {
+    message: '"010"으로 시작하는 휴대폰 번호를 입력해주세요.',
+  })
+  .refine(val => val.length <= 11, {
+    message: '"010"을 포함해 총 11자리까지만 입력해주세요.',
+  });
+
+export const phoneNumberCompleteSchema = phoneNumberSchema.refine(val => val.length === 11, {
+  message: "휴대폰 번호를 끝까지 입력해주세요.",
+});
+
 export const applyApplicantInfoSchema = z.object({
   name: z
     .string()
@@ -81,19 +96,7 @@ export const applyApplicantInfoSchema = z.object({
     .max(5, "이름은 5자 이내로 작성해주세요.")
     .regex(/^[가-힣ㄱ-ㅎㅏ-ㅣ]+$/, "이름은 한글로 작성해주세요."),
 
-  phoneNumber: z
-    .string()
-    .min(1, "휴대폰 번호를 입력해주세요.")
-    .transform(val => val.replace(/[\s-]/g, ""))
-    .refine(val => /^\d+$/.test(val), {
-      message: "휴대폰 번호는 숫자만 입력해주세요.",
-    })
-    .refine(val => val.length <= 2 || val.startsWith("010"), {
-      message: '"010"으로 시작하는 휴대폰 번호를 입력해주세요.',
-    })
-    .refine(val => val.length <= 11, {
-      message: '"010"을 포함해 총 11자리까지만 입력해주세요.',
-    }),
+  phoneNumber: phoneNumberSchema,
 
   careerDetails: careerDetailsEnum,
 

--- a/apps/web/src/types/apis/response.ts
+++ b/apps/web/src/types/apis/response.ts
@@ -26,7 +26,8 @@ export type Status =
   | "RECRUIT_NOT_FOUND"
   | "TEMP_APPLICATION_NOT_FOUND"
   | "INVALID_CREDENTIALS"
-  | "VALIDATION_ERROR";
+  | "VALIDATION_ERROR"
+  | "TOO_MANY_EMAIL_REQUESTS";
 
 export interface ApiResponse<T> {
   status: Status;


### PR DESCRIPTION
## 💡 작업 내용

- [x] 인증번호 재발송 제한 안내 문구 추가 (인증번호 발송 실패로 통일되고 있는 상태)
- [x] 인증 번호 유효시간이 탭 전환 시 실제 시간과 동일하도록 수정 필요
- [x] 잘못된 전화번호 입력 시, 에러 메시지 추가 (10자리 미만, 특수문자 작성 시) 
- [x] 프로필 작성 페이지의 지원자 신분 선택 드롭다운 포커스 이탈 시에도 오버레이가 유지되는 버그 수정 필요
- [x] '이어서 작성하기' 페이지에서 이미 지원 완료된 지원자의 경우, 다이얼로그 액션 추가 -> 처리되어있음.

## 💡 자세한 설명

지원 플로우에서 발생한 버그(하)를 개선합니다.

### 인증번호 재발송 제한 안내 문구 추가 
`TOO_MANY_EMAIL_REQUESTS` 에러 코드에 대해 `인증번호 발송 제한 - 잠시 후 다시 시도해주세요.` 토스트가 출력되도록 수정했으며 handleError 에러 로깅 함수를 작성했습니다.    
기존에 있던 에러는 `인증 시도 실패 - 일시적 오류일 수 있으니 다시 시도해주세요.` 로 수정했습니다. 
 
### 브라우저 탭 전환 시에도 인증번호 유효시간이 정확하도록 타이머 수정
useCountdownTimer 함수를 아래와 같이 수정했습니다. 

- 기존 타이머의 문제
기존의 타이머는 단순히 1초씩 감소하는 구조로 탭 전환 시 JS 실행이 중지되어 타이머가 경과된 실제 시간과 일치하지 않는 문제가 있었음.

- 수정된 타이머
1초마다 1씩 감소하는 구조가 아닌 종료 시각 - 현재 시각으로 계산하여 시간이 얼마나 지났는지 계산하는 구조로 변경함.

### 휴대폰 번호 검증 로직 추가 
- 하이픈 및 숫자를 제외한 문자는 입력할 수 없도록 차단합니다.
- 입력 필드 포커싱 아웃되었을 때 휴대폰 번호 형식이 아니라면 에러메시지를 출력합니다.

### 프로필 작성 페이지 셀렉트 필드 포커스 이탈 시 목록이 닫히도록 수정
ApplicationInfoStep 에서 셀렉트 필드를 사용하는 코드를 SelectController 컴포넌트로 분리하는 리팩토링을 진행했습니다.    
SelectController 컴포넌트 내부에 useCloseOutside 훅을 사용하였습니다.  

### '이어서 작성하기' 페이지에서 이미 지원 완료된 지원자의 경우, 다이얼로그 액션 추가
해당 개선작업은 IdentifiyVerificationStep의 HandleCheckApplyStatus에서 이미 처리되어있음을 확인했습니다!


## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #373 
