### PR TITLE
refactor: MenuItem 컴포넌트 QA 대응

### DIFF
--- a/apps/web/src/features/apply/steps/registration/components/PortfolioFileItem.tsx
+++ b/apps/web/src/features/apply/steps/registration/components/PortfolioFileItem.tsx
@@ -1,5 +1,4 @@
-import { FileItem, IconButton } from "@jects/jds";
-import type { MouseEvent } from "react";
+import { FileItem } from "@jects/jds";
 
 import type { PortfolioFile } from "@/types/apis/application";
 import { changeFileSizeUnit } from "@/utils/changeFileSizeUnit";
@@ -14,8 +13,7 @@ export function PortfolioFileItem({ portfolio, onDelete }: PortfolioFileItemProp
     window.open(portfolio.fileUrl, "_blank", "noopener,noreferrer");
   };
 
-  const handleDelete = (e: MouseEvent) => {
-    e.stopPropagation();
+  const handleDelete = () => {
     onDelete(portfolio.id);
   };
 
@@ -24,11 +22,8 @@ export function PortfolioFileItem({ portfolio, onDelete }: PortfolioFileItemProp
       fileName={portfolio.fileName}
       fileSize={changeFileSizeUnit(Number(portfolio.fileSize), ["KB", "MB"], true)}
       onClick={openFile}
-      suffixButton={
-        <IconButton.Basic size='lg' hierarchy='tertiary' icon='close-line' onClick={handleDelete}>
-          삭제
-        </IconButton.Basic>
-      }
+      removeOnClick={handleDelete}
+      removeable
     />
   );
 }

--- a/packages/jds/src/components/FileItem/FileItem.stories.tsx
+++ b/packages/jds/src/components/FileItem/FileItem.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { FileItem } from "./FileItem";
 

--- a/packages/jds/src/components/FileItem/FileItem.stories.tsx
+++ b/packages/jds/src/components/FileItem/FileItem.stories.tsx
@@ -1,7 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { FileItem } from "./FileItem";
-import { IconButton } from "../Button/IconButton";
 
 const meta: Meta<typeof FileItem> = {
   title: "Components/FileItem",

--- a/packages/jds/src/components/FileItem/FileItem.tsx
+++ b/packages/jds/src/components/FileItem/FileItem.tsx
@@ -1,5 +1,4 @@
 import { forwardRef } from "react";
-import { IconButton } from "../Button/IconButton";
 
 import {
   FileErrorSpan,
@@ -11,6 +10,7 @@ import {
   FileSizeLabel,
 } from "./fileItem.styles";
 import type { FileItemProps } from "./fileItem.types";
+import { IconButton } from "../Button/IconButton";
 
 export const FileItem = forwardRef<HTMLButtonElement, FileItemProps>(
   (
@@ -22,10 +22,15 @@ export const FileItem = forwardRef<HTMLButtonElement, FileItemProps>(
       hasError = false,
       errorMessage,
       removeable = false,
+      removeOnClick,
       ...buttonRest
     },
     ref,
   ) => {
+    const handleRemoveClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+      e.stopPropagation();
+      removeOnClick?.();
+    };
     return (
       <FileItemWrapButton
         ref={ref}
@@ -63,7 +68,7 @@ export const FileItem = forwardRef<HTMLButtonElement, FileItemProps>(
               hierarchy='tertiary'
               size='lg'
               icon='close-line'
-              onClick={() => alert("클릭")}
+              onClick={handleRemoveClick}
             />}
           </FileItemDataContainer>
         </FileItemSectionDiv>

--- a/packages/jds/src/components/FileItem/FileItem.tsx
+++ b/packages/jds/src/components/FileItem/FileItem.tsx
@@ -27,10 +27,6 @@ export const FileItem = forwardRef<HTMLButtonElement, FileItemProps>(
     },
     ref,
   ) => {
-    const handleRemoveClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-      e.stopPropagation();
-      removeOnClick?.();
-    };
     return (
       <FileItemWrapButton
         ref={ref}

--- a/packages/jds/src/components/FileItem/fileItem.types.ts
+++ b/packages/jds/src/components/FileItem/fileItem.types.ts
@@ -24,4 +24,5 @@ export interface FileItemProps extends ComponentPropsWithoutRef<"button"> {
   hasError?: boolean;
   errorMessage?: ReactNode;
   removeable?: boolean;
+  removeOnClick?: () => void;
 }

--- a/packages/jds/src/components/Label/Label.style.ts
+++ b/packages/jds/src/components/Label/Label.style.ts
@@ -11,11 +11,13 @@ export const TEXT_ALIGN_MAPPING = {
 export type LabelSize = "lg" | "md" | "sm" | "xs";
 export type LabelTextAlign = keyof typeof TEXT_ALIGN_MAPPING;
 export type LabelWeight = "bold" | "normal" | "subtle";
+export type LabelCursor = "pointer" | "default";
 
 interface LabelStyledProps {
   $size: LabelSize;
   $textAlign: LabelTextAlign;
   $weight: LabelWeight;
+  $cursor: LabelCursor;
 }
 
 export const getLabelTokenKey = (
@@ -27,7 +29,7 @@ export const getLabelTokenKey = (
 
 export const LabelStyled = styled("label", {
   shouldForwardProp: prop => isPropValid(prop) && !prop.startsWith("$"),
-})<LabelStyledProps>(({ theme, $size, $textAlign, $weight }) => {
+})<LabelStyledProps>(({ theme, $size, $textAlign, $weight, $cursor = "default" }) => {
   const tokenKey = getLabelTokenKey($size, $weight);
   const justifyContent = TEXT_ALIGN_MAPPING[$textAlign];
 
@@ -36,7 +38,7 @@ export const LabelStyled = styled("label", {
     justifyContent,
     alignItems: "center",
     color: theme.color.semantic.object.bold,
-    cursor: "default",
+    cursor: $cursor,
     ...theme.textStyle[tokenKey],
   };
 });

--- a/packages/jds/src/components/Label/Label.tsx
+++ b/packages/jds/src/components/Label/Label.tsx
@@ -16,7 +16,7 @@ import { PolymorphicForwardRef } from "@/utils/forwardRef";
 
 //ToDo: Label의 기본 속성을 span 태그로 변경
 export const Label = PolymorphicForwardRef<"label", LabelOwnProps>(
-  ({ as, size = "md", textAlign = "left", weight = "normal", children, ...restProps }, ref) => {
+  ({ as, size = "md", textAlign = "left", weight = "normal", cursor = 'default', children, ...restProps }, ref) => {
     const Component = as || ("label" as ElementType);
 
     return (
@@ -26,6 +26,7 @@ export const Label = PolymorphicForwardRef<"label", LabelOwnProps>(
         $size={size}
         $textAlign={textAlign}
         $weight={weight}
+        $cursor={cursor}
         {...restProps}
       >
         {children}

--- a/packages/jds/src/components/Label/label.types.ts
+++ b/packages/jds/src/components/Label/label.types.ts
@@ -1,4 +1,4 @@
-import type { LabelSize, LabelTextAlign, LabelWeight } from "./Label.style";
+import type { LabelCursor, LabelSize, LabelTextAlign, LabelWeight } from "./Label.style";
 
 /**
  * @remarks
@@ -10,4 +10,5 @@ export type LabelOwnProps = {
   size?: LabelSize;
   textAlign?: LabelTextAlign;
   weight?: LabelWeight;
+  cursor?: LabelCursor;
 };

--- a/packages/jds/src/components/Menu/MenuItem/MenuItem.tsx
+++ b/packages/jds/src/components/Menu/MenuItem/MenuItem.tsx
@@ -1,9 +1,8 @@
 import { forwardRef } from "react";
 
-import { StyledImage, StyledMenuItemAnchor, StyledMenuItemButton } from "./menuItem.styles";
+import { StyledImage, StyledMenuItemAnchor, StyledMenuItemButton, MenuItemLabel } from "./menuItem.styles";
 import type { MenuItemAnchorProps, MenuItemButtonProps } from "./menuItem.types";
 import { Icon } from "../../Icon";
-import { Label } from "../../Label";
 
 const MenuItemButton = forwardRef<HTMLButtonElement, MenuItemButtonProps>(
   (
@@ -44,9 +43,9 @@ const MenuItemButton = forwardRef<HTMLButtonElement, MenuItemButtonProps>(
             $size={size}
           />
         )}
-        <Label as='span' size={size} textAlign='left' weight='normal' cursor={disabled ? 'default' : 'pointer'}>
+        <MenuItemLabel as='span' size={size} textAlign='left' weight='normal' cursor={disabled ? 'default' : 'pointer'}>
           {children}
-        </Label>
+        </MenuItemLabel>
         {suffixIconVisible && <Icon name={suffixIcon} size={size} />}
       </StyledMenuItemButton>
     );
@@ -93,9 +92,9 @@ const MenuItemAnchor = forwardRef<HTMLAnchorElement, MenuItemAnchorProps>(
             $size={size}
           />
         )}
-        <Label as='span' size={size} textAlign='left' weight='normal'>
+        <MenuItemLabel as='span' size={size} textAlign='left' weight='normal'>
           {children}
-        </Label>
+        </MenuItemLabel>
         {suffixIconVisible && <Icon name={suffixIcon} size={size} />}
       </StyledMenuItemAnchor>
     );

--- a/packages/jds/src/components/Menu/MenuItem/MenuItem.tsx
+++ b/packages/jds/src/components/Menu/MenuItem/MenuItem.tsx
@@ -44,7 +44,7 @@ const MenuItemButton = forwardRef<HTMLButtonElement, MenuItemButtonProps>(
             $size={size}
           />
         )}
-        <Label as='span' size={size} textAlign='left' weight='normal'>
+        <Label as='span' size={size} textAlign='left' weight='normal' cursor={disabled ? 'default' : 'pointer'}>
           {children}
         </Label>
         {suffixIconVisible && <Icon name={suffixIcon} size={size} />}

--- a/packages/jds/src/components/Menu/MenuItem/menuItem.styles.ts
+++ b/packages/jds/src/components/Menu/MenuItem/menuItem.styles.ts
@@ -6,6 +6,7 @@ import { InteractionLayer } from "utils";
 import type { StyledImageProps, StyledMenuItemProps } from "./menuItem.types";
 import { menuItemColorMap, menuItemImageSizeMap } from "./menuItem.variants";
 import { Image } from "../../Image";
+import { Label } from "../../Label";
 
 const createInteractionStyles = (
   theme: Theme,
@@ -121,3 +122,7 @@ export const StyledImage = styled(Image)<StyledImageProps>(({ $size }) => {
     width,
   };
 });
+
+export const MenuItemLabel = styled(Label)(() => ({
+  color: "inherit",
+}));


### PR DESCRIPTION
## 💡 작업 내용

### 🚑 QA 대응

- [x] `disabled` / `isSelected` / `isDestructive` 상태에서 MenuItem Label 색상이 변경되지 않는 이슈 수정
- [x] MenuItem 텍스트 영역 `cursor: pointer` 미적용 이슈 수정

### 🚀 추가 변경점

- [x] `Label` 컴포넌트에 `cursor` prop 추가
- [x] Storybook import 패키지명 수정 (`@storybook/react-vite` → `@storybook/react`)

## 💡 자세한 설명

### 1. MenuItem Label 색상 미반영 이슈

> `Label` 컴포넌트 내부에서 `color: theme.color.semantic.object.bold`를 명시적으로 선언하고 있어, 부모인 `StyledMenuItemButton`이 상태에 따라 색상을 변경해도 `Label`이 항상 bold 색상을 덮어쓰는 문제였습니다.

`MenuItemLabel`을 추가하고 `color: "inherit"`을 적용했습니다. 이렇게 하면 부모의 `menuItemColorMap` 결과값이 텍스트까지  상속됩니다.
```ts
// menuItem.styles.ts
export const MenuItemLabel = styled(Label)(() => ({
  color: "inherit",
}));
```

```
StyledMenuItemButton (color: disabled→subtle / selected→accent / destructive→red)
  └─ MenuItemLabel (color: inherit → 부모 색상 그대로 상속) 
```

### 2. MenuItem 텍스트 영역 cursor 미적용 이슈

> 브라우저의 텍스트 기본값이 `cursor: default`이기 때문에, 부모 버튼에 `cursor: pointer`가 지정되어 있어도 텍스트 자식 요소에서는 적용되지 않는 문제였습니다.
> `Label` 컴포넌트에 `cursor` prop을 추가하고, `MenuItemButton`에서 `disabled` 여부에 따라 명시적으로 전달하도록 수정했습니다.

```tsx
// MenuItem.tsx
<MenuItemLabel cursor={disabled ? 'default' : 'pointer'}>
  {children}
</MenuItemLabel>
```

### 3. `Label` cursor prop 추가

> 위 수정을 위해 `Label`에 `cursor?: LabelCursor` prop을 추가했습니다. `LabelCursor`는 `"pointer" | "default"` 타입으로 제한됩니다. 기본값은 `"default"`로, 기존 동작과 동일합니다.

## 📗 참고 자료 (선택)

없음

## 📢 리뷰 요구 사항 (선택)

없음

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
