### PR TITLE
refactor: Card 컴포넌트 QA 대응

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,0 +1,10 @@
+{
+  "mode": "pre",
+  "tag": "next",
+  "initialVersions": {
+    "ject-official-website-client": "0.0.1",
+    "@ject/eslint-config": "0.0.1",
+    "@jects/jds": "0.0.1"
+  },
+  "changesets": []
+}

--- a/packages/jds/src/components/Card/Card.stories.tsx
+++ b/packages/jds/src/components/Card/Card.stories.tsx
@@ -68,10 +68,15 @@ type Story = StoryObj<typeof meta>;
 
 export const CompoundBasic: Story = {
   name: "Basic 형태의 Compound 사용",
-  args: {},
-  render: () => (
-    <div style={{ width: "400px" }}>
-      <Card.Root layout='vertical' variant='plate'>
+  args: {
+    layout: "vertical",
+    variant: "plate",
+    interactive: false,
+    isDisabled: false,
+  },
+  render: args => (
+    <div>
+      <Card.Root {...args}>
         <Card.Image alt='프로젝트 이미지' />
         <Card.Content>
           <Card.Title>타이틀 레이블</Card.Title>
@@ -81,6 +86,7 @@ export const CompoundBasic: Story = {
           </Card.Body>
           <Card.Caption>캡션 레이블입니다.</Card.Caption>
         </Card.Content>
+        {args.interactive && <Card.Overlay />}
       </Card.Root>
     </div>
   ),

--- a/packages/jds/src/components/Card/compound/CardContent.tsx
+++ b/packages/jds/src/components/Card/compound/CardContent.tsx
@@ -1,16 +1,41 @@
-import { forwardRef } from "react";
+import { Children, forwardRef, isValidElement, type ReactNode } from "react";
 
 import { useCardContext } from "../Card.context";
 import type { CardContentProps } from "../Card.types";
-import { StyledCardContent } from "./compound.styles";
+import { StyledCardContent, StyledContentMain } from "./compound.styles";
+
+interface ComponentWithDisplayName {
+  displayName?: string;
+}
+
+const isTargetComponent = (child: ReactNode, targetNames: string[]): boolean => {
+  if (!isValidElement(child)) return false;
+
+  const type = child.type;
+  const componentType = type as ComponentWithDisplayName;
+
+  if (typeof type === "string") return false;
+
+  return targetNames.includes(componentType.displayName || "");
+};
 
 export const CardContent = forwardRef<HTMLDivElement, CardContentProps>(
   ({ children, ...restProps }, ref) => {
     const { variant, layout } = useCardContext();
+    const childrenArray = Children.toArray(children);
+
+    const mainContentNodes: ReactNode[] = [];
+    const metaNodes: ReactNode[] = [];
+
+    childrenArray.forEach(child => {
+      if (isTargetComponent(child, ["Card.Caption", "Card.Meta"])) metaNodes.push(child);
+      else mainContentNodes.push(child);
+    });
 
     return (
       <StyledCardContent ref={ref} $variant={variant} $layout={layout} {...restProps}>
-        {children}
+        {mainContentNodes.length > 0 && <StyledContentMain>{mainContentNodes}</StyledContentMain>}
+        {metaNodes.length > 0 && <StyledContentMain>{metaNodes}</StyledContentMain>}
       </StyledCardContent>
     );
   },

--- a/packages/jds/src/components/Card/compound/compound.styles.ts
+++ b/packages/jds/src/components/Card/compound/compound.styles.ts
@@ -321,12 +321,22 @@ export const StyledCardContent = styled.div<{
   ...getContentStyles(theme, $variant, $layout),
 }));
 
+export const StyledContentMain = styled.div(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  alignItems: "flex-start",
+  alignSelf: "stretch",
+  width: "100%",
+  gap: theme.scheme.semantic.spacing[8],
+}));
+
 export const StyledCardMeta = styled.div(({ theme }) => ({
   display: "flex",
-  alignItems: "center",
+  flexDirection: "column",
+  justifyContent: "center",
   padding: 0,
   alignSelf: "stretch",
-  gap: theme.scheme.semantic.spacing[16],
+  gap: theme.scheme.semantic.spacing[8],
 }));
 
 export const StyledCardMetaItem = styled("span", {
@@ -457,7 +467,7 @@ export const StyledHorizontalPostContentWrap = styled("div", {
   display: "flex",
   flexDirection: "column",
   flex: "1 0 0",
-  gap: theme.scheme.semantic.spacing[8],
+  gap: theme.scheme.semantic.spacing[16],
 }));
 
 export const StyledHorizontalCardPostLayout = styled("div", {

--- a/packages/jds/src/components/Card/presets/Post.tsx
+++ b/packages/jds/src/components/Card/presets/Post.tsx
@@ -13,6 +13,7 @@ import {
 } from "../compound";
 import {
   StyledCardOverlay,
+  StyledContentMain,
   StyledHorizontalCardPostLayout,
   StyledHorizontalPostContentWrap,
 } from "../compound/compound.styles";
@@ -51,8 +52,10 @@ const PostContent = ({ layout, image, title, body, author, date }: PostContentPr
       <CardContent>
         <StyledHorizontalCardPostLayout>
           <StyledHorizontalPostContentWrap>
-            <CardTitle>{title}</CardTitle>
-            <CardBody>{body}</CardBody>
+            <StyledContentMain>
+              <CardTitle>{title}</CardTitle>
+              <CardBody>{body}</CardBody>
+            </StyledContentMain>
             <CardMeta>
               <CardMetaItem>{author}</CardMetaItem>
               <CardMetaItem>{date}</CardMetaItem>


### PR DESCRIPTION
## 💡 작업 내용

- [x] 스토리북 args에 따른 미리 보기 대응
- [x] 내부 레이아웃이 디자인과 일치하지 않음 

## 💡 자세한 설명

### 1. 스토리북 args에 따른 미리 보기 대응

> Card 컴포넌트가 스토리북 args 변경에 따른 대응이 정상적으로 이루어지지 않고 있었습니다. 따라서 정상적으로 동작을 확인할 수 있도록 변경했습니다. 단, Card 컴포넌트는 각 요소를 조립해 사용하는 형태로 구현되어 있기 때문에 일부 컴포넌트는 예시 문서로 확인 부탁드립니다. (e.g. Post 형태)

![card component](https://github.com/user-attachments/assets/2cb1660b-ccbc-40ce-8d7e-191dd622b193)

### 2. 내부 레이아웃이 디자인과 일치하지 않음 

> 기존에는 `Card.Content`의 모든 자식 요소에 일괄적으로 `spacing.16`이 적용되었습니다. 하지만 디자인 가이드상 `Title`과 `Body` 사이는 `spacing.8`, 그리고 이 그룹과 `Caption`/`Meta` 사이는 `spacing.16`으로 구분되어야 하므로 이를 분리할 필요가 있었습니다. 때문에, `Card.Content` 컴포넌트 내부에서 자식 요소(Children)들의 렌더링 방식을 변경하여, 컴포넌트 타입에 따라 서로 다른 간격(Gap)이 적용되도록 수정했습니다. 

`Children.toArray`를 사용하여 자식 요소를 순회하며 Main 그룹(`Title`, `Body`)과 Meta 그룹(`Caption`, `Meta`)으로 분리

```tsx
const isTargetComponent = (child: ReactNode, targetNames: string[]): boolean => {
  if (!isValidElement(child)) return false;

  const type = child.type;
  const componentType = type as ComponentWithDisplayName;

  if (typeof type === "string") return false;

  return targetNames.includes(componentType.displayName || "");
};

export const CardContent = forwardRef<HTMLDivElement, CardContentProps>(
  ({ children, ...restProps }, ref) => {
    const { variant, layout } = useCardContext();
    const childrenArray = Children.toArray(children);

    const mainContentNodes: ReactNode[] = [];
    const metaNodes: ReactNode[] = [];

    childrenArray.forEach(child => {
      if (isTargetComponent(child, ["Card.Caption", "Card.Meta"])) metaNodes.push(child);
      else mainContentNodes.push(child);
    });

    return (
      <StyledCardContent ref={ref} $variant={variant} $layout={layout} {...restProps}>
        {mainContentNodes.length > 0 && <StyledContentMain>{mainContentNodes}</StyledContentMain>}
        {metaNodes.length > 0 && <StyledContentMain>{metaNodes}</StyledContentMain>}
      </StyledCardContent>
    );
  },
);
```

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #378 
