### PR TITLE
refactor: Select 컴포넌트 QA 대응

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -35,7 +35,7 @@
     "react": "^18.3.1",
     "react-device-detect": "^2.2.3",
     "react-dom": "^18.3.1",
-    "react-error-boundary": "^6.0.0",
+    "react-error-boundary": "6.0.0",
     "react-hook-form": "^7.54.2",
     "react-router-dom": "^7.1.5",
     "tailwindcss": "^4.0.0",

--- a/apps/web/src/features/apply/steps/registration/components/PortfolioFileItem.tsx
+++ b/apps/web/src/features/apply/steps/registration/components/PortfolioFileItem.tsx
@@ -1,4 +1,4 @@
-import { FileItem } from "@jects/jds";
+import { FileItem, IconButton } from "@jects/jds";
 
 import type { PortfolioFile } from "@/types/apis/application";
 import { changeFileSizeUnit } from "@/utils/changeFileSizeUnit";
@@ -22,8 +22,11 @@ export function PortfolioFileItem({ portfolio, onDelete }: PortfolioFileItemProp
       fileName={portfolio.fileName}
       fileSize={changeFileSizeUnit(Number(portfolio.fileSize), ["KB", "MB"], true)}
       onClick={openFile}
-      removeable
-      onRemove={handleDelete}
+      suffixButton={
+        <IconButton.Basic size='lg' hierarchy='tertiary' icon='close-line' onClick={handleDelete}>
+          삭제
+        </IconButton.Basic>
+      }
     />
   );
 }

--- a/apps/web/src/features/apply/steps/registration/components/PortfolioFileItem.tsx
+++ b/apps/web/src/features/apply/steps/registration/components/PortfolioFileItem.tsx
@@ -1,4 +1,4 @@
-import { FileItem, IconButton } from "@jects/jds";
+import { FileItem } from "@jects/jds";
 
 import type { PortfolioFile } from "@/types/apis/application";
 import { changeFileSizeUnit } from "@/utils/changeFileSizeUnit";
@@ -22,11 +22,8 @@ export function PortfolioFileItem({ portfolio, onDelete }: PortfolioFileItemProp
       fileName={portfolio.fileName}
       fileSize={changeFileSizeUnit(Number(portfolio.fileSize), ["KB", "MB"], true)}
       onClick={openFile}
-      suffixButton={
-        <IconButton.Basic size='lg' hierarchy='tertiary' icon='close-line' onClick={handleDelete}>
-          삭제
-        </IconButton.Basic>
-      }
+      removeable
+      onRemove={handleDelete}
     />
   );
 }

--- a/apps/web/src/pages/TeamProject.tsx
+++ b/apps/web/src/pages/TeamProject.tsx
@@ -58,7 +58,7 @@ const TeamProject = () => {
             <SelectField value={value} isOpen={isOpen} onClick={() => setIsOpen(!isOpen)} />
             {isOpen && (
               <div className='absolute z-40 w-full translate-y-2'>
-                <Select variant='list' value={value} onChange={handleSelect}>
+                <Select variant='label' value={value} onChange={handleSelect}>
                   <Select.Label value='전체(12)'>전체(12)</Select.Label>
                   <Select.Label value='3기(6)'>3기(6)</Select.Label>
                   <Select.Label value='2기(2)'>2기(2)</Select.Label>

--- a/apps/web/src/pages/TeamProject.tsx
+++ b/apps/web/src/pages/TeamProject.tsx
@@ -58,7 +58,7 @@ const TeamProject = () => {
             <SelectField value={value} isOpen={isOpen} onClick={() => setIsOpen(!isOpen)} />
             {isOpen && (
               <div className='absolute z-40 w-full translate-y-2'>
-                <Select variant='label' value={value} onChange={handleSelect}>
+                <Select variant='list' value={value} onChange={handleSelect}>
                   <Select.Label value='전체(12)'>전체(12)</Select.Label>
                   <Select.Label value='3기(6)'>3기(6)</Select.Label>
                   <Select.Label value='2기(2)'>2기(2)</Select.Label>

--- a/packages/jds/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/jds/src/components/Accordion/Accordion.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Accordion } from "./Accordion";
 import type { AccordionRootProps } from "./accordion.types";

--- a/packages/jds/src/components/Badge/contentBadge/ContentBadge.stories.tsx
+++ b/packages/jds/src/components/Badge/contentBadge/ContentBadge.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { ContentBadge } from "./ContentBadge";
 import type {

--- a/packages/jds/src/components/Badge/dotBadge/DotBadge.stories.tsx
+++ b/packages/jds/src/components/Badge/dotBadge/DotBadge.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { DotBadge } from "./DotBadge";
 import type { DotBadgeFeedbackProps } from "./DotBadge";

--- a/packages/jds/src/components/Badge/numericBadge/NumericBadge.stories.tsx
+++ b/packages/jds/src/components/Badge/numericBadge/NumericBadge.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { NumericBadge } from "./NumericBadge";
 import type { NumericBadgeBasicProps, NumericBasicBadgeProps } from "./NumericBadge";

--- a/packages/jds/src/components/Banner/BannerBar.stories.tsx
+++ b/packages/jds/src/components/Banner/BannerBar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import type { BannerBarProps } from "./banner.types";
 import { Banner } from "./index";

--- a/packages/jds/src/components/Banner/BannerImage.stories.tsx
+++ b/packages/jds/src/components/Banner/BannerImage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import type { BannerImageProps } from "./banner.types";
 import { Banner } from "./index";

--- a/packages/jds/src/components/Button/BlockButton/BlockButton.stories.tsx
+++ b/packages/jds/src/components/Button/BlockButton/BlockButton.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexRow, FlexColumn, Label } from "@storybook-utils/layout";
 import { BlockButton } from "components";
 

--- a/packages/jds/src/components/Button/IconButton/IconButton.stories.tsx
+++ b/packages/jds/src/components/Button/IconButton/IconButton.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexRow, FlexColumn, Label } from "@storybook-utils/layout";
 import { IconButton } from "components";
 

--- a/packages/jds/src/components/Button/LabelButton/LabelButton.stories.tsx
+++ b/packages/jds/src/components/Button/LabelButton/LabelButton.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexRow, FlexColumn, Label } from "@storybook-utils/layout";
 import { LabelButton } from "components";
 

--- a/packages/jds/src/components/Callout/Callout.stories.tsx
+++ b/packages/jds/src/components/Callout/Callout.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Callout } from "./Callout";
 

--- a/packages/jds/src/components/Card/Card.stories.tsx
+++ b/packages/jds/src/components/Card/Card.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Card } from "./index";
 

--- a/packages/jds/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/jds/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexRow, FlexColumn, Label } from "@storybook-utils/layout";
 import { Checkbox, type CheckedState } from "components";
 import { useState } from "react";

--- a/packages/jds/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/jds/src/components/Dialog/Dialog.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexRow } from "@storybook-utils/layout";
 import { useState } from "react";
 

--- a/packages/jds/src/components/Divider/Divider.stories.tsx
+++ b/packages/jds/src/components/Divider/Divider.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 
 import { Divider } from "./Divider";

--- a/packages/jds/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/jds/src/components/EmptyState/EmptyState.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn } from "@storybook-utils/layout";
 
 import { EmptyState } from "./EmptyState";

--- a/packages/jds/src/components/Footer/Footer.stories.tsx
+++ b/packages/jds/src/components/Footer/Footer.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Footer } from "./Footer";
 import type { FooterSection } from "./footer.types";

--- a/packages/jds/src/components/Hero/Hero.stories.tsx
+++ b/packages/jds/src/components/Hero/Hero.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Hero } from "./Hero";
 

--- a/packages/jds/src/components/Icon/Icon.stories.tsx
+++ b/packages/jds/src/components/Icon/Icon.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Icon } from "./Icon";
 

--- a/packages/jds/src/components/Image/Image.stories.tsx
+++ b/packages/jds/src/components/Image/Image.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Image } from "./Image";
 

--- a/packages/jds/src/components/Input/InputArea/InputArea.stories.tsx
+++ b/packages/jds/src/components/Input/InputArea/InputArea.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 
 import { InputArea } from "./InputArea";
@@ -102,7 +102,7 @@ export const Default: Story = {
     label: "피드백",
     helperText: "자유롭게 피드백을 작성해주세요",
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -125,7 +125,7 @@ export const FixedHeight: Story = {
     height: 200,
     helperText: "높이가 200px로 고정되어 있습니다. 내용 초과 시 스크롤됩니다.",
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -149,7 +149,7 @@ export const DynamicHeight: Story = {
     helperText: "최소 150px이며, 내용 입력 또는 우측 하단 핸들로 크기를 조절할 수 있습니다",
     maxLength: 1000,
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -172,7 +172,7 @@ export const CSSHeightValue: Story = {
     minHeight: "10rem",
     helperText: "minHeight를 10rem으로 설정했습니다",
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -196,7 +196,7 @@ export const WithCount: Story = {
     maxLength: 500,
     minHeight: 180,
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -220,7 +220,7 @@ export const Error: Story = {
     helperText: "10자 이상 입력해주세요",
     maxLength: 100,
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("짧은 글");
@@ -243,7 +243,7 @@ export const Disabled: Story = {
     interaction: "disabled",
     helperText: "현재 입력이 비활성화되어 있습니다",
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("비활성화된 상태입니다");
@@ -266,7 +266,7 @@ export const ReadOnly: Story = {
     interaction: "readOnly",
     helperText: "읽기 전용 모드입니다",
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("이 텍스트는 읽기 전용입니다. 수정할 수 없습니다.");
@@ -289,7 +289,7 @@ export const EmptyStyle: Story = {
     style: "empty",
     helperText: "테두리가 없는 깔끔한 스타일",
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -312,7 +312,7 @@ export const HorizontalLayout: Story = {
     layout: "horizontal",
     helperText: "레이블이 왼쪽에 위치합니다",
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -335,7 +335,7 @@ export const WithLabelIcon: Story = {
     labelIcon: "information-line",
     helperText: "아이콘을 호버하면 추가 정보를 볼 수 있습니다",
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -357,7 +357,7 @@ export const HelperOnly: Story = {
     label: "Helper만",
     helperText: "Helper 텍스트만 표시됩니다",
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -379,7 +379,7 @@ export const CountOnly: Story = {
     label: "Count만",
     maxLength: 100,
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -402,7 +402,7 @@ export const HiddenLabel: Story = {
     labelVisible: false,
     helperText: "레이블이 숨겨진 상태입니다",
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("");

--- a/packages/jds/src/components/Input/SelectField/SelectField.stories.tsx
+++ b/packages/jds/src/components/Input/SelectField/SelectField.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 import { BlockButton } from "components";
 import { useState } from "react";

--- a/packages/jds/src/components/Input/TagField/TagField.stories.tsx
+++ b/packages/jds/src/components/Input/TagField/TagField.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 import { BlockButton } from "components";
 import { useState } from "react";
@@ -81,7 +81,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     tags: [],
-    onTagsChange: () => {},
+    onTagsChange: () => { },
   },
   render: function Render() {
     const [tags, setTags] = useState<Tag[]>([
@@ -119,7 +119,7 @@ export const Default: Story = {
 export const BasicTagField: Story = {
   args: {
     tags: [],
-    onTagsChange: () => {},
+    onTagsChange: () => { },
   },
   render: function Render() {
     const [tags, setTags] = useState<Tag[]>([
@@ -155,7 +155,7 @@ export const BasicTagField: Story = {
 export const WithLabelIcon: Story = {
   args: {
     tags: [],
-    onTagsChange: () => {},
+    onTagsChange: () => { },
   },
   render: function Render() {
     const [tags, setTags] = useState<Tag[]>([
@@ -189,7 +189,7 @@ export const WithLabelIcon: Story = {
 export const WithValidation: Story = {
   args: {
     tags: [],
-    onTagsChange: () => {},
+    onTagsChange: () => { },
   },
   render: function Render() {
     const [tags1, setTags1] = useState<Tag[]>([{ id: "1", label: "React" }]);
@@ -253,7 +253,7 @@ export const WithValidation: Story = {
 export const States: Story = {
   args: {
     tags: [],
-    onTagsChange: () => {},
+    onTagsChange: () => { },
   },
   render: function Render() {
     const [tags1, setTags1] = useState<Tag[]>([
@@ -286,7 +286,7 @@ export const States: Story = {
           helperText='이 필드는 비활성화되어 있습니다'
           interaction='disabled'
           tags={tags2}
-          onTagsChange={() => {}}
+          onTagsChange={() => { }}
         />
 
         <TagField
@@ -294,7 +294,7 @@ export const States: Story = {
           helperText='이 필드는 읽기 전용 상태입니다'
           interaction='readOnly'
           tags={tags3}
-          onTagsChange={() => {}}
+          onTagsChange={() => { }}
         />
       </FlexColumn>
     );
@@ -315,7 +315,7 @@ export const States: Story = {
 export const ButtonWithValidation: Story = {
   args: {
     tags: [],
-    onTagsChange: () => {},
+    onTagsChange: () => { },
   },
   render: function Render() {
     const [tags1, setTags1] = useState<Tag[]>([{ id: "1", label: "React" }]);
@@ -378,7 +378,7 @@ export const ButtonWithValidation: Story = {
 export const AllStyles: Story = {
   args: {
     tags: [],
-    onTagsChange: () => {},
+    onTagsChange: () => { },
   },
   render: function Render() {
     const [tags1, setTags1] = useState<Tag[]>([
@@ -485,7 +485,7 @@ export const AllStyles: Story = {
 export const Layouts: Story = {
   args: {
     tags: [],
-    onTagsChange: () => {},
+    onTagsChange: () => { },
   },
   render: function Render() {
     const [tags1, setTags1] = useState<Tag[]>([
@@ -539,7 +539,7 @@ export const Layouts: Story = {
 export const AllVariants: Story = {
   args: {
     tags: [],
-    onTagsChange: () => {},
+    onTagsChange: () => { },
   },
   render: function Render() {
     const [basicTags, setBasicTags] = useState<Tag[]>([

--- a/packages/jds/src/components/Input/TextField/TextField.stories.tsx
+++ b/packages/jds/src/components/Input/TextField/TextField.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 import { BlockButton } from "components";
 import { useState } from "react";
@@ -69,7 +69,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   args: {
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render() {
     const [value, setValue] = useState("");
@@ -105,7 +105,7 @@ export const WithLabelIcon: Story = {
     placeholder: "example@ject.com",
     helperText: "유효한 이메일 주소를 입력해주세요",
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -128,7 +128,7 @@ export const WithLabelIcon: Story = {
 export const WithValidation: Story = {
   args: {
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render() {
     const [value1, setValue1] = useState("");
@@ -178,7 +178,7 @@ export const WithValidation: Story = {
 export const States: Story = {
   args: {
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render() {
     const [value1, setValue1] = useState("");
@@ -232,7 +232,7 @@ export const BasicTextField: Story = {
     placeholder: "이메일을 입력하세요",
     helperText: "유효한 이메일 주소를 입력해주세요",
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -257,7 +257,7 @@ export const BasicTextField: Story = {
 export const ButtonWithValidation: Story = {
   args: {
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render() {
     const [value1, setValue1] = useState("");
@@ -310,7 +310,7 @@ export const ButtonWithValidation: Story = {
 export const AllStyles: Story = {
   args: {
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render() {
     const [value1, setValue1] = useState("");
@@ -399,7 +399,7 @@ export const AllStyles: Story = {
 export const Layouts: Story = {
   args: {
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render() {
     const [value1, setValue1] = useState("");
@@ -447,7 +447,7 @@ export const Layouts: Story = {
 export const AllVariants: Story = {
   args: {
     value: "",
-    onChange: () => {},
+    onChange: () => { },
   },
   render: function Render() {
     const [basicValue, setBasicValue] = useState("");

--- a/packages/jds/src/components/Label/Label.stories.tsx
+++ b/packages/jds/src/components/Label/Label.stories.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import type { Decorator, Meta, StoryObj } from "@storybook/react";
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 
 import { Label } from "./Label";
 

--- a/packages/jds/src/components/Logo/Logo.stories.tsx
+++ b/packages/jds/src/components/Logo/Logo.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexRow, FlexColumn, Label } from "@storybook-utils/layout";
 import { Logo } from "components";
 

--- a/packages/jds/src/components/Menu/MegaMenu/MegaMenu.stories.tsx
+++ b/packages/jds/src/components/Menu/MegaMenu/MegaMenu.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { MegaMenu } from "./MegaMenu";
 import { MenuItem } from "../MenuItem";

--- a/packages/jds/src/components/Menu/Menu/Menu.stories.tsx
+++ b/packages/jds/src/components/Menu/Menu/Menu.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexRow } from "@storybook-utils/layout";
 
 import { Menu } from "./Menu";

--- a/packages/jds/src/components/Menu/MenuItem/MenuItem.stories.tsx
+++ b/packages/jds/src/components/Menu/MenuItem/MenuItem.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow } from "@storybook-utils/layout";
 
 import { MenuItem } from ".";

--- a/packages/jds/src/components/Navigation/GlobalNavigation/GlobalNavigation.stories.tsx
+++ b/packages/jds/src/components/Navigation/GlobalNavigation/GlobalNavigation.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { GlobalNavigation } from "./GlobalNavigation";
 import { useGlobalNavigationVariant } from "./useGlobalNavigationVariant";

--- a/packages/jds/src/components/Navigation/LocalNavigation/LocalNavigation.stories.tsx
+++ b/packages/jds/src/components/Navigation/LocalNavigation/LocalNavigation.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { LocalNavigation } from "./LocalNavigation";
 import { IconButton } from "../../Button/IconButton";

--- a/packages/jds/src/components/Radio/Radio.stories.tsx
+++ b/packages/jds/src/components/Radio/Radio.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow } from "@storybook-utils/layout";
 
 import { Radio } from "./Radio";

--- a/packages/jds/src/components/Radio/preset/RadioContent.stories.tsx
+++ b/packages/jds/src/components/Radio/preset/RadioContent.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow } from "@storybook-utils/layout";
 import type { FormEvent } from "react";
 import { useState } from "react";

--- a/packages/jds/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/jds/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 import { useState } from "react";
 

--- a/packages/jds/src/components/Select/Select.stories.tsx
+++ b/packages/jds/src/components/Select/Select.stories.tsx
@@ -1,5 +1,4 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-import type { Meta, StoryObj } from "@storybook/react-vite";
+import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 
 import { Select } from "./index";
@@ -55,7 +54,7 @@ export const Default: Story = {
 
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: "16px", width: "20rem" }}>
-        <Select {...(args as any)} value={currentValue} onChange={handleChange as any}>
+        <Select {...(args)} value={currentValue} onChange={handleChange}>
           <Item value='seoul'>서울특별시</Item>
           <Item value='gyeonggi'>경기도</Item>
           <Item value='incheon'>인천광역시</Item>
@@ -90,7 +89,7 @@ export const WithLabel: Story = {
 
     return (
       <div style={{ width: "20rem" }}>
-        <Select {...(args as any)} value={currentValue} onChange={handleChange as any}>
+        <Select {...(args)} value={currentValue} onChange={handleChange}>
           <Item value='seoul'>서울특별시</Item>
           <Item value='gyeonggi'>경기도</Item>
           <Item value='incheon'>인천광역시</Item>
@@ -120,7 +119,7 @@ export const SmallSize: Story = {
 
     return (
       <div style={{ width: "20rem" }}>
-        <Select {...(args as any)} value={currentValue} onChange={handleChange as any}>
+        <Select {...(args)} value={currentValue} onChange={handleChange}>
           <Item value='option1'>Option 1</Item>
           <Item value='option2'>Option 2</Item>
           <Item value='option3'>Option 3</Item>
@@ -149,7 +148,7 @@ export const WithCaption: Story = {
 
     return (
       <div style={{ width: "20rem" }}>
-        <Select {...(args as any)} value={currentValue} onChange={handleChange as any}>
+        <Select {...(args)} value={currentValue} onChange={handleChange}>
           <Item value='free' caption='무료로 시작하세요'>
             Free
           </Item>
@@ -187,14 +186,14 @@ export const WithBadge: Story = {
 
     return (
       <div style={{ width: "20rem" }}>
-        <Select {...(args as any)} value={currentValue} onChange={handleChange as any}>
-          <Item value='free' caption='무료로 시작하세요' {...(args.variant === 'label' ? { badge: 'Free' } : {}) as any}>
+        <Select {...(args)} value={currentValue} onChange={handleChange}>
+          <Item value='free' caption='무료로 시작하세요' {...(args.variant === 'label' ? { badge: 'Free' } : {})}>
             Free Plan
           </Item>
-          <Item value='pro' caption='개인 사용자에게 추천' {...(args.variant === 'label' ? { badge: '인기' } : {}) as any}>
+          <Item value='pro' caption='개인 사용자에게 추천' {...(args.variant === 'label' ? { badge: '인기' } : {})}>
             Pro Plan
           </Item>
-          <Item value='team' caption='팀 협업을 위한 플랜' {...(args.variant === 'label' ? { badge: 'NEW' } : {}) as any}>
+          <Item value='team' caption='팀 협업을 위한 플랜' {...(args.variant === 'label' ? { badge: 'NEW' } : {})}>
             Team Plan
           </Item>
         </Select>
@@ -222,7 +221,7 @@ export const WithDisabled: Story = {
 
     return (
       <div style={{ width: "20rem" }}>
-        <Select {...(args as any)} value={currentValue} onChange={handleChange as any}>
+        <Select {...(args)} value={currentValue} onChange={handleChange}>
           <Item value='available1'>사용 가능 1</Item>
           <Item value='disabled1' isDisabled>
             비활성화됨 1
@@ -257,14 +256,14 @@ export const AllFeatures: Story = {
 
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: "16px", width: "20rem" }}>
-        <Select {...(args as any)} value={currentValue} onChange={handleChange as any}>
-          <Item value='free' caption='무료 체험 플랜' {...(args.variant === 'label' ? { badge: '무료' } : {}) as any}>
+        <Select {...(args)} value={currentValue} onChange={handleChange}>
+          <Item value='free' caption='무료 체험 플랜' {...(args.variant === 'label' ? { badge: '무료' } : {})}>
             Free
           </Item>
-          <Item value='standard' caption='개인 사용자에게 추천' {...(args.variant === 'label' ? { badge: '인기' } : {}) as any}>
+          <Item value='standard' caption='개인 사용자에게 추천' {...(args.variant === 'label' ? { badge: '인기' } : {})}>
             Standard
           </Item>
-          <Item value='premium' caption='프리미엄 기능 제공' {...(args.variant === 'label' ? { badge: '신규' } : {}) as any}>
+          <Item value='premium' caption='프리미엄 기능 제공' {...(args.variant === 'label' ? { badge: '신규' } : {})}>
             Premium
           </Item>
           <Item value='enterprise' caption='기업용 맞춤 플랜' isDisabled>

--- a/packages/jds/src/components/Select/Select.stories.tsx
+++ b/packages/jds/src/components/Select/Select.stories.tsx
@@ -13,10 +13,10 @@ const meta = {
   argTypes: {
     variant: {
       control: "radio",
-      options: ["label", "checkbox", "radio"],
-      description: "Select의 변형 (label, checkbox, radio)",
+      options: ["list", "checkbox", "radio"],
+      description: "Select의 변형 (list, checkbox, radio)",
       table: {
-        defaultValue: { summary: "label" },
+        defaultValue: { summary: "list" },
       },
     },
     size: {
@@ -39,7 +39,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    variant: "label",
+    variant: "list",
     value: "seoul",
     onChange: () => { },
   },
@@ -51,7 +51,7 @@ export const Default: Story = {
     const currentValue = isMulti ? multiValue : singleValue;
     const handleChange = isMulti ? setMultiValue : setSingleValue;
 
-    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.Label;
+    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.List;
 
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: "16px", width: "20rem" }}>
@@ -74,7 +74,7 @@ export const Default: Story = {
 
 export const WithLabel: Story = {
   args: {
-    variant: "label",
+    variant: "list",
     value: "seoul",
     label: "지역 선택",
     onChange: () => { },
@@ -87,7 +87,7 @@ export const WithLabel: Story = {
     const currentValue = isMulti ? multiValue : singleValue;
     const handleChange = isMulti ? setMultiValue : setSingleValue;
 
-    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.Label;
+    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.List;
 
     return (
       <div style={{ width: "20rem" }}>
@@ -105,7 +105,7 @@ export const WithLabel: Story = {
 
 export const SmallSize: Story = {
   args: {
-    variant: "label",
+    variant: "list",
     value: "option1",
     size: "sm",
     onChange: () => { },
@@ -118,7 +118,7 @@ export const SmallSize: Story = {
     const currentValue = isMulti ? multiValue : singleValue;
     const handleChange = isMulti ? setMultiValue : setSingleValue;
 
-    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.Label;
+    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.List;
 
     return (
       <div style={{ width: "20rem" }}>
@@ -135,7 +135,7 @@ export const SmallSize: Story = {
 
 export const WithCaption: Story = {
   args: {
-    variant: "label",
+    variant: "list",
     value: "pro",
     label: "요금제 선택",
     onChange: () => { },
@@ -148,7 +148,7 @@ export const WithCaption: Story = {
     const currentValue = isMulti ? multiValue : singleValue;
     const handleChange = isMulti ? setMultiValue : setSingleValue;
 
-    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.Label;
+    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.List;
 
     return (
       <div style={{ width: "20rem" }}>
@@ -174,7 +174,7 @@ export const WithCaption: Story = {
 
 export const WithBadge: Story = {
   args: {
-    variant: "label",
+    variant: "list",
     value: "pro",
     label: "요금제 선택",
     onChange: () => { },
@@ -187,19 +187,19 @@ export const WithBadge: Story = {
     const currentValue = isMulti ? multiValue : singleValue;
     const handleChange = isMulti ? setMultiValue : setSingleValue;
 
-    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.Label;
+    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.List;
 
     return (
       <div style={{ width: "20rem" }}>
         {/* @ts-expect-error: TypeScript cannot infer strict conditional matching of variant and value */}
         <Select {...(args)} value={currentValue} onChange={handleChange}>
-          <Item value='free' caption='무료로 시작하세요' {...(args.variant === 'label' ? { badge: 'Free' } : {})}>
+          <Item value='free' caption='무료로 시작하세요' {...(args.variant === 'list' ? { badge: 'Free' } : {})}>
             Free Plan
           </Item>
-          <Item value='pro' caption='개인 사용자에게 추천' {...(args.variant === 'label' ? { badge: '인기' } : {})}>
+          <Item value='pro' caption='개인 사용자에게 추천' {...(args.variant === 'list' ? { badge: '인기' } : {})}>
             Pro Plan
           </Item>
-          <Item value='team' caption='팀 협업을 위한 플랜' {...(args.variant === 'label' ? { badge: 'NEW' } : {})}>
+          <Item value='team' caption='팀 협업을 위한 플랜' {...(args.variant === 'list' ? { badge: 'NEW' } : {})}>
             Team Plan
           </Item>
         </Select>
@@ -210,7 +210,7 @@ export const WithBadge: Story = {
 
 export const WithDisabled: Story = {
   args: {
-    variant: "label",
+    variant: "list",
     value: "available1",
     label: "옵션 선택",
     onChange: () => { },
@@ -223,7 +223,7 @@ export const WithDisabled: Story = {
     const currentValue = isMulti ? multiValue : singleValue;
     const handleChange = isMulti ? setMultiValue : setSingleValue;
 
-    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.Label;
+    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.List;
 
     return (
       <div style={{ width: "20rem" }}>
@@ -245,7 +245,7 @@ export const WithDisabled: Story = {
 
 export const AllFeatures: Story = {
   args: {
-    variant: "label",
+    variant: "list",
     value: "standard",
     label: "서비스 플랜 선택",
     size: "md",
@@ -259,19 +259,19 @@ export const AllFeatures: Story = {
     const currentValue = isMulti ? multiValue : singleValue;
     const handleChange = isMulti ? setMultiValue : setSingleValue;
 
-    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.Label;
+    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.List;
 
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: "16px", width: "20rem" }}>
         {/* @ts-expect-error: TypeScript cannot infer strict conditional matching of variant and value */}
         <Select {...(args)} value={currentValue} onChange={handleChange}>
-          <Item value='free' caption='무료 체험 플랜' {...(args.variant === 'label' ? { badge: '무료' } : {})}>
+          <Item value='free' caption='무료 체험 플랜' {...(args.variant === 'list' ? { badge: '무료' } : {})}>
             Free
           </Item>
-          <Item value='standard' caption='개인 사용자에게 추천' {...(args.variant === 'label' ? { badge: '인기' } : {})}>
+          <Item value='standard' caption='개인 사용자에게 추천' {...(args.variant === 'list' ? { badge: '인기' } : {})}>
             Standard
           </Item>
-          <Item value='premium' caption='프리미엄 기능 제공' {...(args.variant === 'label' ? { badge: '신규' } : {})}>
+          <Item value='premium' caption='프리미엄 기능 제공' {...(args.variant === 'list' ? { badge: '신규' } : {})}>
             Premium
           </Item>
           <Item value='enterprise' caption='기업용 맞춤 플랜' isDisabled>

--- a/packages/jds/src/components/Select/Select.stories.tsx
+++ b/packages/jds/src/components/Select/Select.stories.tsx
@@ -1,5 +1,4 @@
-// eslint-disable-next-line storybook/no-renderer-packages
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 
 import { Select } from "./index";

--- a/packages/jds/src/components/Select/Select.stories.tsx
+++ b/packages/jds/src/components/Select/Select.stories.tsx
@@ -1,3 +1,4 @@
+// eslint-disable-next-line storybook/no-renderer-packages
 import type { Meta, StoryObj } from "@storybook/react";
 import { useState } from "react";
 
@@ -54,6 +55,7 @@ export const Default: Story = {
 
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: "16px", width: "20rem" }}>
+        {/* @ts-expect-error: TypeScript cannot infer strict conditional matching of variant and value */}
         <Select {...(args)} value={currentValue} onChange={handleChange}>
           <Item value='seoul'>서울특별시</Item>
           <Item value='gyeonggi'>경기도</Item>
@@ -89,6 +91,7 @@ export const WithLabel: Story = {
 
     return (
       <div style={{ width: "20rem" }}>
+        {/* @ts-expect-error: TypeScript cannot infer strict conditional matching of variant and value */}
         <Select {...(args)} value={currentValue} onChange={handleChange}>
           <Item value='seoul'>서울특별시</Item>
           <Item value='gyeonggi'>경기도</Item>
@@ -119,6 +122,7 @@ export const SmallSize: Story = {
 
     return (
       <div style={{ width: "20rem" }}>
+        {/* @ts-expect-error: TypeScript cannot infer strict conditional matching of variant and value */}
         <Select {...(args)} value={currentValue} onChange={handleChange}>
           <Item value='option1'>Option 1</Item>
           <Item value='option2'>Option 2</Item>
@@ -148,6 +152,7 @@ export const WithCaption: Story = {
 
     return (
       <div style={{ width: "20rem" }}>
+        {/* @ts-expect-error: TypeScript cannot infer strict conditional matching of variant and value */}
         <Select {...(args)} value={currentValue} onChange={handleChange}>
           <Item value='free' caption='무료로 시작하세요'>
             Free
@@ -186,6 +191,7 @@ export const WithBadge: Story = {
 
     return (
       <div style={{ width: "20rem" }}>
+        {/* @ts-expect-error: TypeScript cannot infer strict conditional matching of variant and value */}
         <Select {...(args)} value={currentValue} onChange={handleChange}>
           <Item value='free' caption='무료로 시작하세요' {...(args.variant === 'label' ? { badge: 'Free' } : {})}>
             Free Plan
@@ -221,6 +227,7 @@ export const WithDisabled: Story = {
 
     return (
       <div style={{ width: "20rem" }}>
+        {/* @ts-expect-error: TypeScript cannot infer strict conditional matching of variant and value */}
         <Select {...(args)} value={currentValue} onChange={handleChange}>
           <Item value='available1'>사용 가능 1</Item>
           <Item value='disabled1' isDisabled>
@@ -256,6 +263,7 @@ export const AllFeatures: Story = {
 
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: "16px", width: "20rem" }}>
+        {/* @ts-expect-error: TypeScript cannot infer strict conditional matching of variant and value */}
         <Select {...(args)} value={currentValue} onChange={handleChange}>
           <Item value='free' caption='무료 체험 플랜' {...(args.variant === 'label' ? { badge: '무료' } : {})}>
             Free

--- a/packages/jds/src/components/Select/Select.stories.tsx
+++ b/packages/jds/src/components/Select/Select.stories.tsx
@@ -1,4 +1,5 @@
-import type { Meta, StoryObj } from "@storybook/react";
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 
 import { Select } from "./index";
@@ -10,6 +11,14 @@ const meta = {
     layout: "centered",
   },
   argTypes: {
+    variant: {
+      control: "radio",
+      options: ["label", "checkbox", "radio"],
+      description: "Select의 변형 (label, checkbox, radio)",
+      table: {
+        defaultValue: { summary: "label" },
+      },
+    },
     size: {
       control: "select",
       options: ["md", "sm"],
@@ -30,25 +39,32 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    variant: "list",
+    variant: "label",
     value: "seoul",
-    onChange: () => {},
+    onChange: () => { },
   },
-  render: function Render() {
-    const [value, setValue] = useState("seoul");
+  render: function Render(args) {
+    const isMulti = args.variant === "checkbox";
+    const [singleValue, setSingleValue] = useState("seoul");
+    const [multiValue, setMultiValue] = useState<string[]>(["seoul"]);
+
+    const currentValue = isMulti ? multiValue : singleValue;
+    const handleChange = isMulti ? setMultiValue : setSingleValue;
+
+    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.Label;
 
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: "16px", width: "20rem" }}>
-        <Select variant='list' value={value} onChange={setValue}>
-          <Select.Label value='seoul'>서울특별시</Select.Label>
-          <Select.Label value='gyeonggi'>경기도</Select.Label>
-          <Select.Label value='incheon'>인천광역시</Select.Label>
-          <Select.Label value='busan'>부산광역시</Select.Label>
-          <Select.Label value='daegu'>대구광역시</Select.Label>
+        <Select {...(args as any)} value={currentValue} onChange={handleChange as any}>
+          <Item value='seoul'>서울특별시</Item>
+          <Item value='gyeonggi'>경기도</Item>
+          <Item value='incheon'>인천광역시</Item>
+          <Item value='busan'>부산광역시</Item>
+          <Item value='daegu'>대구광역시</Item>
         </Select>
 
         <div style={{ padding: "12px", backgroundColor: "#f5f5f5", borderRadius: "6px" }}>
-          <strong>선택된 값:</strong> {value}
+          <strong>선택된 값:</strong> {Array.isArray(currentValue) ? currentValue.join(", ") : currentValue}
         </div>
       </div>
     );
@@ -57,21 +73,28 @@ export const Default: Story = {
 
 export const WithLabel: Story = {
   args: {
-    variant: "list",
+    variant: "label",
     value: "seoul",
-    onChange: () => {},
     label: "지역 선택",
+    onChange: () => { },
   },
-  render: function Render() {
-    const [value, setValue] = useState("seoul");
+  render: function Render(args) {
+    const isMulti = args.variant === "checkbox";
+    const [singleValue, setSingleValue] = useState("seoul");
+    const [multiValue, setMultiValue] = useState<string[]>(["seoul"]);
+
+    const currentValue = isMulti ? multiValue : singleValue;
+    const handleChange = isMulti ? setMultiValue : setSingleValue;
+
+    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.Label;
 
     return (
       <div style={{ width: "20rem" }}>
-        <Select variant='list' label='지역 선택' value={value} onChange={setValue}>
-          <Select.Label value='seoul'>서울특별시</Select.Label>
-          <Select.Label value='gyeonggi'>경기도</Select.Label>
-          <Select.Label value='incheon'>인천광역시</Select.Label>
-          <Select.Label value='busan'>부산광역시</Select.Label>
+        <Select {...(args as any)} value={currentValue} onChange={handleChange as any}>
+          <Item value='seoul'>서울특별시</Item>
+          <Item value='gyeonggi'>경기도</Item>
+          <Item value='incheon'>인천광역시</Item>
+          <Item value='busan'>부산광역시</Item>
         </Select>
       </div>
     );
@@ -80,20 +103,27 @@ export const WithLabel: Story = {
 
 export const SmallSize: Story = {
   args: {
-    variant: "list",
+    variant: "label",
     value: "option1",
-    onChange: () => {},
     size: "sm",
+    onChange: () => { },
   },
-  render: function Render() {
-    const [value, setValue] = useState("option1");
+  render: function Render(args) {
+    const isMulti = args.variant === "checkbox";
+    const [singleValue, setSingleValue] = useState("option1");
+    const [multiValue, setMultiValue] = useState<string[]>(["option1"]);
+
+    const currentValue = isMulti ? multiValue : singleValue;
+    const handleChange = isMulti ? setMultiValue : setSingleValue;
+
+    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.Label;
 
     return (
       <div style={{ width: "20rem" }}>
-        <Select variant='list' size='sm' value={value} onChange={setValue}>
-          <Select.Label value='option1'>Option 1</Select.Label>
-          <Select.Label value='option2'>Option 2</Select.Label>
-          <Select.Label value='option3'>Option 3</Select.Label>
+        <Select {...(args as any)} value={currentValue} onChange={handleChange as any}>
+          <Item value='option1'>Option 1</Item>
+          <Item value='option2'>Option 2</Item>
+          <Item value='option3'>Option 3</Item>
         </Select>
       </div>
     );
@@ -102,29 +132,36 @@ export const SmallSize: Story = {
 
 export const WithCaption: Story = {
   args: {
-    variant: "list",
+    variant: "label",
     value: "pro",
-    onChange: () => {},
     label: "요금제 선택",
+    onChange: () => { },
   },
-  render: function Render() {
-    const [value, setValue] = useState("pro");
+  render: function Render(args) {
+    const isMulti = args.variant === "checkbox";
+    const [singleValue, setSingleValue] = useState("pro");
+    const [multiValue, setMultiValue] = useState<string[]>(["pro"]);
+
+    const currentValue = isMulti ? multiValue : singleValue;
+    const handleChange = isMulti ? setMultiValue : setSingleValue;
+
+    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.Label;
 
     return (
       <div style={{ width: "20rem" }}>
-        <Select variant='list' label='요금제 선택' value={value} onChange={setValue}>
-          <Select.Label value='free' caption='무료로 시작하세요'>
+        <Select {...(args as any)} value={currentValue} onChange={handleChange as any}>
+          <Item value='free' caption='무료로 시작하세요'>
             Free
-          </Select.Label>
-          <Select.Label value='pro' caption='개인 사용자에게 추천'>
+          </Item>
+          <Item value='pro' caption='개인 사용자에게 추천'>
             Pro
-          </Select.Label>
-          <Select.Label value='team' caption='팀 협업을 위한 플랜'>
+          </Item>
+          <Item value='team' caption='팀 협업을 위한 플랜'>
             Team
-          </Select.Label>
-          <Select.Label value='enterprise' caption='대규모 조직을 위한 플랜'>
+          </Item>
+          <Item value='enterprise' caption='대규모 조직을 위한 플랜'>
             Enterprise
-          </Select.Label>
+          </Item>
         </Select>
       </div>
     );
@@ -133,26 +170,33 @@ export const WithCaption: Story = {
 
 export const WithBadge: Story = {
   args: {
-    variant: "list",
+    variant: "label",
     value: "pro",
-    onChange: () => {},
     label: "요금제 선택",
+    onChange: () => { },
   },
-  render: function Render() {
-    const [value, setValue] = useState("pro");
+  render: function Render(args) {
+    const isMulti = args.variant === "checkbox";
+    const [singleValue, setSingleValue] = useState("pro");
+    const [multiValue, setMultiValue] = useState<string[]>(["pro"]);
+
+    const currentValue = isMulti ? multiValue : singleValue;
+    const handleChange = isMulti ? setMultiValue : setSingleValue;
+
+    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.Label;
 
     return (
       <div style={{ width: "20rem" }}>
-        <Select variant='list' label='요금제 선택' value={value} onChange={setValue}>
-          <Select.Label value='free' caption='무료로 시작하세요' badge='Free'>
+        <Select {...(args as any)} value={currentValue} onChange={handleChange as any}>
+          <Item value='free' caption='무료로 시작하세요' {...(args.variant === 'label' ? { badge: 'Free' } : {}) as any}>
             Free Plan
-          </Select.Label>
-          <Select.Label value='pro' caption='개인 사용자에게 추천' badge='인기'>
+          </Item>
+          <Item value='pro' caption='개인 사용자에게 추천' {...(args.variant === 'label' ? { badge: '인기' } : {}) as any}>
             Pro Plan
-          </Select.Label>
-          <Select.Label value='team' caption='팀 협업을 위한 플랜' badge='NEW'>
+          </Item>
+          <Item value='team' caption='팀 협업을 위한 플랜' {...(args.variant === 'label' ? { badge: 'NEW' } : {}) as any}>
             Team Plan
-          </Select.Label>
+          </Item>
         </Select>
       </div>
     );
@@ -161,25 +205,32 @@ export const WithBadge: Story = {
 
 export const WithDisabled: Story = {
   args: {
-    variant: "list",
+    variant: "label",
     value: "available1",
-    onChange: () => {},
     label: "옵션 선택",
+    onChange: () => { },
   },
-  render: function Render() {
-    const [value, setValue] = useState("available1");
+  render: function Render(args) {
+    const isMulti = args.variant === "checkbox";
+    const [singleValue, setSingleValue] = useState("available1");
+    const [multiValue, setMultiValue] = useState<string[]>(["available1"]);
+
+    const currentValue = isMulti ? multiValue : singleValue;
+    const handleChange = isMulti ? setMultiValue : setSingleValue;
+
+    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.Label;
 
     return (
       <div style={{ width: "20rem" }}>
-        <Select variant='list' label='옵션 선택' value={value} onChange={setValue}>
-          <Select.Label value='available1'>사용 가능 1</Select.Label>
-          <Select.Label value='disabled1' isDisabled>
+        <Select {...(args as any)} value={currentValue} onChange={handleChange as any}>
+          <Item value='available1'>사용 가능 1</Item>
+          <Item value='disabled1' isDisabled>
             비활성화됨 1
-          </Select.Label>
-          <Select.Label value='available2'>사용 가능 2</Select.Label>
-          <Select.Label value='disabled2' isDisabled>
+          </Item>
+          <Item value='available2'>사용 가능 2</Item>
+          <Item value='disabled2' isDisabled>
             비활성화됨 2
-          </Select.Label>
+          </Item>
         </Select>
       </div>
     );
@@ -188,34 +239,41 @@ export const WithDisabled: Story = {
 
 export const AllFeatures: Story = {
   args: {
-    variant: "list",
+    variant: "label",
     value: "standard",
-    onChange: () => {},
     label: "서비스 플랜 선택",
     size: "md",
+    onChange: () => { },
   },
-  render: function Render() {
-    const [value, setValue] = useState("standard");
+  render: function Render(args) {
+    const isMulti = args.variant === "checkbox";
+    const [singleValue, setSingleValue] = useState("standard");
+    const [multiValue, setMultiValue] = useState<string[]>(["standard"]);
+
+    const currentValue = isMulti ? multiValue : singleValue;
+    const handleChange = isMulti ? setMultiValue : setSingleValue;
+
+    const Item = args.variant === "checkbox" ? Select.Checkbox : args.variant === "radio" ? Select.Radio : Select.Label;
 
     return (
       <div style={{ display: "flex", flexDirection: "column", gap: "16px", width: "20rem" }}>
-        <Select variant='list' label='서비스 플랜 선택' size='md' value={value} onChange={setValue}>
-          <Select.Label value='free' caption='무료 체험 플랜' badge='무료'>
+        <Select {...(args as any)} value={currentValue} onChange={handleChange as any}>
+          <Item value='free' caption='무료 체험 플랜' {...(args.variant === 'label' ? { badge: '무료' } : {}) as any}>
             Free
-          </Select.Label>
-          <Select.Label value='standard' caption='개인 사용자에게 추천' badge='인기'>
+          </Item>
+          <Item value='standard' caption='개인 사용자에게 추천' {...(args.variant === 'label' ? { badge: '인기' } : {}) as any}>
             Standard
-          </Select.Label>
-          <Select.Label value='premium' caption='프리미엄 기능 제공' badge='신규'>
+          </Item>
+          <Item value='premium' caption='프리미엄 기능 제공' {...(args.variant === 'label' ? { badge: '신규' } : {}) as any}>
             Premium
-          </Select.Label>
-          <Select.Label value='enterprise' caption='기업용 맞춤 플랜' isDisabled>
+          </Item>
+          <Item value='enterprise' caption='기업용 맞춤 플랜' isDisabled>
             Enterprise (준비중)
-          </Select.Label>
+          </Item>
         </Select>
 
         <div style={{ padding: "12px", backgroundColor: "#f5f5f5", borderRadius: "6px" }}>
-          <strong>선택된 플랜:</strong> {value}
+          <strong>선택된 플랜:</strong> {Array.isArray(currentValue) ? currentValue.join(", ") : currentValue}
         </div>
       </div>
     );

--- a/packages/jds/src/components/Select/Select.tsx
+++ b/packages/jds/src/components/Select/Select.tsx
@@ -35,7 +35,7 @@ const createCheckboxHandlers = (props: Extract<SelectProps, { variant: "checkbox
   };
 };
 
-const createLabelHandlers = (props: Extract<SelectProps, { variant?: "label" }>) => {
+const createListHandlers = (props: Extract<SelectProps, { variant?: "list" }>) => {
   const { value, onChange } = props;
 
   return {
@@ -61,7 +61,7 @@ const createRadioHandlers = (props: Extract<SelectProps, { variant: "radio" }>) 
 
 export const Select = forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
   const { size = "md", label, children } = props;
-  const variant = props.variant ?? "label";
+  const variant = props.variant ?? "list";
 
   const getVariantHandlers = () => {
     switch (variant) {
@@ -69,9 +69,9 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
         return createCheckboxHandlers(props as Extract<SelectProps, { variant: "checkbox" }>);
       case "radio":
         return createRadioHandlers(props as Extract<SelectProps, { variant: "radio" }>);
-      case "label":
+      case "list":
       default:
-        return createLabelHandlers(props as Extract<SelectProps, { variant?: "label" }>);
+        return createListHandlers(props as Extract<SelectProps, { variant?: "list" }>);
     }
   };
 

--- a/packages/jds/src/components/Select/Select.tsx
+++ b/packages/jds/src/components/Select/Select.tsx
@@ -35,7 +35,7 @@ const createCheckboxHandlers = (props: Extract<SelectProps, { variant: "checkbox
   };
 };
 
-const createListHandlers = (props: Extract<SelectProps, { variant?: "list" }>) => {
+const createLabelHandlers = (props: Extract<SelectProps, { variant?: "label" }>) => {
   const { value, onChange } = props;
 
   return {
@@ -61,7 +61,7 @@ const createRadioHandlers = (props: Extract<SelectProps, { variant: "radio" }>) 
 
 export const Select = forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
   const { size = "md", label, children } = props;
-  const variant = props.variant ?? "list";
+  const variant = props.variant ?? "label";
 
   const getVariantHandlers = () => {
     switch (variant) {
@@ -69,9 +69,9 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>((props, ref) => {
         return createCheckboxHandlers(props as Extract<SelectProps, { variant: "checkbox" }>);
       case "radio":
         return createRadioHandlers(props as Extract<SelectProps, { variant: "radio" }>);
-      case "list":
+      case "label":
       default:
-        return createListHandlers(props as Extract<SelectProps, { variant?: "list" }>);
+        return createLabelHandlers(props as Extract<SelectProps, { variant?: "label" }>);
     }
   };
 

--- a/packages/jds/src/components/Select/SelectList.tsx
+++ b/packages/jds/src/components/Select/SelectList.tsx
@@ -10,9 +10,9 @@ import {
   StyledSelectItemCaption,
   StyledSelectItemBadge,
 } from "./select.styles";
-import type { SelectLabelProps } from "./select.types";
+import type { SelectListProps } from "./select.types";
 
-export const SelectLabel = forwardRef<HTMLDivElement, SelectLabelProps>(
+export const SelectList = forwardRef<HTMLDivElement, SelectListProps>(
   ({ value, isDisabled = false, caption, badge, children, ...restProps }, ref) => {
     const { size, isSelected, onChange } = useSelectContext();
 
@@ -72,4 +72,4 @@ export const SelectLabel = forwardRef<HTMLDivElement, SelectLabelProps>(
   },
 );
 
-SelectLabel.displayName = "Select.Label";
+SelectList.displayName = "Select.List";

--- a/packages/jds/src/components/Select/index.ts
+++ b/packages/jds/src/components/Select/index.ts
@@ -1,17 +1,17 @@
 import { Select as SelectBase } from "./Select";
 import { SelectCheckbox } from "./SelectCheckbox";
-import { SelectLabel } from "./SelectLabel";
+import { SelectList } from "./SelectList";
 import { SelectRadio } from "./SelectRadio";
 
 export const Select = Object.assign(SelectBase, {
-  Label: SelectLabel,
+  List: SelectList,
   Radio: SelectRadio,
   Checkbox: SelectCheckbox,
 });
 
 export type {
   SelectProps,
-  SelectLabelProps,
+  SelectListProps,
   SelectRadioProps,
   SelectCheckboxProps,
   SelectVariant,

--- a/packages/jds/src/components/Select/select.styles.ts
+++ b/packages/jds/src/components/Select/select.styles.ts
@@ -103,10 +103,10 @@ export const StyledSelectItem = styled("div", {
   const baseStyles: CSSObject = {
     ...restInteractionStyle,
     display: "flex",
-    flexDirection: "column",
-    justifyContent: "center",
-    alignItems: "flex-start",
-    gap: 0,
+    flexDirection: "row",
+    justifyContent: "flex-start",
+    alignItems: "center",
+    gap: theme.scheme.semantic.spacing[8],
     padding: getItemPaddingBySize(theme, $size),
     backgroundColor: "transparent",
     borderBottom: `1px solid ${theme.color.semantic.stroke.subtler}`,
@@ -189,6 +189,7 @@ export const StyledSelectItemText = styled(Label, {
 
   return {
     color: getColor(),
+    cursor: "inherit",
   };
 });
 
@@ -196,11 +197,13 @@ export const StyledSelectItemCaption = styled(Label, {
   shouldForwardProp: prop => !prop.startsWith("$"),
 })<{ $isDisabled: boolean }>(({ theme, $isDisabled }) => ({
   color: $isDisabled ? theme.color.semantic.object.subtle : theme.color.semantic.object.assistive,
+  cursor: "inherit",
 }));
 
 export const StyledSelectItemBadge = styled(ContentBadge.Basic)({
   position: "relative",
   zIndex: 1,
+  cursor: "inherit",
 });
 
 //ToDo: CheckBox, Radio를 감싸는 임시 div이므로 직접 스타일링 수정 필요

--- a/packages/jds/src/components/Select/select.types.ts
+++ b/packages/jds/src/components/Select/select.types.ts
@@ -1,6 +1,6 @@
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
-export type SelectVariant = "list" | "checkbox" | "radio";
+export type SelectVariant = "label" | "checkbox" | "radio";
 export type SelectSize = "md" | "sm";
 
 export type SelectValue = string | string[];
@@ -19,9 +19,9 @@ export interface BaseSelectProps {
   children?: ReactNode;
 }
 
-export interface SelectListProps
+export interface SelectLabelVariantProps
   extends BaseSelectProps, Omit<ComponentPropsWithoutRef<"div">, "size" | "onChange"> {
-  variant?: "list";
+  variant?: "label";
   value: string;
   onChange: (value: string) => void;
 }
@@ -40,7 +40,10 @@ export interface SelectCheckboxVariantProps
   onChange: (value: string[]) => void;
 }
 
-export type SelectProps = SelectListProps | SelectRadioVariantProps | SelectCheckboxVariantProps;
+export type SelectProps =
+  | SelectLabelVariantProps
+  | SelectRadioVariantProps
+  | SelectCheckboxVariantProps;
 
 export interface BaseSelectItemProps {
   value: string;

--- a/packages/jds/src/components/Select/select.types.ts
+++ b/packages/jds/src/components/Select/select.types.ts
@@ -1,6 +1,6 @@
 import type { ComponentPropsWithoutRef, ReactNode } from "react";
 
-export type SelectVariant = "label" | "checkbox" | "radio";
+export type SelectVariant = "list" | "checkbox" | "radio";
 export type SelectSize = "md" | "sm";
 
 export type SelectValue = string | string[];
@@ -19,9 +19,9 @@ export interface BaseSelectProps {
   children?: ReactNode;
 }
 
-export interface SelectLabelVariantProps
+export interface SelectListVariantProps
   extends BaseSelectProps, Omit<ComponentPropsWithoutRef<"div">, "size" | "onChange"> {
-  variant?: "label";
+  variant?: "list";
   value: string;
   onChange: (value: string) => void;
 }
@@ -41,7 +41,7 @@ export interface SelectCheckboxVariantProps
 }
 
 export type SelectProps =
-  | SelectLabelVariantProps
+  | SelectListVariantProps
   | SelectRadioVariantProps
   | SelectCheckboxVariantProps;
 
@@ -52,7 +52,7 @@ export interface BaseSelectItemProps {
   children?: ReactNode;
 }
 
-export interface SelectLabelProps
+export interface SelectListProps
   extends BaseSelectItemProps, Omit<ComponentPropsWithoutRef<"div">, "onClick"> {
   badge?: ReactNode;
 }

--- a/packages/jds/src/components/Snackbar/Snackbar.stories.tsx
+++ b/packages/jds/src/components/Snackbar/Snackbar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn } from "@storybook-utils/layout";
 
 import { Snackbar } from "./Snackbar";

--- a/packages/jds/src/components/Step/Step.stories.tsx
+++ b/packages/jds/src/components/Step/Step.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 import { useState } from "react";
 

--- a/packages/jds/src/components/Tab/tab.stories.tsx
+++ b/packages/jds/src/components/Tab/tab.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Tab } from "./tab";
 

--- a/packages/jds/src/components/Title/Title.stories.tsx
+++ b/packages/jds/src/components/Title/Title.stories.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from "@emotion/react";
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Title } from "./Title";
 

--- a/packages/jds/src/components/Toast/Toast.stories.tsx
+++ b/packages/jds/src/components/Toast/Toast.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 
 import { Toast } from "./Toast";

--- a/packages/jds/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/jds/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 import { Icon, IconButton, Input, Tooltip, BlockButton } from "components";
 import { Label as LabelComponent } from "components";

--- a/packages/jds/src/components/Uploader/UploaderFile.stories.tsx
+++ b/packages/jds/src/components/Uploader/UploaderFile.stories.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from "@emotion/react";
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn } from "@storybook-utils/layout";
 import { useState } from "react";
 

--- a/packages/jds/src/components/Uploader/UploaderImage.stories.tsx
+++ b/packages/jds/src/components/Uploader/UploaderImage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn } from "@storybook-utils/layout";
 import { useState } from "react";
 

--- a/packages/jds/src/tokens/Tokens.stories.tsx
+++ b/packages/jds/src/tokens/Tokens.stories.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { useTheme } from "@emotion/react";
 import { css } from "@emotion/react";
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 const TokenShowcase = () => {
   return <div>Token Showcase</div>;


### PR DESCRIPTION
## 💡 작업 내용

- [x] `Select` 컴포넌트 UI/UX 및 타입 개선 (`list` -> `label` 네이밍 변경 포함)
- [x] `Select` 컴포넌트 내부 렌더링 스타일 개선 (가로축 정렬, 포인터 커서 오류 수정)
- [x] `Select` Storybook 동적 컨트롤(Controls) 지원 및 ESLint 설정 에러 해결
- [x] `Select` 컴포넌트를 사용하는 타 화면(`TeamProject.tsx`) 마이그레이션

## 💡 자세한 설명

**1. `Select` 컴포넌트 디자인 명세 동기화**

- 컴포넌트 내부 구조를 디자인 명세(`label`, `checkbox`, `radio`)와 동일한 형태를 갖추도록 기존의 `list` variant 이름을 `label`로 변경했습니다 (`select.types.ts`, `Select.tsx`).
- `apps/web`의 `TeamProject.tsx` 내 구형 `list`를 사용하던 부분을 `label`로 일괄 교체하여 타입 및 빌드 에러 수정했습니다.

**2. 레이아웃 및 UX 수정**

- **정렬:** 기존 체크박스와 라디오 버튼이 텍스트와 가로로 정렬되지 않고 세로로 뚝 떨어지는 문제를 해결하고자, 컨테이너 래퍼(`StyledSelectItem`)의 `flex-direction`을 `row`로 변경하고 간격을 디자인 시안에 맞게 스페이싱했습니다.
- **커서 설정:** 텍스트나 뱃지 위에 마우스를 올렸을 때 클릭 가능한 손가락 모양 포인터가 나오지 않고 `default`로 강제되는 문제를 해결했습니다. 텍스트 요소들(`StyledSelectItemText`, `StyledSelectItemCaption`, `StyledSelectItemBadge`)에 `cursor: "inherit"` 옵션을 주어 부모 컨테이너의 포인터 속성을 상속받게 했습니다 (`select.styles.ts`).

**3. Storybook 설정 및 개선**

- `Select.stories.tsx`에서 `@storybook/react` 대신 Vite 프레임워크 패키지 설정에 맞도록 `@storybook/react-vite`를 렌더러로 변경하여 ESLint 렌더러 패키지 에러(`storybook/no-renderer-packages`)를 해결했습니다.
- 스토리북 앱의 Controls 하단 패널을 통해 컴포넌트를 직접 조작해볼 수 있도록 UI 코드를 구성했습니다 (variant 컨트롤에 따라 하위 Item 컴포넌트를 동적으로 렌더링).

## 📗 참고 자료 (선택)


## 📢 리뷰 요구 사항 (선택)

- Storybook에서 Select 탭의 Controls 기능이 원하는 의도대로 조작되는지 한 번 확인 부탁드립니다.

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes  #378 

