### PR TITLE
refactor: Field 컴포넌트 QA 대응 (Text, Select, Tag)

### DIFF
--- a/packages/jds/src/components/Badge/contentBadge/ContentBadge.tsx
+++ b/packages/jds/src/components/Badge/contentBadge/ContentBadge.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from "react";
+import type { MouseEvent, ReactNode } from "react";
 
 import {
   BadgeIcon,
@@ -24,6 +24,7 @@ export interface ContentBadgeBasicProps {
   badgeStyle?: ContentBadgeStyle;
   isMuted?: boolean;
   withIcon?: boolean;
+  onIconClick?: (e: MouseEvent<Element>) => void;
   children: ReactNode;
 }
 
@@ -33,6 +34,7 @@ const ContentBadgeBasic = ({
   badgeStyle = "solid",
   isMuted = false,
   withIcon = false,
+  onIconClick,
   children,
 }: ContentBadgeBasicProps) => {
   const iconSize = iconSizeMap[size];
@@ -63,6 +65,7 @@ const ContentBadgeBasic = ({
           hierarchy={hierarchy}
           badgeStyle={badgeStyle}
           isMuted={isMuted}
+          onClick={onIconClick}
         />
       )}
     </ContentBadgeBasicDiv>

--- a/packages/jds/src/components/Input/InputArea/InputArea.tsx
+++ b/packages/jds/src/components/Input/InputArea/InputArea.tsx
@@ -56,14 +56,7 @@ export const InputArea = forwardRef<HTMLTextAreaElement, InputAreaProps>(
             >
               {label}
             </StyledFieldLabel>
-            {labelIcon && (
-              <StyledLabelIcon
-                name={labelIcon}
-                size='2xs'
-                $disabled={isDisabled}
-                $readOnly={isReadOnly}
-              />
-            )}
+            {labelIcon && <StyledLabelIcon name={labelIcon} size='2xs' />}
           </StyledLabelContainer>
         )}
 

--- a/packages/jds/src/components/Input/SelectField/SelectField.stories.tsx
+++ b/packages/jds/src/components/Input/SelectField/SelectField.stories.tsx
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 import { BlockButton } from "components";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { SelectField } from "./index";
+import type { SelectFieldPublicProps } from "./selectField.types";
 
 const meta = {
   title: "Components/Input/SelectField",
@@ -81,30 +82,46 @@ const meta = {
 } satisfies Meta<typeof SelectField>;
 
 export default meta;
+
 type Story = StoryObj<typeof meta>;
+
+const Template = (args: SelectFieldPublicProps) => {
+  const [isOpen, setIsOpen] = useState(args.isOpen ?? false);
+  const [value, setValue] = useState(args.value ?? "");
+
+  useEffect(() => {
+    setIsOpen(args.isOpen!);
+  }, [args.isOpen]);
+
+  useEffect(() => {
+    setValue(args.value);
+  }, [args.value]);
+
+  const handleClick = () => {
+    const isNewState = !isOpen;
+    setIsOpen(isNewState);
+    args.onClick?.();
+  };
+
+  return (
+    <div style={{ width: "20rem" }}>
+      <SelectField {...args} value={value} isOpen={isOpen} onClick={handleClick} />
+    </div>
+  );
+};
 
 export const Default: Story = {
   args: {
+    label: "지역 선택",
+    placeholder: "거주 지역을 선택하세요",
+    helperText: "현재 거주하시는 지역을 선택해주세요",
+    isWithInfoIcon: true,
     value: "",
+    isOpen: false,
+    validation: "none",
+    style: "outlined",
   },
-  render: function Render() {
-    const [isOpen, setIsOpen] = useState(false);
-    const [value] = useState("");
-
-    return (
-      <div style={{ width: "20rem" }}>
-        <SelectField.Button
-          label='지역 선택'
-          placeholder='거주 지역을 선택하세요'
-          helperText='현재 거주하시는 지역을 선택해주세요'
-          value={value}
-          isOpen={isOpen}
-          onClick={() => setIsOpen(!isOpen)}
-          button={<BlockButton.Basic size='md'>확인</BlockButton.Basic>}
-        />
-      </div>
-    );
-  },
+  render: Template,
   parameters: {
     docs: {
       description: {

--- a/packages/jds/src/components/Input/SelectField/SelectField.stories.tsx
+++ b/packages/jds/src/components/Input/SelectField/SelectField.stories.tsx
@@ -49,9 +49,9 @@ const meta = {
       control: "text",
       description: "레이블 텍스트",
     },
-    labelIcon: {
-      control: "text",
-      description: "레이블 옆에 표시할 아이콘 (IconName)",
+    isWithInfoIcon: {
+      control: "boolean",
+      description: "info 아이콘 표시 여부",
     },
     helperText: {
       control: "text",
@@ -119,6 +119,7 @@ export const Default: Story = {
     value: "",
     isOpen: false,
     validation: "none",
+    interaction: "enabled",
     style: "outlined",
   },
   render: Template,
@@ -191,38 +192,6 @@ export const WithValue: Story = {
     docs: {
       description: {
         story: "**선택된 값 표시**\n\n값이 선택된 상태를 보여줍니다.",
-      },
-    },
-  },
-};
-
-export const WithLabelIcon: Story = {
-  args: {
-    value: "",
-  },
-  render: function Render() {
-    const [isOpen, setIsOpen] = useState(false);
-    const [value] = useState("");
-
-    return (
-      <div style={{ width: "20rem" }}>
-        <SelectField
-          label='중요한 선택'
-          labelIcon='information-line'
-          placeholder='옵션을 선택하세요'
-          helperText='중요한 정보이므로 신중히 선택하세요'
-          value={value}
-          isOpen={isOpen}
-          onClick={() => setIsOpen(!isOpen)}
-        />
-      </div>
-    );
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "**Label Icon 포함**\n\n레이블 옆에 아이콘을 추가할 수 있습니다. 어떤 IconName이든 사용 가능합니다.",
       },
     },
   },

--- a/packages/jds/src/components/Input/SelectField/SelectField.tsx
+++ b/packages/jds/src/components/Input/SelectField/SelectField.tsx
@@ -88,8 +88,8 @@ export const SelectField = forwardRef<HTMLDivElement, SelectFieldProps>(
       layout = "vertical",
       validation = "none",
       interaction = "enabled",
+      isWithInfoIcon = false,
       label,
-      labelIcon,
       helperText,
       ...restProps
     },
@@ -102,7 +102,7 @@ export const SelectField = forwardRef<HTMLDivElement, SelectFieldProps>(
         validation={validation}
         interaction={interaction}
         label={label}
-        labelIcon={labelIcon}
+        isWithInfoIcon={isWithInfoIcon}
         helperText={helperText}
       >
         <StyledFieldContainer $layout={layout}>

--- a/packages/jds/src/components/Input/SelectField/selectField.types.ts
+++ b/packages/jds/src/components/Input/SelectField/selectField.types.ts
@@ -5,7 +5,7 @@ import type { FieldPublicProps } from "../input.types";
 
 export interface SelectFieldPublicProps extends FieldPublicProps {
   label?: ReactNode;
-  labelIcon?: IconName;
+  isWithInfoIcon?: boolean;
   helperText?: string;
   value: string;
   placeholder?: string;
@@ -18,5 +18,6 @@ export interface SelectFieldPublicProps extends FieldPublicProps {
 export type SelectFieldProps = SelectFieldPublicProps;
 
 export interface SelectFieldButtonProps extends SelectFieldPublicProps {
+  labelIcon?: IconName;
   button: ReactNode;
 }

--- a/packages/jds/src/components/Input/TagField/TagField.stories.tsx
+++ b/packages/jds/src/components/Input/TagField/TagField.stories.tsx
@@ -1,10 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 import { BlockButton } from "components";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { TagField } from "./index";
-import type { Tag } from "./tagField.types";
+import type { Tag, TagFieldPublicProps } from "./tagField.types";
 
 const meta = {
   title: "Components/Input/TagField",
@@ -49,9 +49,9 @@ const meta = {
       control: "text",
       description: "레이블 텍스트",
     },
-    labelIcon: {
-      control: "text",
-      description: "레이블 옆에 표시할 아이콘 (IconName)",
+    isWithInfoIcon: {
+      control: "boolean",
+      description: "레이블 옆 Info 아이콘 표시 여부",
     },
     helperText: {
       control: "text",
@@ -78,30 +78,42 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const Template = (args: TagFieldPublicProps) => {
+  const [tags, setTags] = useState<Tag[]>(args.tags || []);
+
+  useEffect(() => {
+    setTags(args.tags || []);
+  }, [args.tags]);
+
+  const handleTagsChange = (newTags: Tag[]) => {
+    setTags(newTags);
+    args.onTagsChange?.(newTags);
+  };
+
+  return (
+    <div style={{ width: "20rem" }}>
+      <TagField {...args} tags={tags} onTagsChange={handleTagsChange} />
+    </div>
+  );
+};
+
 export const Default: Story = {
   args: {
-    tags: [],
-    onTagsChange: () => {},
-  },
-  render: function Render() {
-    const [tags, setTags] = useState<Tag[]>([
+    label: "관심 기술 스택",
+    placeholder: "태그를 입력하고 Enter를 누르세요",
+    helperText: "Enter로 추가, Backspace로 삭제",
+    tags: [
       { id: "1", label: "React" },
       { id: "2", label: "TypeScript" },
-    ]);
-
-    return (
-      <div style={{ width: "20rem" }}>
-        <TagField.Button
-          label='기술 스택'
-          placeholder='태그를 입력하세요'
-          helperText='Enter로 추가, Backspace로 삭제'
-          tags={tags}
-          onTagsChange={setTags}
-          button={<BlockButton.Basic size='md'>저장</BlockButton.Basic>}
-        />
-      </div>
-    );
+      { id: "3", label: "Design System" },
+    ],
+    validation: "none",
+    interaction: "enabled",
+    style: "outlined",
+    isWithInfoIcon: false,
+    onTagsChange: () => {},
   },
+  render: Template,
   parameters: {
     docs: {
       description: {
@@ -147,40 +159,6 @@ export const BasicTagField: Story = {
           "**기본 TagField**\n\n" +
           "Label + Tag Input + Helper가 모두 포함된 완전한 TagField입니다.\n" +
           "Controlled Pattern 전용: tags와 onTagsChange는 필수입니다.",
-      },
-    },
-  },
-};
-
-export const WithLabelIcon: Story = {
-  args: {
-    tags: [],
-    onTagsChange: () => {},
-  },
-  render: function Render() {
-    const [tags, setTags] = useState<Tag[]>([
-      { id: "1", label: "Frontend" },
-      { id: "2", label: "Backend" },
-    ]);
-
-    return (
-      <div style={{ width: "20rem" }}>
-        <TagField
-          label='개발 분야'
-          labelIcon='information-line'
-          placeholder='태그를 입력하세요'
-          helperText='관심있는 개발 분야를 태그로 추가하세요'
-          tags={tags}
-          onTagsChange={setTags}
-        />
-      </div>
-    );
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "**Label Icon 포함**\n\n레이블 옆에 아이콘을 추가할 수 있습니다. 어떤 IconName이든 사용 가능합니다.",
       },
     },
   },

--- a/packages/jds/src/components/Input/TagField/TagField.tsx
+++ b/packages/jds/src/components/Input/TagField/TagField.tsx
@@ -126,14 +126,23 @@ const TagFieldInput = forwardRef<HTMLInputElement, TagFieldInputProps>(
       }
     }, [ref]);
 
-    const handleTagClick = useCallback(
-      (e: MouseEvent, tagId: string) => {
-        e.stopPropagation();
+    const handleTagRemove = useCallback(
+      (tagId: string) => {
         onTagsChange(TagFieldUtils.removeTag(tags, tagId));
+        if (ref && typeof ref !== "function" && ref.current) {
+          ref.current.focus();
+        }
       },
-      [tags, onTagsChange],
+      [tags, onTagsChange, ref],
     );
 
+    const handleTagSelect = useCallback(
+      (e: MouseEvent, tagId: string) => {
+        e.stopPropagation();
+        setSelectedTagId(tagId);
+      },
+      [setSelectedTagId],
+    );
     return (
       <StyledTagInputWrapper
         $style={style}
@@ -146,7 +155,8 @@ const TagFieldInput = forwardRef<HTMLInputElement, TagFieldInputProps>(
           tags={tags}
           hasTag={hasTag}
           selectedTagId={selectedTagId}
-          onTagClick={handleTagClick}
+          onTagSelect={handleTagSelect}
+          onTagRemove={handleTagRemove}
         />
         <StyledTagInput
           ref={ref}

--- a/packages/jds/src/components/Input/TagField/TagField.tsx
+++ b/packages/jds/src/components/Input/TagField/TagField.tsx
@@ -177,8 +177,8 @@ export const TagField = forwardRef<HTMLInputElement, TagFieldProps>(
       layout = "vertical",
       validation = "none",
       interaction = "enabled",
+      isWithInfoIcon = false,
       label,
-      labelIcon,
       helperText,
       ...restProps
     },
@@ -191,7 +191,7 @@ export const TagField = forwardRef<HTMLInputElement, TagFieldProps>(
         validation={validation}
         interaction={interaction}
         label={label}
-        labelIcon={labelIcon}
+        isWithInfoIcon={isWithInfoIcon}
         helperText={helperText}
       >
         <StyledFieldContainer $layout={layout}>

--- a/packages/jds/src/components/Input/TagField/TagField.tsx
+++ b/packages/jds/src/components/Input/TagField/TagField.tsx
@@ -70,21 +70,27 @@ const TagFieldInput = forwardRef<HTMLInputElement, TagFieldInputProps>(
             clearInput();
             clearSelection();
           }
+
           return;
         }
 
         if (e.key === "Backspace") {
+          if (inputValue.length > 0) return;
+
           e.preventDefault();
+
           const action = TagFieldUtils.getBackspaceAction(inputValue, tags, selectedTagId);
 
           if (action === "remove") {
             const lastTagId = TagFieldUtils.getLastTagId(tags);
+
             if (lastTagId) {
               onTagsChange(TagFieldUtils.removeTag(tags, lastTagId));
               clearSelection();
             }
           } else if (action === "select") {
             const lastTagId = TagFieldUtils.getLastTagId(tags);
+
             if (lastTagId) {
               setSelectedTagId(lastTagId);
             }
@@ -92,9 +98,7 @@ const TagFieldInput = forwardRef<HTMLInputElement, TagFieldInputProps>(
           return;
         }
 
-        if (selectedTagId) {
-          clearSelection();
-        }
+        if (selectedTagId) clearSelection();
       },
       [
         isComposing,

--- a/packages/jds/src/components/Input/TagField/TagItem.tsx
+++ b/packages/jds/src/components/Input/TagField/TagItem.tsx
@@ -18,13 +18,13 @@ export const TagItem = ({ tag, isSelected, onSelect, onRemove }: TagItemProps) =
   const handleRemoveIconClick = (e: MouseEvent) => {
     e.stopPropagation();
 
-    if (isInteractive && onRemove) onRemove(tag.id);
+    if (onRemove) onRemove(tag.id);
   };
 
   const handleBodyClick = (e: MouseEvent) => {
     e.stopPropagation();
 
-    if (isInteractive && onSelect) onSelect(e, tag.id);
+    if (onSelect) onSelect(e, tag.id);
   };
 
   return (

--- a/packages/jds/src/components/Input/TagField/TagItem.tsx
+++ b/packages/jds/src/components/Input/TagField/TagItem.tsx
@@ -8,24 +8,39 @@ import { useFormField } from "../shared/FormFieldContext";
 export interface TagItemProps {
   tag: Tag;
   isSelected: boolean;
-  onClick?: (e: MouseEvent, tagId: string) => void;
+  onSelect?: (e: MouseEvent, tagId: string) => void;
+  onRemove?: (tagId: string) => void;
 }
 
-export const TagItem = ({ tag, isSelected, onClick }: TagItemProps) => {
+export const TagItem = ({ tag, isSelected, onSelect, onRemove }: TagItemProps) => {
   const { isInteractive } = useFormField();
+
+  const handleRemoveIconClick = (e: MouseEvent) => {
+    e.stopPropagation();
+
+    if (isInteractive && onRemove) onRemove(tag.id);
+  };
+
+  const handleBodyClick = (e: MouseEvent) => {
+    e.stopPropagation();
+
+    if (isInteractive && onSelect) onSelect(e, tag.id);
+  };
 
   return (
     <StyledTagWrapper
       key={tag.id}
       $isSelected={isSelected}
       $isInteractive={isInteractive}
-      onClick={isInteractive && onClick ? e => onClick(e, tag.id) : undefined}
+      onClick={isInteractive ? handleBodyClick : undefined}
+      onMouseDown={e => e.preventDefault()}
     >
       <ContentBadge.Basic
         size='xs'
         hierarchy='secondary'
         badgeStyle='alpha'
         withIcon={isInteractive}
+        onIconClick={isInteractive ? handleRemoveIconClick : undefined}
       >
         {tag.label}
       </ContentBadge.Basic>

--- a/packages/jds/src/components/Input/TagField/TagItem.tsx
+++ b/packages/jds/src/components/Input/TagField/TagItem.tsx
@@ -29,7 +29,6 @@ export const TagItem = ({ tag, isSelected, onSelect, onRemove }: TagItemProps) =
 
   return (
     <StyledTagWrapper
-      key={tag.id}
       $isSelected={isSelected}
       $isInteractive={isInteractive}
       onClick={isInteractive ? handleBodyClick : undefined}

--- a/packages/jds/src/components/Input/TagField/TagList.tsx
+++ b/packages/jds/src/components/Input/TagField/TagList.tsx
@@ -8,10 +8,17 @@ export interface TagListProps {
   tags: Tag[];
   hasTag: boolean;
   selectedTagId: string | null;
-  onTagClick?: (e: MouseEvent, tagId: string) => void;
+  onTagSelect?: (e: MouseEvent, tagId: string) => void;
+  onTagRemove?: (tagId: string) => void;
 }
 
-export const TagList = ({ tags, hasTag, selectedTagId, onTagClick }: TagListProps) => {
+export const TagList = ({
+  tags,
+  hasTag,
+  selectedTagId,
+  onTagSelect,
+  onTagRemove,
+}: TagListProps) => {
   return (
     <StyledTagContainer $hasTag={hasTag}>
       {tags.map(tag => (
@@ -19,7 +26,8 @@ export const TagList = ({ tags, hasTag, selectedTagId, onTagClick }: TagListProp
           key={tag.id}
           tag={tag}
           isSelected={selectedTagId === tag.id}
-          onClick={onTagClick}
+          onSelect={onTagSelect}
+          onRemove={onTagRemove}
         />
       ))}
     </StyledTagContainer>

--- a/packages/jds/src/components/Input/TagField/tagField.types.ts
+++ b/packages/jds/src/components/Input/TagField/tagField.types.ts
@@ -16,7 +16,7 @@ export interface TagFieldPublicProps
       "value" | "onChange" | "defaultValue" | "style" | "type"
     > {
   label?: string;
-  labelIcon?: IconName;
+  isWithInfoIcon?: boolean;
   helperText?: string;
   tags: Tag[];
   onTagsChange: (tags: Tag[]) => void;
@@ -28,5 +28,6 @@ export interface TagFieldPublicProps
 export type TagFieldProps = TagFieldPublicProps;
 
 export interface TagFieldButtonProps extends TagFieldPublicProps {
+  labelIcon?: IconName;
   button: ReactNode;
 }

--- a/packages/jds/src/components/Input/TextField/TextField.stories.tsx
+++ b/packages/jds/src/components/Input/TextField/TextField.stories.tsx
@@ -1,8 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 import { BlockButton } from "components";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
+import type { TextFieldPublicProps } from "./index";
 import { TextField } from "./index";
 
 const meta = {
@@ -48,9 +49,9 @@ const meta = {
       control: "text",
       description: "레이블 텍스트",
     },
-    labelIcon: {
-      control: "text",
-      description: "레이블 옆에 표시할 아이콘 (IconName)",
+    isWithInfoIcon: {
+      control: "boolean",
+      description: "레이블 옆 Info 아이콘 표시 여부",
     },
     helperText: {
       control: "text",
@@ -66,26 +67,36 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof meta>;
 
+const Template = (args: TextFieldPublicProps) => {
+  const [value, setValue] = useState(args.value ?? "");
+
+  useEffect(() => {
+    setValue(args.value);
+  }, [args.value]);
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setValue(e.target.value);
+    args.onChange?.(e);
+  };
+
+  return (
+    <div style={{ width: "20rem" }}>
+      <TextField {...args} value={value} onChange={handleChange} />
+    </div>
+  );
+};
+
 export const Default: Story = {
   args: {
+    label: "레이블",
+    placeholder: "플레이스 홀더 텍스트",
+    helperText: "헬퍼 메시지 레이블",
+    validation: "none",
     value: "",
+    isWithInfoIcon: false,
     onChange: () => {},
   },
-  render: function Render() {
-    const [value, setValue] = useState("");
-    return (
-      <div style={{ width: "20rem" }}>
-        <TextField.Button
-          label='인증 코드'
-          placeholder='인증 코드를 입력하세요'
-          helperText='이메일로 전송된 인증 코드를 입력해주세요'
-          value={value}
-          onChange={e => setValue(e.target.value)}
-          button={<BlockButton.Basic size='md'>인증</BlockButton.Basic>}
-        />
-      </div>
-    );
-  },
+  render: Template,
   parameters: {
     docs: {
       description: {
@@ -93,33 +104,6 @@ export const Default: Story = {
           "**TextField.Button (기본)**\n\n" +
           "Input 오른쪽에 버튼이 포함된 필드입니다.\n" +
           "인증 코드 입력, 검색 등에 사용됩니다.",
-      },
-    },
-  },
-};
-
-export const WithLabelIcon: Story = {
-  args: {
-    label: "이메일",
-    labelIcon: "information-line",
-    placeholder: "example@ject.com",
-    helperText: "유효한 이메일 주소를 입력해주세요",
-    value: "",
-    onChange: () => {},
-  },
-  render: function Render(args) {
-    const [value, setValue] = useState("");
-    return (
-      <div style={{ width: "20rem" }}>
-        <TextField {...args} value={value} onChange={e => setValue(e.target.value)} />
-      </div>
-    );
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "**Label Icon 포함**\n\n레이블 옆에 아이콘을 추가할 수 있습니다. 어떤 IconName이든 사용 가능합니다.",
       },
     },
   },

--- a/packages/jds/src/components/Input/TextField/TextField.tsx
+++ b/packages/jds/src/components/Input/TextField/TextField.tsx
@@ -50,8 +50,8 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       layout = "vertical",
       validation = "none",
       interaction = "enabled",
+      isWithInfoIcon = false,
       label,
-      labelIcon,
       helperText,
       ...restProps
     },
@@ -64,7 +64,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         validation={validation}
         interaction={interaction}
         label={label}
-        labelIcon={labelIcon}
+        isWithInfoIcon={isWithInfoIcon}
         helperText={helperText}
       >
         <StyledFieldContainer $layout={layout}>

--- a/packages/jds/src/components/Input/TextField/textField.types.ts
+++ b/packages/jds/src/components/Input/TextField/textField.types.ts
@@ -6,7 +6,7 @@ import type { FieldPublicProps, FieldInputPublicProps } from "../input.types";
 export interface TextFieldPublicProps
   extends FieldPublicProps, Omit<FieldInputPublicProps, "value" | "onChange" | "defaultValue"> {
   label?: ReactNode;
-  labelIcon?: IconName;
+  isWithInfoIcon?: boolean;
   helperText?: string;
   value: string;
   onChange: (e: ChangeEvent<HTMLInputElement>) => void;
@@ -15,5 +15,6 @@ export interface TextFieldPublicProps
 export type TextFieldProps = TextFieldPublicProps;
 
 export interface TextFieldButtonProps extends TextFieldPublicProps {
+  labelIcon?: IconName;
   button: ReactNode;
 }

--- a/packages/jds/src/components/Input/shared/FormField.tsx
+++ b/packages/jds/src/components/Input/shared/FormField.tsx
@@ -15,7 +15,7 @@ interface FormFieldLabelProps {
 }
 
 export const FormFieldLabel = ({ children }: FormFieldLabelProps) => {
-  const { fieldId, label, labelIcon, layout, isDisabled, isReadOnly } = useFormField();
+  const { fieldId, label, isWithInfoIcon, layout, isDisabled, isReadOnly } = useFormField();
 
   if (!label && !children) {
     return null;
@@ -34,14 +34,7 @@ export const FormFieldLabel = ({ children }: FormFieldLabelProps) => {
       >
         {children || label}
       </StyledFieldLabel>
-      {labelIcon && (
-        <StyledLabelIcon
-          name={labelIcon}
-          size='2xs'
-          $disabled={isDisabled}
-          $readOnly={isReadOnly}
-        />
-      )}
+      {isWithInfoIcon && <StyledLabelIcon name='information-line' size='2xs' />}
     </StyledLabelContainer>
   );
 };
@@ -89,7 +82,7 @@ export const FormField = ({
   validation,
   interaction,
   label,
-  labelIcon,
+  isWithInfoIcon,
   helperText,
   children,
 }: FormFieldProps) => {
@@ -100,7 +93,7 @@ export const FormField = ({
       validation={validation}
       interaction={interaction}
       label={label}
-      labelIcon={labelIcon}
+      isWithInfoIcon={isWithInfoIcon}
       helperText={helperText}
     >
       {children}

--- a/packages/jds/src/components/Input/shared/FormFieldContext.tsx
+++ b/packages/jds/src/components/Input/shared/FormFieldContext.tsx
@@ -1,6 +1,5 @@
 import { createContext, useContext, useId, type ReactNode } from "react";
 
-import type { IconName } from "../../Icon/Icon.types";
 import type { InputStyle, InputLayout, InputValidation, InputInteraction } from "../input.types";
 import { getInteractionStates } from "../input.types";
 
@@ -14,7 +13,7 @@ export interface FormFieldContextValue {
   isReadOnly: boolean;
   isInteractive: boolean;
   label?: ReactNode;
-  labelIcon?: IconName;
+  isWithInfoIcon?: boolean;
   helperText?: string;
 }
 
@@ -34,7 +33,7 @@ export interface FormFieldProviderProps {
   validation?: InputValidation;
   interaction?: InputInteraction;
   label?: ReactNode;
-  labelIcon?: IconName;
+  isWithInfoIcon?: boolean;
   helperText?: string;
   children: ReactNode;
 }
@@ -45,7 +44,7 @@ export const FormFieldProvider = ({
   validation = "none",
   interaction = "enabled",
   label,
-  labelIcon,
+  isWithInfoIcon,
   helperText,
   children,
 }: FormFieldProviderProps) => {
@@ -62,7 +61,7 @@ export const FormFieldProvider = ({
     isReadOnly,
     isInteractive,
     label,
-    labelIcon,
+    isWithInfoIcon,
     helperText,
   };
 

--- a/packages/jds/src/components/Input/shared/field.styles.ts
+++ b/packages/jds/src/components/Input/shared/field.styles.ts
@@ -21,14 +21,14 @@ export const getLabelColor = (theme: Theme, disabled: boolean, readOnly: boolean
 
 export const getLabelIconColor = (theme: Theme, disabled: boolean, readOnly: boolean): string => {
   if (disabled) {
-    return theme.color.semantic.object.assistive;
+    return theme.color.semantic.object.neutral;
   }
 
   if (readOnly) {
-    return theme.color.semantic.object.alternative;
+    return theme.color.semantic.object.neutral;
   }
 
-  return theme.color.semantic.object.alternative;
+  return theme.color.semantic.accent.neutral;
 };
 
 export const getHelperTextColor = (
@@ -92,11 +92,9 @@ export const StyledLabelContainer = styled("div", {
 
 export const StyledLabelIcon = styled(Icon, {
   shouldForwardProp: prop => !prop.startsWith("$"),
-})<{ $disabled?: boolean; $readOnly?: boolean }>(
-  ({ theme, $disabled = false, $readOnly = false }) => ({
-    color: getLabelIconColor(theme, $disabled, $readOnly),
-  }),
-);
+})(({ theme }) => ({
+  color: theme.color.semantic.accent.neutral,
+}));
 
 export const StyledFieldLabel = styled(Label, {
   shouldForwardProp: prop => !prop.startsWith("$"),


### PR DESCRIPTION
## 💡 작업 내용

### 공통 수정점

- [x] 스토리북 args에 따른 미리 보기 대응
- [x] `labelIcon → isWithInfoIcon`으로 변경 (피그마에서 라벨 옆 아이콘 사용 고정됨)

### TagField

- [x] 태그 body를 클릭했을 때 태그가 삭제되는 이슈 수정
- [x] 태그로 만들기 이전의 텍스트 입력값을 삭제할 수 없는 이슈 수정

## 💡 자세한 설명

### 공통 수정점

_**1. 스토리북 args에 따른 미리 보기 대응**_

> 모든 Input 컴포넌트가 스토리북 args 변경에 따른 대응이 정상적으로 이루어지지 않고 있었습니다. 따라서 정상적으로 동작을 확인할 수 있도록 변경했습니다. 동작 확인 예시는 SelectField만 첨부했습니다. 

![selectFIeld](https://github.com/user-attachments/assets/a6d64728-c6be-4792-a9ce-26290840ce52)

_**2. `labelIcon → isWithInfoIcon`으로 변경**_

> 기존 Field 컴포넌트는 `labelIcon`을 선택 가능하도록 열어 둔 형태였지만, 현재 Figma에서는 Label 옆 아이콘을 `Info`로만 고정해 두었기 때문에 확장을 닫아 두는 형태로 변경했습니다. 

```tsx
{isWithInfoIcon && <StyledLabelIcon name='information-line' size='2xs' />}
```

### TagField

_**1. 태그 body를 클릭했을 때 태그가 삭제되는 이슈 수정**_

> TagItem의 최상위 부모인 `StyledTagWrapper`의 onClick 이벤트에 삭제 로직이 걸려 있어 발생한 이슈였습니다. 해결 단계는 아래와 같습니다:

1. TagItem의 props를 onSelect(태그 body 클릭)와 onRemove(태그 삭제 아이콘 클릭)로 분리
2. StyledTagWrapper 클릭 시에는 onSelect를 실행하도록 변경
3. ContentBadge의 삭제 아이콘 클릭 시에만 onRemove를 실행하도록 수정 (ContentBadge에 onIconClick prop 추가)

![tagField remove](https://github.com/user-attachments/assets/a9040171-7527-46ca-84c5-c2ba78a4cb7e)

_**2. 태그로 만들기 이전의 텍스트 입력값을 삭제할 수 없는 이슈 수정**_

> handleKeyDown 함수에서 `e.key === "Backspace"`일 때 `e.preventDefault()`를 조건 없이 호출하고 있어 발생한 이슈였습니다. 해당 동작이 브라우저의 기본 동작을 제한하기 때문에 입력된 글자가 없을 때만 해당 함수를 호출하도록 수정했습니다. 

```ts
if (inputValue.length > 0) return;
```

![TagField Backspace](https://github.com/user-attachments/assets/1db6c745-8750-421c-9c8e-aecf6e5f9c0c)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #378 
