### PR TITLE
feat: Kbd 디자인 시스템 구현

### DIFF
--- a/apps/web/src/features/apply/steps/registration/components/PortfolioFileItem.tsx
+++ b/apps/web/src/features/apply/steps/registration/components/PortfolioFileItem.tsx
@@ -1,4 +1,4 @@
-import { FileItem } from "@jects/jds";
+import { FileItem, IconButton } from "@jects/jds";
 
 import type { PortfolioFile } from "@/types/apis/application";
 import { changeFileSizeUnit } from "@/utils/changeFileSizeUnit";
@@ -22,8 +22,11 @@ export function PortfolioFileItem({ portfolio, onDelete }: PortfolioFileItemProp
       fileName={portfolio.fileName}
       fileSize={changeFileSizeUnit(Number(portfolio.fileSize), ["KB", "MB"], true)}
       onClick={openFile}
-      removeable
-      onRemove={handleDelete}
+      suffixButton={
+        <IconButton.Basic size='lg' hierarchy='tertiary' icon='close-line' onClick={handleDelete}>
+          삭제
+        </IconButton.Basic>
+      }
     />
   );
 }

--- a/packages/jds/src/components/Kbd/Kbd.stories.tsx
+++ b/packages/jds/src/components/Kbd/Kbd.stories.tsx
@@ -1,0 +1,105 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { FlexRow, FlexColumn } from "@storybook-utils/layout";
+
+import { Kbd } from "./Kbd";
+
+const meta = {
+  title: "Components/Kbd",
+  component: Kbd,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "키보드 키는 키보드 입력이나 단축키를 시각적으로 표현하기 위한 컴포넌트입니다. 특정 키 또는 키 조합을 명확히 인지할 수 있도록 표시하여, 사용자가 수행해야 할 입력 행동을 보조적으로 안내합니다.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: "radio",
+      options: ["lg", "md", "sm", "xs"],
+      description: "컴포넌트의 시각적 크기입니다.",
+      table: {
+        defaultValue: { summary: "md" },
+      },
+    },
+    type: {
+      control: "radio",
+      options: ["key", "text", "function"],
+      description: "역할이나 유형에 대한 구분입니다.",
+      table: {
+        defaultValue: { summary: "key" },
+      },
+    },
+    muted: {
+      control: "boolean",
+      description: "시각적으로 강조도가 낮춰졌는지의 여부입니다.",
+      table: {
+        defaultValue: { summary: "false" },
+      },
+    },
+    children: {
+      control: "text",
+      description: "키에 들어갈 텍스트 또는 아이콘입니다.",
+    },
+  },
+} satisfies Meta<typeof Kbd>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    children: "K",
+    size: "md",
+    type: "key",
+    muted: false,
+  },
+};
+
+export const Types: Story = {
+  args: {
+    children: "kbd",
+  },
+  render: () => (
+    <FlexColumn>
+      <FlexRow>
+        <span>key</span>
+        <Kbd type='key'>A</Kbd>
+        <Kbd type='key'>/</Kbd>
+        <Kbd type='key'>\</Kbd>
+      </FlexRow>
+      <FlexRow>
+        <span>text</span>
+        <Kbd type='text'>ctrl</Kbd>
+        <Kbd type='text'>alt</Kbd>
+        <Kbd type='text'>tab</Kbd>
+        <Kbd type='text'>esc</Kbd>
+      </FlexRow>
+      <FlexRow>
+        <span>function</span>
+        <Kbd type='function'>⌘</Kbd>
+        <Kbd type='function'>⌥</Kbd>
+        <Kbd type='function'>⇧</Kbd>
+        <Kbd type='function'>⌃</Kbd>
+        <Kbd type='function'>⌫</Kbd>
+        <Kbd type='function'>⏎</Kbd>
+      </FlexRow>
+    </FlexColumn>
+  ),
+};
+
+export const isMuted: Story = {
+  args: {
+    children: "kbd",
+  },
+  render: () => (
+    <FlexColumn>
+      <Kbd muted>A</Kbd>
+      <Kbd>/</Kbd>
+    </FlexColumn>
+  ),
+};

--- a/packages/jds/src/components/Kbd/Kbd.style.ts
+++ b/packages/jds/src/components/Kbd/Kbd.style.ts
@@ -1,0 +1,57 @@
+import isPropValid from "@emotion/is-prop-valid";
+import styled from "@emotion/styled";
+import { Theme } from "@emotion/react";
+import { pxToRem } from "utils";
+
+import type { KbdSize, KbdStyleProps, KbdType } from "./Kbd.types";
+import { kbdSizeMap, typographyMap } from "./Kbd.variants";
+
+export const getKbdTypography = (type: KbdType, size: KbdSize) => {
+  return typographyMap[type][size];
+};
+
+export const getKbdStyles = (theme: Theme, isMuted: boolean) => {
+  if (isMuted) {
+    return {
+      border: theme.color.semantic.stroke.alpha.subtler,
+      color: theme.color.semantic.object.subtle,
+    };
+  }
+
+  return {
+    border: theme.color.semantic.stroke.alpha.subtle,
+    color: theme.color.semantic.object.alternative,
+  };
+};
+
+export const StyledKbd = styled("kbd", {
+  shouldForwardProp: prop => isPropValid(prop) && !prop.startsWith("$"),
+})<KbdStyleProps>(({ theme, $size, $type, $isMuted }) => {
+  const kbdSize = kbdSizeMap[$size];
+  const kbdStyles = getKbdStyles(theme, $isMuted);
+  const kbdTypography = getKbdTypography($type, $size);
+
+  const textStyle = theme.textStyle[kbdTypography as keyof typeof theme.textStyle];
+
+  return {
+    boxSizing: "initial",
+
+    display: "inline-flex",
+    alignItems: "center",
+    justifyContent: "center",
+
+    height: pxToRem(kbdSize.height),
+    minWidth: pxToRem(kbdSize.minWidth),
+
+    padding: `0 ${pxToRem(kbdSize.paddingX)}`,
+    paddingTop: theme.scheme.semantic.spacing[1],
+
+    borderRadius: theme.scheme.semantic.radius[4],
+    backgroundColor: theme.color.semantic.fill.subtlest,
+
+    color: kbdStyles.color,
+    border: `1px solid ${kbdStyles.border}`,
+
+    ...textStyle,
+  };
+});

--- a/packages/jds/src/components/Kbd/Kbd.tsx
+++ b/packages/jds/src/components/Kbd/Kbd.tsx
@@ -1,0 +1,19 @@
+import type { KbdProps } from "./Kbd.types";
+import { StyledKbd } from "./Kbd.style";
+
+export const Kbd = ({
+  children,
+  size = "md",
+  type = "key",
+  muted = false,
+  className,
+  ...restProps
+}: KbdProps) => {
+  return (
+    <StyledKbd $size={size} $type={type} $isMuted={muted} className={className} {...restProps}>
+      {children}
+    </StyledKbd>
+  );
+};
+
+Kbd.displayName = "Kbd";

--- a/packages/jds/src/components/Kbd/Kbd.types.ts
+++ b/packages/jds/src/components/Kbd/Kbd.types.ts
@@ -8,6 +8,7 @@ export interface KbdProps extends HTMLAttributes<HTMLElement> {
   size?: KbdSize;
   type?: KbdType;
   muted?: boolean;
+  "aria-label"?: string;
 }
 
 export interface KbdStyleProps {

--- a/packages/jds/src/components/Kbd/Kbd.types.ts
+++ b/packages/jds/src/components/Kbd/Kbd.types.ts
@@ -1,0 +1,17 @@
+import { HTMLAttributes, ReactNode } from "react";
+
+export type KbdSize = "lg" | "md" | "sm" | "xs";
+export type KbdType = "key" | "text" | "function";
+
+export interface KbdProps extends HTMLAttributes<HTMLElement> {
+  children: ReactNode;
+  size?: KbdSize;
+  type?: KbdType;
+  muted?: boolean;
+}
+
+export interface KbdStyleProps {
+  $size: KbdSize;
+  $type: KbdType;
+  $isMuted: boolean;
+}

--- a/packages/jds/src/components/Kbd/Kbd.variants.ts
+++ b/packages/jds/src/components/Kbd/Kbd.variants.ts
@@ -1,0 +1,35 @@
+import type { KbdSize, KbdType } from "./Kbd.types";
+
+interface KbdSizeConfig {
+  height: number;
+  minWidth: number;
+  paddingX: number;
+}
+
+export const kbdSizeMap: Record<KbdSize, KbdSizeConfig> = {
+  lg: { height: 26, minWidth: 16, paddingX: 6 },
+  md: { height: 24, minWidth: 14, paddingX: 6 },
+  sm: { height: 22, minWidth: 11, paddingX: 6 },
+  xs: { height: 20, minWidth: 9, paddingX: 6 },
+};
+
+export const typographyMap: Record<KbdType, Record<KbdSize, string>> = {
+  function: {
+    lg: "semantic-textStyle-label-lg-normal",
+    md: "semantic-textStyle-label-md-normal",
+    sm: "semantic-textStyle-label-sm-normal",
+    xs: "semantic-textStyle-label-xs-normal",
+  },
+  key: {
+    lg: "semantic-textStyle-syntax-lg",
+    md: "semantic-textStyle-syntax-md",
+    sm: "semantic-textStyle-syntax-sm",
+    xs: "semantic-textStyle-syntax-xs",
+  },
+  text: {
+    lg: "semantic-textStyle-syntax-lg",
+    md: "semantic-textStyle-syntax-md",
+    sm: "semantic-textStyle-syntax-sm",
+    xs: "semantic-textStyle-syntax-xs",
+  },
+};


### PR DESCRIPTION
## 💡 작업 내용

- [x] Kbd 디자인 시스템 구현

## 💡 자세한 설명

> Figma 명세에 맞춰 키보드 입력을 시각적으로 표현하는 Kbd 컴포넌트를 구현했습니다. props 변경에 따른 변형 모습은 스토리북에서 확인할 수 있습니다. 

- Kbd.types.ts: 컴포넌트의 Props와 도메인 타입 정의
- Kbd.variants.ts: 스타일 값을 결정하는 데이터 관리
- Kbd.style.ts: variants에서 계산된 토큰을 받아 CSS로 렌더링하기 위함

<img width="1010" height="740" alt="스크린샷 2026-02-28 오후 4 29 35" src="https://github.com/user-attachments/assets/6cf5b856-b46c-47f6-9199-a46baf12a893" />

## 📢 리뷰 요구 사항 (선택)

> `aria-label`을 필수로 지정해야 하는가에 대한 고민을 했을 때, 스크린리더가 `kbd` 컴포넌트 태그를 만났을 때 내부 텍스트를 그대로 읽는다는 레퍼런스를 참고해 별도로 지정하지 않았습니다. 단, 아이콘을 사용하는 경우에는 `aria-label`을 명시적으로 지정해 줘야 시각적 정보를 명확히 할 수 있을 듯하네요. 옵셔널로라도 넣어 줘야 할지 고민입니다!

[html-kbd-tag](https://www.lenovo.com/ca/en/glossary/html-kbd-tag/)

레퍼런스가 궁금하시다면 위 링크에서 `How does the HTML <kbd> tag interact with screen readers?` 부분 참고해 주시면 됩니다!

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #388 
