### PR TITLE
refactor: EmptyState 컴포넌트 QA 대응

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,10 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "ject-official-website-client": "0.0.1",
+    "@ject/eslint-config": "0.0.1",
+    "@jects/jds": "0.0.1"
+  },
+  "changesets": []
+}

--- a/packages/jds/src/components/EmptyState/emptyState.styles.ts
+++ b/packages/jds/src/components/EmptyState/emptyState.styles.ts
@@ -8,10 +8,25 @@ import { Label } from "../Label";
 
 const variantStylesMap = {
   outlined: (theme: Theme): CSSObject => ({
-    border: `1px dashed ${theme.color.semantic.stroke.alpha.assistive}`,
+    backgroundColor: "transparent",
+    "&::after": {
+      content: '""',
+      position: "absolute",
+      inset: 0,
+      borderRadius: "inherit",
+      border: `1px dashed ${theme.color.semantic.stroke.alpha.assistive}`,
+      pointerEvents: "none",
+    },
   }),
   alpha: (theme: Theme): CSSObject => ({
-    backgroundColor: theme.color.semantic.fill.subtlest,
+    "&::after": {
+      content: '""',
+      position: "absolute",
+      inset: 0,
+      borderRadius: "inherit",
+      backgroundColor: theme.color.semantic.fill.subtlest,
+      pointerEvents: "none",
+    },
   }),
 };
 

--- a/packages/jds/src/components/EmptyState/emptyState.styles.ts
+++ b/packages/jds/src/components/EmptyState/emptyState.styles.ts
@@ -71,6 +71,7 @@ export const EmptyStateBodyTextP = styled("p", {
   display: "-webkit-box",
   WebkitBoxOrient: "vertical",
   WebkitLineClamp: 3,
+  margin: theme.scheme.semantic.spacing[0],
   overflow: "hidden",
   color: theme.color.semantic.object.assistive,
   textAlign: $layout === "vertical" ? "center" : "left",


### PR DESCRIPTION
## 💡 작업 내용

- [x] Figma와 시각적 레이아웃이 동일하지 않은 문제 수정

## 💡 자세한 설명

### 1. body text에 의도하지 않은 margin이 부여되어 있음

> 브라우저 기본 스타일인 margin-top 속성이 초기화되지 않아 발생한 문제였습니다. p 태그에 margin 속성을 0으로 명시해 해결했습니다.

<img width="644" height="190" alt="스크린샷 2026-02-23 오전 1 44 22" src="https://github.com/user-attachments/assets/8765bb0b-b611-4190-b8fa-62a58c28948c" />

### 2. outlined 일 때 외곽선이 내부로 설정되어 있지 않아 사이즈가 달라짐

> `border`가 컴포넌트 크기의 일부를 차지하여 발생하는 문제였습니다. 가상 요소로 `border`를 부여하도록 변경하여 컴포넌트 크기에 영향을 미치지 않도록 수정했습니다. 

<img width="1278" height="422" alt="image" src="https://github.com/user-attachments/assets/c5877b05-6eb7-4dcf-a0a5-daf1db9b4f7b" />

<img width="1290" height="424" alt="image" src="https://github.com/user-attachments/assets/c7da3d12-1900-4191-8b1a-1ddad0f5be8a" />

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #378 
