### PR TITLE
refactor: Callout 컴포넌트 QA 대응

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
     },
     "apps/web": {
       "name": "ject-official-website-client",
-      "version": "0.0.1-next.0",
+      "version": "0.0.1",
       "dependencies": {
         "@amplitude/analytics-browser": "^2.17.2",
         "@amplitude/plugin-session-replay-browser": "^1.16.4",
@@ -79,6 +79,28 @@
         "vite": "^6.0.5",
         "vite-plugin-svgr": "^4.3.0",
         "vitest": "^4.0.13"
+      }
+    },
+    "apps/web/node_modules/@jects/jds": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@jects/jds/-/jds-0.0.1.tgz",
+      "integrity": "sha512-W9hNJmZbkuDzsMDuG5Q1quMfWY5gJIkJx7TEI20C4g+RxB79VSjKS3NhWUZCQv7B/AQjdYiuDuf4rc10gHFy9A==",
+      "license": "MIT",
+      "dependencies": {
+        "radix-ui": "^1.4.3"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=10.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "4.53.2"
+      },
+      "peerDependencies": {
+        "@emotion/react": ">=11",
+        "@emotion/styled": ">=11",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "config/eslint": {
@@ -16978,7 +17000,7 @@
     },
     "packages/jds": {
       "name": "@jects/jds",
-      "version": "0.0.1",
+      "version": "0.0.2-dev",
       "license": "MIT",
       "dependencies": {
         "radix-ui": "^1.4.3"

--- a/packages/jds/package.json
+++ b/packages/jds/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jects/jds",
-  "version": "0.0.1",
+  "version": "0.0.2-dev",
   "description": "Ject Design System",
   "author": "Ject Team",
   "license": "MIT",

--- a/packages/jds/src/components/Button/LabelButton/labelButton.types.ts
+++ b/packages/jds/src/components/Button/LabelButton/labelButton.types.ts
@@ -3,7 +3,7 @@ import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
 export type LabelButtonSize = "xs" | "sm" | "md" | "lg";
 export type LabelButtonHierarchy = "accent" | "primary" | "secondary" | "tertiary";
-export type LabelButtonIntent = "positive" | "destructive" | "notifying";
+export type LabelButtonIntent = "positive" | "destructive";
 
 export interface BaseLabelButtonProps extends ComponentPropsWithoutRef<"button"> {
   children: ReactNode;

--- a/packages/jds/src/components/Button/LabelButton/labelButton.types.ts
+++ b/packages/jds/src/components/Button/LabelButton/labelButton.types.ts
@@ -3,7 +3,7 @@ import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
 export type LabelButtonSize = "xs" | "sm" | "md" | "lg";
 export type LabelButtonHierarchy = "accent" | "primary" | "secondary" | "tertiary";
-export type LabelButtonIntent = "positive" | "destructive";
+export type LabelButtonIntent = "positive" | "destructive" | "notifying";
 
 export interface BaseLabelButtonProps extends ComponentPropsWithoutRef<"button"> {
   children: ReactNode;

--- a/packages/jds/src/components/Callout/Callout.stories.tsx
+++ b/packages/jds/src/components/Callout/Callout.stories.tsx
@@ -27,7 +27,7 @@ export const CalloutBasic: StoryObj<typeof Callout.Basic> = {
     hierarchy: "primary",
     size: "lg",
     title: "베이직 콜아웃 타이틀",
-    blockButtonProps: {
+    labelButtonProps: {
       children: "레이블",
       disabled: false,
       prefixIcon: "blank",
@@ -41,7 +41,7 @@ export const CalloutBasic: StoryObj<typeof Callout.Basic> = {
       hierarchy={args.hierarchy}
       size={args.size}
       title={args.title}
-      blockButtonProps={args.blockButtonProps}
+      labelButtonProps={args.labelButtonProps}
     >
       {args.children}
     </Callout.Basic>
@@ -57,7 +57,7 @@ export const CalloutFeedback: StoryObj<typeof Callout.Feedback> = {
     feedback: "positive",
     size: "lg",
     title: "피드백 콜아웃 타이틀",
-    blockButtonProps: {
+    labelButtonProps: {
       children: "레이블",
       disabled: false,
       prefixIcon: "blank",
@@ -71,7 +71,7 @@ export const CalloutFeedback: StoryObj<typeof Callout.Feedback> = {
       feedback={args.feedback}
       size={args.size}
       title={args.title}
-      blockButtonProps={args.blockButtonProps}
+      labelButtonProps={args.labelButtonProps}
     >
       {args.children}
     </Callout.Feedback>

--- a/packages/jds/src/components/Callout/Callout.stories.tsx
+++ b/packages/jds/src/components/Callout/Callout.stories.tsx
@@ -9,9 +9,8 @@ const meta = {
     layout: "centered",
   },
   argTypes: {
-    variant: { control: "radio", options: ["hero", "hint"] },
-    hierarchy: { control: "radio", options: ["accent", "primary", "secondary"] },
-    size: { control: "radio", options: ["lg", "md", "sm", "xs", "2xs"] },
+    hierarchy: { control: "radio", options: ["primary", "secondary"] },
+    size: { control: "radio", options: ["lg", "md", "sm", "xs"] },
     title: { control: "text" },
     children: { control: "text" },
   },
@@ -22,11 +21,10 @@ export default meta;
 export const CalloutBasic: StoryObj<typeof Callout.Basic> = {
   name: "Basic",
   argTypes: {
-    hierarchy: { control: "radio", options: ["accent", "primary", "secondary"] },
+    hierarchy: { control: "radio", options: ["primary", "secondary"] },
   },
   args: {
-    hierarchy: "accent",
-    variant: "hero",
+    hierarchy: "primary",
     size: "lg",
     title: "베이직 콜아웃 타이틀",
     blockButtonProps: {
@@ -41,7 +39,6 @@ export const CalloutBasic: StoryObj<typeof Callout.Basic> = {
   render: args => (
     <Callout.Basic
       hierarchy={args.hierarchy}
-      variant={args.variant}
       size={args.size}
       title={args.title}
       blockButtonProps={args.blockButtonProps}
@@ -58,7 +55,6 @@ export const CalloutFeedback: StoryObj<typeof Callout.Feedback> = {
   },
   args: {
     feedback: "positive",
-    variant: "hero",
     size: "lg",
     title: "피드백 콜아웃 타이틀",
     blockButtonProps: {
@@ -73,7 +69,6 @@ export const CalloutFeedback: StoryObj<typeof Callout.Feedback> = {
   render: args => (
     <Callout.Feedback
       feedback={args.feedback}
-      variant={args.variant}
       size={args.size}
       title={args.title}
       blockButtonProps={args.blockButtonProps}

--- a/packages/jds/src/components/Callout/Callout.stories.tsx
+++ b/packages/jds/src/components/Callout/Callout.stories.tsx
@@ -4,76 +4,121 @@ import { Callout } from "./Callout";
 
 const meta = {
   title: "Components/Callout",
-  component: Callout.Basic,
+  component: Callout,
   parameters: {
     layout: "centered",
+    docs: {
+      description: {
+        component:
+          "Callout 컴포넌트는 Basic 모드(hierarchy)와 Feedback 모드(feedback)를 지원합니다. 두 속성은 동시에 사용할 수 없습니다.",
+      },
+    },
   },
   argTypes: {
-    hierarchy: { control: "radio", options: ["primary", "secondary"] },
-    size: { control: "radio", options: ["lg", "md", "sm", "xs"] },
-    title: { control: "text" },
-    children: { control: "text" },
+    size: {
+      control: "radio",
+      options: ["lg", "md", "sm", "xs"],
+      description: "Callout의 크기",
+      table: {
+        defaultValue: { summary: "md" },
+      },
+    },
+    title: {
+      control: "text",
+      description: "Callout 타이틀",
+    },
+    children: {
+      control: "text",
+      description: "Callout 본문 내용",
+    },
+    labelButtonProps: {
+      control: "object",
+      description: "우측 버튼 설정 (옵션)",
+    },
+    hierarchy: {
+      control: "radio",
+      options: ["primary", "secondary"],
+      description: "중요도 단계",
+      table: {
+        defaultValue: { summary: "secondary" },
+      },
+    },
+    feedback: {
+      control: "radio",
+      options: ["positive", "destructive", "notifying"],
+      description: "피드백 상태",
+    },
   },
-} satisfies Meta<typeof Callout.Basic>;
+} satisfies Meta<typeof Callout>;
 
 export default meta;
+type Story = StoryObj<typeof meta>;
 
-export const CalloutBasic: StoryObj<typeof Callout.Basic> = {
-  name: "Basic",
-  argTypes: {
-    hierarchy: { control: "radio", options: ["primary", "secondary"] },
+export const Basic: Story = {
+  name: "Basic Mode",
+  parameters: {
+    docs: {
+      description: {
+        story: "**Basic Mode**는 `hierarchy` prop을 사용하여 일반적인 정보를 전달할 때 사용합니다.",
+      },
+    },
   },
   args: {
     hierarchy: "primary",
     size: "lg",
     title: "베이직 콜아웃 타이틀",
+    children:
+      "콜아웃 텍스트의 최대 입력 글자수 제한은 없지만, 너무 많은 글자수는 핵심적인 내용을 효과적으로 전달하는 데에 적절치 않다는 점을 유의합니다.",
     labelButtonProps: {
       children: "레이블",
       disabled: false,
       prefixIcon: "blank",
       suffixIcon: "blank",
     },
-    children:
-      "콜아웃 텍스트의 최대 입력 글자수 제한은 없지만, 너무 많은 글자수는 핵심적인 내용을 효과적으로 전달하는 데에 적절치 않다는 점을 유의합니다.",
   },
-  render: args => (
-    <Callout.Basic
-      hierarchy={args.hierarchy}
-      size={args.size}
-      title={args.title}
-      labelButtonProps={args.labelButtonProps}
-    >
-      {args.children}
-    </Callout.Basic>
-  ),
 };
 
-export const CalloutFeedback: StoryObj<typeof Callout.Feedback> = {
-  name: "Feedback",
-  argTypes: {
-    feedback: { control: "radio", options: ["positive", "destructive", "notifying"] },
+export const Feedback: Story = {
+  name: "Feedback Mode",
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "**Feedback Mode**는 `feedback` prop을 사용하여 상태(긍정, 부정, 알림)를 전달할 때 사용합니다.",
+      },
+    },
   },
   args: {
-    feedback: "positive",
-    size: "lg",
     title: "피드백 콜아웃 타이틀",
-    labelButtonProps: {
-      children: "레이블",
-      disabled: false,
-      prefixIcon: "blank",
-      suffixIcon: "blank",
-    },
     children:
       "콜아웃 텍스트의 최대 입력 글자수 제한은 없지만, 너무 많은 글자수는 핵심적인 내용을 효과적으로 전달하는 데에 적절치 않다는 점을 유의합니다.",
   },
   render: args => (
-    <Callout.Feedback
-      feedback={args.feedback}
-      size={args.size}
-      title={args.title}
-      labelButtonProps={args.labelButtonProps}
-    >
-      {args.children}
-    </Callout.Feedback>
+    <div style={{ display: "flex", flexDirection: "column", gap: "1rem", width: "20rem" }}>
+      <Callout
+        feedback='positive'
+        size={args.size}
+        title={args.title}
+        labelButtonProps={args.labelButtonProps}
+      >
+        {args.children}
+      </Callout>
+      <Callout
+        feedback='destructive'
+        size={args.size}
+        title={args.title}
+        labelButtonProps={args.labelButtonProps}
+      >
+        {args.children}
+      </Callout>
+      <Callout
+        feedback='notifying'
+        size={args.size}
+        title={args.title}
+        labelButtonProps={args.labelButtonProps}
+      >
+        {args.children}
+      </Callout>
+    </div>
   ),
 };

--- a/packages/jds/src/components/Callout/Callout.style.ts
+++ b/packages/jds/src/components/Callout/Callout.style.ts
@@ -8,38 +8,27 @@ import {
   calloutSizeMap,
 } from "./Callout.variants";
 
-export const CalloutBasicDiv = styled.div<CalloutBasicDivProps>(
-  ({ theme, hierarchy, variant, size }) => {
-    const style = calloutBasicStylesMap(theme)[variant][hierarchy];
-    const border = variant === "hero" ? "none" : `1px solid ${style.border}`;
-    const borderLeft =
-      variant === "hero" ? `6px solid ${style.border}` : `1px solid ${style.border}`;
-    const borderRadius = variant === "hero" ? "none" : theme.scheme.semantic.radius[6];
+export const CalloutBasicDiv = styled.div<CalloutBasicDivProps>(({ theme, hierarchy, size }) => {
+  const style = calloutBasicStylesMap(theme)[hierarchy];
 
-    return {
-      width: "100%",
-      display: "flex",
-      flexDirection: "column",
-      alignItems: "flex-start",
-      padding: `${pxToRem(calloutSizeMap[size].paddingTopBottom)} ${pxToRem(calloutSizeMap[size].paddingLeftRight)}`,
-      gap: pxToRem(calloutSizeMap[size].gap),
-      border,
-      borderLeft,
-      borderRadius,
-      backgroundColor: style.bg,
-      color: style.color,
-    };
-  },
-);
+  return {
+    width: "100%",
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    padding: `${pxToRem(calloutSizeMap[size].paddingTopBottom)} ${pxToRem(calloutSizeMap[size].paddingLeftRight)}`,
+    gap: pxToRem(calloutSizeMap[size].gap),
+    border: `1px solid ${style.border}`,
+    borderLeft: `1px solid ${style.border}`,
+    borderRadius: theme.scheme.semantic.radius[6],
+    backgroundColor: style.bg,
+    color: style.color,
+  };
+});
 
 export const CalloutFeedbackDiv = styled.div<CalloutFeedbackDivProps>(
-  ({ theme, hierarchy, variant, size }) => {
-    const style = calloutFeedbackStylesMap(theme)[variant][hierarchy];
-    const border = variant === "hero" ? "none" : `1px solid ${style.border}`;
-    const borderLeft =
-      variant === "hero" ? `6px solid ${style.border}` : `1px solid ${style.border}`;
-    const borderRadius = variant === "hero" ? "none" : theme.scheme.semantic.radius[6];
-
+  ({ theme, hierarchy, size }) => {
+    const style = calloutFeedbackStylesMap(theme)[hierarchy];
     return {
       width: "100%",
       display: "flex",
@@ -47,9 +36,9 @@ export const CalloutFeedbackDiv = styled.div<CalloutFeedbackDivProps>(
       alignItems: "flex-start",
       padding: `${pxToRem(calloutSizeMap[size].paddingTopBottom)} ${pxToRem(calloutSizeMap[size].paddingLeftRight)}`,
       gap: pxToRem(calloutSizeMap[size].gap),
-      border,
-      borderLeft,
-      borderRadius,
+      border: `1px solid ${style.border}`,
+      borderLeft: `1px solid ${style.border}`,
+      borderRadius: theme.scheme.semantic.radius[6],
       backgroundColor: style.bg,
       color: style.color,
     };

--- a/packages/jds/src/components/Callout/Callout.style.ts
+++ b/packages/jds/src/components/Callout/Callout.style.ts
@@ -4,12 +4,26 @@ import { pxToRem } from "utils";
 import type { CalloutBasicDivProps, CalloutFeedbackDivProps, CalloutPProps } from "./Callout.types";
 import {
   calloutBasicStylesMap,
+  calloutContentSizeMap,
   calloutFeedbackStylesMap,
   calloutSizeMap,
 } from "./Callout.variants";
 
+const getAfterBorderStyle = (borderColor: string, backgroundColor: string) => ({
+  "&::after": {
+    content: '""',
+    position: "absolute" as const,
+    inset: 0,
+    border: `1px solid ${borderColor}`,
+    borderRadius: "inherit",
+    pointerEvents: "none" as const,
+    backgroundColor: backgroundColor,
+  },
+});
+
 export const CalloutBasicDiv = styled.div<CalloutBasicDivProps>(({ theme, hierarchy, size }) => {
   const style = calloutBasicStylesMap(theme)[hierarchy];
+  const borderRadius = theme.scheme.semantic.radius[6];
 
   return {
     width: "100%",
@@ -18,17 +32,17 @@ export const CalloutBasicDiv = styled.div<CalloutBasicDivProps>(({ theme, hierar
     alignItems: "flex-start",
     padding: `${pxToRem(calloutSizeMap[size].paddingTopBottom)} ${pxToRem(calloutSizeMap[size].paddingLeftRight)}`,
     gap: pxToRem(calloutSizeMap[size].gap),
-    border: `1px solid ${style.border}`,
-    borderLeft: `1px solid ${style.border}`,
-    borderRadius: theme.scheme.semantic.radius[6],
-    backgroundColor: style.bg,
+    borderRadius: borderRadius,
     color: style.color,
+    ...getAfterBorderStyle(style.border, style.bg),
   };
 });
 
 export const CalloutFeedbackDiv = styled.div<CalloutFeedbackDivProps>(
   ({ theme, hierarchy, size }) => {
     const style = calloutFeedbackStylesMap(theme)[hierarchy];
+    const borderRadius = theme.scheme.semantic.radius[6];
+
     return {
       width: "100%",
       display: "flex",
@@ -36,21 +50,29 @@ export const CalloutFeedbackDiv = styled.div<CalloutFeedbackDivProps>(
       alignItems: "flex-start",
       padding: `${pxToRem(calloutSizeMap[size].paddingTopBottom)} ${pxToRem(calloutSizeMap[size].paddingLeftRight)}`,
       gap: pxToRem(calloutSizeMap[size].gap),
-      border: `1px solid ${style.border}`,
-      borderLeft: `1px solid ${style.border}`,
-      borderRadius: theme.scheme.semantic.radius[6],
+      borderRadius: borderRadius,
       backgroundColor: style.bg,
       color: style.color,
+      ...getAfterBorderStyle(style.border, style.bg),
     };
   },
 );
 
+export const CalloutContentDiv = styled.div<CalloutPProps>(({ size }) => {
+  return {
+    display: "flex",
+    flexDirection: "column",
+    alignItems: "flex-start",
+    gap: calloutContentSizeMap[size].gap,
+  };
+});
+
 export const CalloutTitleP = styled.p<CalloutPProps>(({ theme, size }) => {
-  const tokenKey = calloutSizeMap[size].title;
-  return theme.textStyle[tokenKey];
+  const tokenKey = calloutContentSizeMap[size].title;
+  return { margin: theme.scheme.semantic.spacing[0], ...theme.textStyle[tokenKey] };
 });
 
 export const CalloutContentP = styled.p<CalloutPProps>(({ theme, size }) => {
-  const tokenKey = calloutSizeMap[size].content;
-  return theme.textStyle[tokenKey];
+  const tokenKey = calloutContentSizeMap[size].content;
+  return { margin: theme.scheme.semantic.spacing[0], ...theme.textStyle[tokenKey] };
 });

--- a/packages/jds/src/components/Callout/Callout.style.ts
+++ b/packages/jds/src/components/Callout/Callout.style.ts
@@ -1,78 +1,54 @@
 import styled from "@emotion/styled";
 import { pxToRem } from "utils";
 
-import type { CalloutBasicDivProps, CalloutFeedbackDivProps, CalloutPProps } from "./Callout.types";
-import {
-  calloutBasicStylesMap,
-  calloutContentSizeMap,
-  calloutFeedbackStylesMap,
-  calloutSizeMap,
-} from "./Callout.variants";
+import type { CalloutContainerProps, CalloutTextProps } from "./Callout.types";
+import { calloutContentSizeMap, calloutSizeMap } from "./Callout.variants";
 
-const getAfterBorderStyle = (borderColor: string, backgroundColor: string) => ({
-  "&::after": {
-    content: '""',
-    position: "absolute" as const,
-    inset: 0,
-    border: `1px solid ${borderColor}`,
-    borderRadius: "inherit",
-    pointerEvents: "none" as const,
-    backgroundColor: backgroundColor,
-  },
-});
-
-export const CalloutBasicDiv = styled.div<CalloutBasicDivProps>(({ theme, hierarchy, size }) => {
-  const style = calloutBasicStylesMap(theme)[hierarchy];
-  const borderRadius = theme.scheme.semantic.radius[6];
-
-  return {
-    width: "100%",
-    display: "flex",
-    flexDirection: "column",
-    alignItems: "flex-start",
-    padding: `${pxToRem(calloutSizeMap[size].paddingTopBottom)} ${pxToRem(calloutSizeMap[size].paddingLeftRight)}`,
-    gap: pxToRem(calloutSizeMap[size].gap),
-    borderRadius: borderRadius,
-    color: style.color,
-    ...getAfterBorderStyle(style.border, style.bg),
-  };
-});
-
-export const CalloutFeedbackDiv = styled.div<CalloutFeedbackDivProps>(
-  ({ theme, hierarchy, size }) => {
-    const style = calloutFeedbackStylesMap(theme)[hierarchy];
-    const borderRadius = theme.scheme.semantic.radius[6];
+export const CalloutContainer = styled.div<CalloutContainerProps>(
+  ({ theme, $size, $styleToken }) => {
+    const sizeVar = calloutSizeMap[$size];
 
     return {
       width: "100%",
       display: "flex",
       flexDirection: "column",
       alignItems: "flex-start",
-      padding: `${pxToRem(calloutSizeMap[size].paddingTopBottom)} ${pxToRem(calloutSizeMap[size].paddingLeftRight)}`,
-      gap: pxToRem(calloutSizeMap[size].gap),
-      borderRadius: borderRadius,
-      backgroundColor: style.bg,
-      color: style.color,
-      ...getAfterBorderStyle(style.border, style.bg),
+      padding: `${pxToRem(sizeVar.paddingY)} ${pxToRem(sizeVar.paddingX)}`,
+      gap: pxToRem(sizeVar.gap),
+      borderRadius: theme.scheme.semantic.radius[6],
+      backgroundColor: $styleToken.bg,
+      color: $styleToken.color,
+      border: `1px solid ${$styleToken.border}`,
+      borderLeft: `1px solid ${$styleToken.border}`,
     };
   },
 );
 
-export const CalloutContentDiv = styled.div<CalloutPProps>(({ size }) => {
+export const CalloutContentDiv = styled.div<CalloutTextProps>(({ $size }) => {
   return {
     display: "flex",
     flexDirection: "column",
     alignItems: "flex-start",
-    gap: calloutContentSizeMap[size].gap,
+    gap: calloutContentSizeMap[$size].gap,
   };
 });
 
-export const CalloutTitleP = styled.p<CalloutPProps>(({ theme, size }) => {
-  const tokenKey = calloutContentSizeMap[size].title;
-  return { margin: theme.scheme.semantic.spacing[0], ...theme.textStyle[tokenKey] };
+export const CalloutTitleP = styled.p<CalloutTextProps>(({ theme, $size }) => {
+  const tokenKey = calloutContentSizeMap[$size].title;
+  const textStyle = theme.textStyle[tokenKey as keyof typeof theme.textStyle];
+
+  return {
+    margin: 0,
+    ...textStyle,
+  };
 });
 
-export const CalloutContentP = styled.p<CalloutPProps>(({ theme, size }) => {
-  const tokenKey = calloutContentSizeMap[size].content;
-  return { margin: theme.scheme.semantic.spacing[0], ...theme.textStyle[tokenKey] };
+export const CalloutContentP = styled.p<CalloutTextProps>(({ theme, $size }) => {
+  const tokenKey = calloutContentSizeMap[$size].content;
+  const textStyle = theme.textStyle[tokenKey as keyof typeof theme.textStyle];
+
+  return {
+    margin: 0,
+    ...textStyle,
+  };
 });

--- a/packages/jds/src/components/Callout/Callout.tsx
+++ b/packages/jds/src/components/Callout/Callout.tsx
@@ -12,7 +12,6 @@ import {
 } from "./Callout.variants";
 
 const CalloutBasic = ({
-  variant = "hero",
   hierarchy,
   size = "md",
   title,
@@ -25,7 +24,7 @@ const CalloutBasic = ({
     blockButtonProps && calloutBasicButtonStyleMap(buttonSize, blockButtonProps)[hierarchy];
 
   return (
-    <CalloutBasicDiv hierarchy={hierarchy} variant={variant} size={size} className={className}>
+    <CalloutBasicDiv hierarchy={hierarchy} size={size} className={className}>
       {title && <CalloutTitleP size={size}>{title}</CalloutTitleP>}
       <CalloutContentP size={size}>{children}</CalloutContentP>
       {button}
@@ -36,7 +35,6 @@ const CalloutBasic = ({
 CalloutBasic.displayName = "Callout.Basic";
 
 const CalloutFeedback = ({
-  variant = "hero",
   feedback,
   size = "md",
   title,
@@ -49,7 +47,7 @@ const CalloutFeedback = ({
     blockButtonProps && calloutFeedbackButtonStyleMap(buttonSize, blockButtonProps)[feedback];
 
   return (
-    <CalloutFeedbackDiv hierarchy={feedback} variant={variant} size={size} className={className}>
+    <CalloutFeedbackDiv hierarchy={feedback} size={size} className={className}>
       {title && <CalloutTitleP size={size}>{title}</CalloutTitleP>}
       <CalloutContentP size={size}>{children}</CalloutContentP>
       {button}

--- a/packages/jds/src/components/Callout/Callout.tsx
+++ b/packages/jds/src/components/Callout/Callout.tsx
@@ -1,61 +1,48 @@
+import { useTheme } from "@emotion/react";
+
 import {
-  CalloutBasicDiv,
-  CalloutContentP,
-  CalloutTitleP,
-  CalloutFeedbackDiv,
+  CalloutContainer,
   CalloutContentDiv,
+  CalloutTitleP,
+  CalloutContentP,
 } from "./Callout.style";
-import type { BasicCalloutProps, FeedbackCalloutProps } from "./Callout.types";
-import { calloutFeedbackButtonStyleMap, calloutLabelButtonStyleMap } from "./Callout.variants";
+import type { CalloutProps } from "./Callout.types";
+import { getCalloutStyleToken, getButtonConfig } from "./Callout.variants";
+import { LabelButton } from "../Button/LabelButton";
 
-const CalloutBasic = ({
-  hierarchy,
+export const Callout = ({
   size = "md",
   title,
   labelButtonProps,
   children,
   className,
-}: BasicCalloutProps) => {
-  const button = labelButtonProps && calloutLabelButtonStyleMap(size, labelButtonProps)[hierarchy];
+  ...props
+}: CalloutProps) => {
+  const theme = useTheme();
+  const styleToken = getCalloutStyleToken(theme, props);
+  const buttonConfig = labelButtonProps && getButtonConfig(props);
+
+  const renderButton = () => {
+    if (!buttonConfig || !labelButtonProps) return null;
+
+    if (buttonConfig.variant === "feedback") {
+      return (
+        <LabelButton.Feedback intent={buttonConfig.intent!} size={size} {...labelButtonProps} />
+      );
+    }
+
+    return (
+      <LabelButton.Basic hierarchy={buttonConfig.hierarchy} size={size} {...labelButtonProps} />
+    );
+  };
 
   return (
-    <CalloutBasicDiv hierarchy={hierarchy} size={size} className={className}>
-      <CalloutContentDiv size={size}>
-        {title && <CalloutTitleP size={size}>{title}</CalloutTitleP>}
-        <CalloutContentP size={size}>{children}</CalloutContentP>
+    <CalloutContainer $size={size} $styleToken={styleToken} className={className}>
+      <CalloutContentDiv $size={size}>
+        {title && <CalloutTitleP $size={size}>{title}</CalloutTitleP>}
+        <CalloutContentP $size={size}>{children}</CalloutContentP>
       </CalloutContentDiv>
-      {button}
-    </CalloutBasicDiv>
+      {renderButton()}
+    </CalloutContainer>
   );
-};
-
-CalloutBasic.displayName = "Callout.Basic";
-
-const CalloutFeedback = ({
-  feedback,
-  size = "md",
-  title,
-  labelButtonProps,
-  children,
-  className,
-}: FeedbackCalloutProps) => {
-  const button =
-    labelButtonProps && calloutFeedbackButtonStyleMap(size, labelButtonProps)[feedback];
-
-  return (
-    <CalloutFeedbackDiv hierarchy={feedback} size={size} className={className}>
-      <CalloutContentDiv size={size}>
-        {title && <CalloutTitleP size={size}>{title}</CalloutTitleP>}
-        <CalloutContentP size={size}>{children}</CalloutContentP>
-      </CalloutContentDiv>
-      {button}
-    </CalloutFeedbackDiv>
-  );
-};
-
-CalloutFeedback.displayName = "Callout.Feedback";
-
-export const Callout = {
-  Basic: CalloutBasic,
-  Feedback: CalloutFeedback,
 };

--- a/packages/jds/src/components/Callout/Callout.tsx
+++ b/packages/jds/src/components/Callout/Callout.tsx
@@ -3,30 +3,27 @@ import {
   CalloutContentP,
   CalloutTitleP,
   CalloutFeedbackDiv,
+  CalloutContentDiv,
 } from "./Callout.style";
 import type { BasicCalloutProps, FeedbackCalloutProps } from "./Callout.types";
-import {
-  calloutBasicButtonStyleMap,
-  calloutButtonSizeMap,
-  calloutFeedbackButtonStyleMap,
-} from "./Callout.variants";
+import { calloutFeedbackButtonStyleMap, calloutLabelButtonStyleMap } from "./Callout.variants";
 
 const CalloutBasic = ({
   hierarchy,
   size = "md",
   title,
-  blockButtonProps,
+  labelButtonProps,
   children,
   className,
 }: BasicCalloutProps) => {
-  const buttonSize = calloutButtonSizeMap[size];
-  const button =
-    blockButtonProps && calloutBasicButtonStyleMap(buttonSize, blockButtonProps)[hierarchy];
+  const button = labelButtonProps && calloutLabelButtonStyleMap(size, labelButtonProps)[hierarchy];
 
   return (
     <CalloutBasicDiv hierarchy={hierarchy} size={size} className={className}>
-      {title && <CalloutTitleP size={size}>{title}</CalloutTitleP>}
-      <CalloutContentP size={size}>{children}</CalloutContentP>
+      <CalloutContentDiv size={size}>
+        {title && <CalloutTitleP size={size}>{title}</CalloutTitleP>}
+        <CalloutContentP size={size}>{children}</CalloutContentP>
+      </CalloutContentDiv>
       {button}
     </CalloutBasicDiv>
   );
@@ -38,18 +35,19 @@ const CalloutFeedback = ({
   feedback,
   size = "md",
   title,
-  blockButtonProps,
+  labelButtonProps,
   children,
   className,
 }: FeedbackCalloutProps) => {
-  const buttonSize = calloutButtonSizeMap[size];
   const button =
-    blockButtonProps && calloutFeedbackButtonStyleMap(buttonSize, blockButtonProps)[feedback];
+    labelButtonProps && calloutFeedbackButtonStyleMap(size, labelButtonProps)[feedback];
 
   return (
     <CalloutFeedbackDiv hierarchy={feedback} size={size} className={className}>
-      {title && <CalloutTitleP size={size}>{title}</CalloutTitleP>}
-      <CalloutContentP size={size}>{children}</CalloutContentP>
+      <CalloutContentDiv size={size}>
+        {title && <CalloutTitleP size={size}>{title}</CalloutTitleP>}
+        <CalloutContentP size={size}>{children}</CalloutContentP>
+      </CalloutContentDiv>
       {button}
     </CalloutFeedbackDiv>
   );

--- a/packages/jds/src/components/Callout/Callout.types.ts
+++ b/packages/jds/src/components/Callout/Callout.types.ts
@@ -1,6 +1,6 @@
 import type { ReactNode } from "react";
 
-import type { BaseBlockButtonProps } from "../Button/BlockButton/blockButton.types";
+import type { LabelButtonBasicProps } from "../Button/LabelButton";
 
 export type BasicHierarchy = "primary" | "secondary";
 export type FeedbackHierarchy = "positive" | "destructive" | "notifying";
@@ -10,7 +10,7 @@ export interface BaseCalloutProps {
   size?: CalloutSize;
   title?: string;
   className?: string;
-  blockButtonProps?: Omit<BaseBlockButtonProps, "size">;
+  labelButtonProps?: Omit<LabelButtonBasicProps, "size">;
   children: ReactNode;
 }
 

--- a/packages/jds/src/components/Callout/Callout.types.ts
+++ b/packages/jds/src/components/Callout/Callout.types.ts
@@ -2,20 +2,16 @@ import type { ReactNode } from "react";
 
 import type { BaseBlockButtonProps } from "../Button/BlockButton/blockButton.types";
 
-export type BasicHierarchy = "accent" | "primary" | "secondary";
+export type BasicHierarchy = "primary" | "secondary";
 export type FeedbackHierarchy = "positive" | "destructive" | "notifying";
-export type CalloutVariant = "hero" | "hint";
-export type CalloutSize = "lg" | "md" | "sm" | "xs" | "2xs";
+export type CalloutSize = "lg" | "md" | "sm" | "xs";
 
 export interface BaseCalloutProps {
-  variant?: CalloutVariant;
   size?: CalloutSize;
-  titleVisible?: boolean;
-  extraButtonVisible?: boolean;
   title?: string;
+  className?: string;
   blockButtonProps?: Omit<BaseBlockButtonProps, "size">;
   children: ReactNode;
-  className?: string;
 }
 
 export interface BasicCalloutProps extends BaseCalloutProps {
@@ -28,13 +24,11 @@ export interface FeedbackCalloutProps extends BaseCalloutProps {
 
 export interface CalloutBasicDivProps {
   hierarchy: BasicHierarchy;
-  variant: CalloutVariant;
   size: CalloutSize;
 }
 
 export interface CalloutFeedbackDivProps {
   hierarchy: FeedbackHierarchy;
-  variant: CalloutVariant;
   size: CalloutSize;
 }
 

--- a/packages/jds/src/components/Callout/Callout.types.ts
+++ b/packages/jds/src/components/Callout/Callout.types.ts
@@ -14,24 +14,29 @@ export interface BaseCalloutProps {
   children: ReactNode;
 }
 
-export interface BasicCalloutProps extends BaseCalloutProps {
-  hierarchy: BasicHierarchy;
+export interface BasicCalloutModeProps extends BaseCalloutProps {
+  hierarchy?: BasicHierarchy;
+  feedback?: never;
 }
 
-export interface FeedbackCalloutProps extends BaseCalloutProps {
+export interface FeedbackCalloutModeProps extends BaseCalloutProps {
   feedback: FeedbackHierarchy;
+  hierarchy?: never;
 }
 
-export interface CalloutBasicDivProps {
-  hierarchy: BasicHierarchy;
-  size: CalloutSize;
+export type CalloutProps = BasicCalloutModeProps | FeedbackCalloutModeProps;
+
+export interface CalloutStyleToken {
+  bg: string;
+  border: string;
+  color: string;
 }
 
-export interface CalloutFeedbackDivProps {
-  hierarchy: FeedbackHierarchy;
-  size: CalloutSize;
+export interface CalloutContainerProps {
+  $size: CalloutSize;
+  $styleToken: CalloutStyleToken;
 }
 
-export interface CalloutPProps {
-  size: CalloutSize;
+export interface CalloutTextProps {
+  $size: CalloutSize;
 }

--- a/packages/jds/src/components/Callout/Callout.variants.tsx
+++ b/packages/jds/src/components/Callout/Callout.variants.tsx
@@ -1,64 +1,54 @@
 import type { Theme } from "@emotion/react";
 
-import type { BasicHierarchy, CalloutSize, FeedbackHierarchy } from "./Callout.types";
-import { LabelButton, type LabelButtonBasicProps } from "../Button/LabelButton";
+import type { BasicHierarchy, CalloutStyleToken, FeedbackHierarchy } from "./Callout.types";
+import type { LabelButtonBasicProps } from "../Button/LabelButton";
 
-type BasicStyle = Record<BasicHierarchy, { bg: string; border: string; color: string }>;
-
-export const calloutBasicStylesMap = (theme: Theme): BasicStyle => ({
-  primary: {
+const basicStyles: Record<BasicHierarchy, (t: Theme) => CalloutStyleToken> = {
+  primary: theme => ({
     bg: theme.color.semantic.fill.subtler,
     border: theme.color.semantic.stroke.alpha.assistive,
     color: theme.color.semantic.object.bold,
-  },
-  secondary: {
+  }),
+  secondary: theme => ({
     bg: theme.color.semantic.fill.subtlest,
     border: theme.color.semantic.stroke.alpha.subtle,
     color: theme.color.semantic.object.bold,
-  },
-});
+  }),
+};
 
-type FeedbackStyle = Record<FeedbackHierarchy, { bg: string; border: string; color: string }>;
-
-export const calloutFeedbackStylesMap = (theme: Theme): FeedbackStyle => ({
-  positive: {
+const feedbackStyles: Record<FeedbackHierarchy, (t: Theme) => CalloutStyleToken> = {
+  positive: theme => ({
     bg: theme.color.semantic.feedback.positive.alpha.subtlest,
     border: theme.color.semantic.feedback.positive.alpha.subtler,
     color: theme.color.semantic.feedback.positive.normal,
-  },
-  destructive: {
+  }),
+  destructive: theme => ({
     bg: theme.color.semantic.feedback.destructive.alpha.subtlest,
     border: theme.color.semantic.feedback.destructive.alpha.subtler,
     color: theme.color.semantic.feedback.destructive.normal,
-  },
-  notifying: {
+  }),
+  notifying: theme => ({
     bg: theme.color.semantic.feedback.notifying.alpha.subtlest,
     border: theme.color.semantic.feedback.notifying.alpha.subtler,
     color: theme.color.semantic.feedback.notifying.normal,
-  },
-});
+  }),
+};
+
+export const getCalloutStyleToken = (
+  theme: Theme,
+  props: { hierarchy?: BasicHierarchy; feedback?: FeedbackHierarchy },
+): CalloutStyleToken => {
+  if (props.feedback) return feedbackStyles[props.feedback](theme);
+
+  const hierarchy = props.hierarchy || "secondary";
+  return basicStyles[hierarchy](theme);
+};
 
 export const calloutSizeMap = {
-  lg: {
-    paddingTopBottom: 16,
-    paddingLeftRight: 20,
-    gap: 16,
-  },
-  md: {
-    paddingTopBottom: 16,
-    paddingLeftRight: 20,
-    gap: 16,
-  },
-  sm: {
-    paddingTopBottom: 16,
-    paddingLeftRight: 20,
-    gap: 16,
-  },
-  xs: {
-    paddingTopBottom: 12,
-    paddingLeftRight: 16,
-    gap: 12,
-  },
+  lg: { paddingY: 16, paddingX: 20, gap: 16 },
+  md: { paddingY: 16, paddingX: 20, gap: 16 },
+  sm: { paddingY: 16, paddingX: 20, gap: 16 },
+  xs: { paddingY: 12, paddingX: 16, gap: 12 },
 } as const;
 
 export const calloutContentSizeMap = {
@@ -84,19 +74,23 @@ export const calloutContentSizeMap = {
   },
 } as const;
 
-export const calloutLabelButtonStyleMap = (
-  size: CalloutSize,
-  labelButtonProps: Omit<LabelButtonBasicProps, "size">,
-) => ({
-  primary: <LabelButton.Basic hierarchy='primary' size={size} {...labelButtonProps} />,
-  secondary: <LabelButton.Basic hierarchy='secondary' size={size} {...labelButtonProps} />,
-});
+type ButtonConfig = {
+  hierarchy?: LabelButtonBasicProps["hierarchy"];
+  intent?: "positive" | "destructive";
+  variant: "basic" | "feedback";
+};
 
-export const calloutFeedbackButtonStyleMap = (
-  size: CalloutSize,
-  labelButtonProps: Omit<LabelButtonBasicProps, "size">,
-) => ({
-  notifying: <LabelButton.Basic hierarchy='primary' size={size} {...labelButtonProps} />,
-  positive: <LabelButton.Feedback intent='positive' size={size} {...labelButtonProps} />,
-  destructive: <LabelButton.Feedback intent='destructive' size={size} {...labelButtonProps} />,
-});
+export const getButtonConfig = (mode: {
+  hierarchy?: BasicHierarchy;
+  feedback?: FeedbackHierarchy;
+}): ButtonConfig => {
+  if (mode.feedback) {
+    if (mode.feedback === "notifying") {
+      return { variant: "basic", hierarchy: "primary" };
+    }
+
+    return { variant: "feedback", intent: mode.feedback };
+  }
+
+  return { variant: "basic", hierarchy: mode.hierarchy || "secondary" };
+};

--- a/packages/jds/src/components/Callout/Callout.variants.tsx
+++ b/packages/jds/src/components/Callout/Callout.variants.tsx
@@ -1,11 +1,6 @@
 import type { Theme } from "@emotion/react";
 
-import type {
-  BasicHierarchy,
-  CalloutSize,
-  CalloutVariant,
-  FeedbackHierarchy,
-} from "./Callout.types";
+import type { BasicHierarchy, CalloutSize, FeedbackHierarchy } from "./Callout.types";
 import type { BlockButtonSize } from "../Button/BlockButton";
 import { BlockButton } from "../Button/BlockButton";
 import type { BaseBlockButtonProps } from "../Button/BlockButton/blockButton.types";
@@ -15,128 +10,71 @@ export const calloutButtonSizeMap: Record<CalloutSize, BlockButtonSize> = {
   md: "sm",
   sm: "sm",
   xs: "xs",
-  "2xs": "xs",
 };
 
-type BasicStyle = Record<
-  CalloutVariant,
-  Record<BasicHierarchy, { bg: string; border: string; color: string }>
->;
+type BasicStyle = Record<BasicHierarchy, { bg: string; border: string; color: string }>;
 
 export const calloutBasicStylesMap = (theme: Theme): BasicStyle => ({
-  hero: {
-    accent: {
-      bg: theme.color.semantic.accent.alpha.subtler,
-      border: theme.color.semantic.accent.neutral,
-      color: theme.color.semantic.accent.bold,
-    },
-    primary: {
-      bg: theme.color.semantic.fill.subtler,
-      border: theme.color.semantic.stroke.bold,
-      color: theme.color.semantic.object.bolder,
-    },
-    secondary: {
-      bg: theme.color.semantic.fill.subtlest,
-      border: theme.color.semantic.stroke.neutral,
-      color: theme.color.semantic.object.bold,
-    },
+  primary: {
+    bg: theme.color.semantic.surface.deep,
+    border: theme.color.semantic.stroke.alpha.assistive,
+    color: theme.color.semantic.object.bold,
   },
-  hint: {
-    accent: {
-      bg: theme.color.semantic.accent.alpha.inverse.subtlest,
-      border: theme.color.semantic.accent.alpha.subtle,
-      color: theme.color.semantic.accent.normal,
-    },
-    primary: {
-      bg: theme.color.semantic.surface.deep,
-      border: theme.color.semantic.stroke.alpha.assistive,
-      color: theme.color.semantic.object.bold,
-    },
-    secondary: {
-      bg: theme.color.semantic.surface.deep,
-      border: theme.color.semantic.stroke.alpha.subtler,
-      color: theme.color.semantic.object.normal,
-    },
+  secondary: {
+    bg: theme.color.semantic.surface.deep,
+    border: theme.color.semantic.stroke.alpha.subtler,
+    color: theme.color.semantic.object.normal,
   },
 });
 
-type FeedbackStyle = Record<
-  CalloutVariant,
-  Record<FeedbackHierarchy, { bg: string; border: string; color: string }>
->;
+type FeedbackStyle = Record<FeedbackHierarchy, { bg: string; border: string; color: string }>;
 
 export const calloutFeedbackStylesMap = (theme: Theme): FeedbackStyle => ({
-  hero: {
-    positive: {
-      bg: theme.color.semantic.feedback.positive.alpha.subtler,
-      border: theme.color.semantic.feedback.positive.neutral,
-      color: theme.color.semantic.feedback.positive.bold,
-    },
-    destructive: {
-      bg: theme.color.semantic.feedback.destructive.alpha.subtler,
-      border: theme.color.semantic.feedback.destructive.neutral,
-      color: theme.color.semantic.feedback.destructive.bold,
-    },
-    notifying: {
-      bg: theme.color.semantic.feedback.notifying.alpha.subtler,
-      border: theme.color.semantic.feedback.notifying.neutral,
-      color: theme.color.semantic.feedback.notifying.bold,
-    },
+  positive: {
+    bg: theme.color.semantic.feedback.positive.alpha.subtlest,
+    border: theme.color.semantic.feedback.positive.alpha.subtler,
+    color: theme.color.semantic.feedback.positive.normal,
   },
-  hint: {
-    positive: {
-      bg: theme.color.semantic.feedback.positive.alpha.subtlest,
-      border: theme.color.semantic.feedback.positive.alpha.subtler,
-      color: theme.color.semantic.feedback.positive.normal,
-    },
-    destructive: {
-      bg: theme.color.semantic.feedback.destructive.alpha.subtlest,
-      border: theme.color.semantic.feedback.destructive.alpha.subtler,
-      color: theme.color.semantic.feedback.destructive.normal,
-    },
-    notifying: {
-      bg: theme.color.semantic.feedback.notifying.alpha.subtlest,
-      border: theme.color.semantic.feedback.notifying.alpha.subtler,
-      color: theme.color.semantic.feedback.notifying.normal,
-    },
+  destructive: {
+    bg: theme.color.semantic.feedback.destructive.alpha.subtlest,
+    border: theme.color.semantic.feedback.destructive.alpha.subtler,
+    color: theme.color.semantic.feedback.destructive.normal,
+  },
+  notifying: {
+    bg: theme.color.semantic.feedback.notifying.alpha.subtlest,
+    border: theme.color.semantic.feedback.notifying.alpha.subtler,
+    color: theme.color.semantic.feedback.notifying.normal,
   },
 });
 
 export const calloutSizeMap = {
   lg: {
     paddingTopBottom: 16,
-    paddingLeftRight: 24,
+    paddingLeftRight: 20,
     gap: 16,
     title: "semantic-textStyle-title-2",
     content: "semantic-textStyle-body-lg-bold",
   },
   md: {
     paddingTopBottom: 16,
-    paddingLeftRight: 24,
+    paddingLeftRight: 20,
     gap: 16,
     title: "semantic-textStyle-title-1",
     content: "semantic-textStyle-body-md-bold",
   },
   sm: {
     paddingTopBottom: 16,
-    paddingLeftRight: 24,
+    paddingLeftRight: 20,
     gap: 16,
     title: "semantic-textStyle-label-lg-bold",
     content: "semantic-textStyle-body-sm-bold",
   },
   xs: {
     paddingTopBottom: 12,
-    paddingLeftRight: 20,
+    paddingLeftRight: 16,
     gap: 12,
     title: "semantic-textStyle-label-md-bold",
     content: "semantic-textStyle-body-xs-bold",
-  },
-  "2xs": {
-    paddingTopBottom: 12,
-    paddingLeftRight: 20,
-    gap: 12,
-    title: "semantic-textStyle-label-sm-bold",
-    content: "semantic-textStyle-body-2xs-bold",
   },
 } as const;
 

--- a/packages/jds/src/components/Callout/Callout.variants.tsx
+++ b/packages/jds/src/components/Callout/Callout.variants.tsx
@@ -1,29 +1,20 @@
 import type { Theme } from "@emotion/react";
 
 import type { BasicHierarchy, CalloutSize, FeedbackHierarchy } from "./Callout.types";
-import type { BlockButtonSize } from "../Button/BlockButton";
-import { BlockButton } from "../Button/BlockButton";
-import type { BaseBlockButtonProps } from "../Button/BlockButton/blockButton.types";
-
-export const calloutButtonSizeMap: Record<CalloutSize, BlockButtonSize> = {
-  lg: "sm",
-  md: "sm",
-  sm: "sm",
-  xs: "xs",
-};
+import { LabelButton, type LabelButtonBasicProps } from "../Button/LabelButton";
 
 type BasicStyle = Record<BasicHierarchy, { bg: string; border: string; color: string }>;
 
 export const calloutBasicStylesMap = (theme: Theme): BasicStyle => ({
   primary: {
-    bg: theme.color.semantic.surface.deep,
+    bg: theme.color.semantic.fill.subtler,
     border: theme.color.semantic.stroke.alpha.assistive,
     color: theme.color.semantic.object.bold,
   },
   secondary: {
-    bg: theme.color.semantic.surface.deep,
-    border: theme.color.semantic.stroke.alpha.subtler,
-    color: theme.color.semantic.object.normal,
+    bg: theme.color.semantic.fill.subtlest,
+    border: theme.color.semantic.stroke.alpha.subtle,
+    color: theme.color.semantic.object.bold,
   },
 });
 
@@ -52,71 +43,60 @@ export const calloutSizeMap = {
     paddingTopBottom: 16,
     paddingLeftRight: 20,
     gap: 16,
-    title: "semantic-textStyle-title-2",
-    content: "semantic-textStyle-body-lg-bold",
   },
   md: {
     paddingTopBottom: 16,
     paddingLeftRight: 20,
     gap: 16,
-    title: "semantic-textStyle-title-1",
-    content: "semantic-textStyle-body-md-bold",
   },
   sm: {
     paddingTopBottom: 16,
     paddingLeftRight: 20,
     gap: 16,
-    title: "semantic-textStyle-label-lg-bold",
-    content: "semantic-textStyle-body-sm-bold",
   },
   xs: {
     paddingTopBottom: 12,
     paddingLeftRight: 16,
     gap: 12,
-    title: "semantic-textStyle-label-md-bold",
-    content: "semantic-textStyle-body-xs-bold",
   },
 } as const;
 
-export const calloutBasicButtonStyleMap = (
-  buttonSize: BlockButtonSize,
-  blockButtonProps: Omit<BaseBlockButtonProps, "size">,
+export const calloutContentSizeMap = {
+  lg: {
+    gap: 10,
+    title: "semantic-textStyle-title-1",
+    content: "semantic-textStyle-body-lg-normal",
+  },
+  md: {
+    gap: 10,
+    title: "semantic-textStyle-label-lg-bold",
+    content: "semantic-textStyle-body-md-normal",
+  },
+  sm: {
+    gap: 6,
+    title: "semantic-textStyle-label-md-bold",
+    content: "semantic-textStyle-body-sm-normal",
+  },
+  xs: {
+    gap: 6,
+    title: "semantic-textStyle-label-sm-bold",
+    content: "semantic-textStyle-body-2xs-normal",
+  },
+} as const;
+
+export const calloutLabelButtonStyleMap = (
+  size: CalloutSize,
+  labelButtonProps: Omit<LabelButtonBasicProps, "size">,
 ) => ({
-  accent: (
-    <BlockButton.Basic hierarchy='accent' size={buttonSize} variant='solid' {...blockButtonProps} />
-  ),
-  primary: (
-    <BlockButton.Basic
-      hierarchy='primary'
-      size={buttonSize}
-      variant='solid'
-      {...blockButtonProps}
-    />
-  ),
-  secondary: (
-    <BlockButton.Basic
-      hierarchy='secondary'
-      size={buttonSize}
-      variant='solid'
-      {...blockButtonProps}
-    />
-  ),
+  primary: <LabelButton.Basic hierarchy='primary' size={size} {...labelButtonProps} />,
+  secondary: <LabelButton.Basic hierarchy='secondary' size={size} {...labelButtonProps} />,
 });
 
 export const calloutFeedbackButtonStyleMap = (
-  buttonSize: BlockButtonSize,
-  blockButtonProps: Omit<BaseBlockButtonProps, "size">,
+  size: CalloutSize,
+  labelButtonProps: Omit<LabelButtonBasicProps, "size">,
 ) => ({
-  notifying: (
-    <BlockButton.Basic
-      hierarchy='primary'
-      size={buttonSize}
-      variant='solid'
-      {...blockButtonProps}
-    />
-  ),
-  positive: <BlockButton.Feedback intent='positive' size={buttonSize} {...blockButtonProps} />,
-  destructive: (
-    <BlockButton.Feedback intent='destructive' size={buttonSize} {...blockButtonProps} />
-  ),
+  notifying: <LabelButton.Basic hierarchy='primary' size={size} {...labelButtonProps} />,
+  positive: <LabelButton.Feedback intent='positive' size={size} {...labelButtonProps} />,
+  destructive: <LabelButton.Feedback intent='destructive' size={size} {...labelButtonProps} />,
 });

--- a/packages/jds/src/components/Callout/index.ts
+++ b/packages/jds/src/components/Callout/index.ts
@@ -1,2 +1,1 @@
 export * from "./Callout";
-export type { BasicCalloutProps, FeedbackCalloutProps } from "./Callout.types";

--- a/packages/jds/src/components/EmptyState/emptyState.styles.ts
+++ b/packages/jds/src/components/EmptyState/emptyState.styles.ts
@@ -9,24 +9,10 @@ import { Label } from "../Label";
 const variantStylesMap = {
   outlined: (theme: Theme): CSSObject => ({
     backgroundColor: "transparent",
-    "&::after": {
-      content: '""',
-      position: "absolute",
-      inset: 0,
-      borderRadius: "inherit",
-      border: `1px dashed ${theme.color.semantic.stroke.alpha.assistive}`,
-      pointerEvents: "none",
-    },
+    border: `1px dashed ${theme.color.semantic.stroke.alpha.assistive}`,
   }),
   alpha: (theme: Theme): CSSObject => ({
-    "&::after": {
-      content: '""',
-      position: "absolute",
-      inset: 0,
-      borderRadius: "inherit",
-      backgroundColor: theme.color.semantic.fill.subtlest,
-      pointerEvents: "none",
-    },
+    backgroundColor: theme.color.semantic.fill.subtlest,
   }),
 };
 


### PR DESCRIPTION
## 💡 작업 내용

- [x] figma에서 사용되지 않는 props 제거
- [x] figma 디자인 변경점 대응
- [x] feedback 상태를 prop으로 관리할 수 있도록 변경
- [x] web이 로컬 패키지에 영향받지 않도록 버전 수정

## 💡 자세한 설명

### 1. 피그마 변경점 대응

> figma에서 사용되지 않는 props와 디자인 변경점 대응을 진행했습니다. 변경 사항은 아래와 같습니다:

- 삭제된 props 및 변경된 타입
  - hierarchy 'accent' 제거
  - variant 제거 (hint만 존재)
  - size '2xs' 제거
  - 사용되고 있지 않은 props 타입 제거
- 디자인 변경점
  - blockButton을 labelButton으로 변경
  - border가 콘텐츠 영역을 차지하지 않도록 가상 요소로 부여
  - 디자인 변경 대응 (배경 색상 및 폰트 크기)

<img width="907" height="556" alt="스크린샷 2026-02-24 오후 7 47 25" src="https://github.com/user-attachments/assets/683f263f-6f45-4fc6-b72b-9062805cf49f" />

### 2. feedback 상태를 prop으로 관리할 수 있도록 변경

> 통합된 컴포넌트로 관리할 수 있다고 판단해 `feedback` 상태를 prop으로 관리할 수 있도록 수정했습니다. 해당 이슈는 코드 확인 부탁드립니다.

<img width="891" height="105" alt="스크린샷 2026-02-24 오후 7 47 52" src="https://github.com/user-attachments/assets/9e9f86cd-c153-48f5-82ed-59079e71c732" />

<img width="907" height="744" alt="스크린샷 2026-02-24 오후 7 47 42" src="https://github.com/user-attachments/assets/cc307d6b-1edc-4ed5-aa0e-1c64aab904f9" />

### 3. web이 로컬 패키지에 영향받지 않도록 버전 수정

> 현재 web이 monorepo의 영향으로 로컬 패키지를 참조하고 있는 것을 확인했습니다. 리팩토링 변경점에 영향을 받지 않도록 `@jects/jds` 로컬 버전을 `0.0.2-dev`로 수정해 web이 로컬 jds 패키지를 바라보지 않을 수 있도록 변경했습니다. 

```json
  "name": "@jects/jds",
  "version": "0.0.2-dev",
```

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #378 
