### PR TITLE
feat: Code(코드) 디자인 시스템 구현

### DIFF
--- a/packages/jds/src/components/Code/Code.stories.tsx
+++ b/packages/jds/src/components/Code/Code.stories.tsx
@@ -1,0 +1,68 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FlexColumn, FlexRow } from "@storybook-utils/layout";
+
+import { Code } from "./Code";
+
+const CODE_TEXT = "inline code syntax";
+
+const meta: Meta<typeof Code> = {
+  title: "Components/Code",
+  component: Code,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "인라인 코드는 문장 흐름 안에서 특정 키워드, 값, 명령어, 짧은 코드 조각을 시각적으로 구분하기 위한 텍스트 컴포넌트입니다. 주요 내용의 이해를 보조하는 용도로, 문장을 끊지 않고 맥락 속에서 코드를 인지할 수 있도록 합니다.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    size: {
+      control: "radio",
+      options: ["lg", "md", "sm", "xs"],
+      description: "컴포넌트의 시각적 크기입니다.",
+      table: {
+        defaultValue: { summary: "md" },
+      },
+    },
+    children: {
+      control: "text",
+      description: "코드 구문 표시 역할의 텍스트 내용입니다.",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Code>;
+
+export const Default: Story = {
+  args: {
+    children: CODE_TEXT,
+    size: "md",
+  },
+};
+
+export const AllSizes: Story = {
+  render: () => (
+    <FlexColumn>
+      <FlexRow>
+        <span>xs</span>
+        <Code size='xs'>{CODE_TEXT}</Code>
+      </FlexRow>
+      <FlexRow>
+        <span>sm</span>
+        <Code size='sm'>{CODE_TEXT}</Code>
+      </FlexRow>
+      <FlexRow>
+        <span>md</span>
+        <Code size='md'>{CODE_TEXT}</Code>
+      </FlexRow>
+      <FlexRow>
+        <span>lg</span>
+        <Code size='lg'>{CODE_TEXT}</Code>
+      </FlexRow>
+    </FlexColumn>
+  ),
+};

--- a/packages/jds/src/components/Code/Code.styles.ts
+++ b/packages/jds/src/components/Code/Code.styles.ts
@@ -1,0 +1,44 @@
+import isPropValid from "@emotion/is-prop-valid";
+import type { Theme } from "@emotion/react";
+import styled from "@emotion/styled";
+
+import type { CodeSize, CodeStyleProps } from "./Code.types";
+
+export const codeTypographyMap: Record<CodeSize, string> = {
+  lg: "semantic-textStyle-syntax-lg",
+  md: "semantic-textStyle-syntax-md",
+  sm: "semantic-textStyle-syntax-sm",
+  xs: "semantic-textStyle-syntax-xs",
+};
+
+export const getCodeColors = (theme: Theme) => {
+  return {
+    bg: theme.color.semantic.fill.subtlest,
+    border: theme.color.semantic.stroke.alpha.assistive,
+    color: theme.color.semantic.object.bold,
+  };
+};
+
+export const StyledCode = styled("code", {
+  shouldForwardProp: prop => isPropValid(prop) && !prop.startsWith("$"),
+})<CodeStyleProps>(({ theme, $size }) => {
+  const codeTypographyKey = codeTypographyMap[$size];
+  const codeColors = getCodeColors(theme);
+  const textStyle = theme.textStyle[codeTypographyKey as keyof typeof theme.textStyle];
+
+  return {
+    display: "inline-flex",
+    alignItems: "center",
+
+    padding: `${theme.scheme.semantic.spacing[0]} ${theme.scheme.semantic.spacing[6]}`,
+
+    borderRadius: theme.scheme.semantic.radius[4],
+    background: codeColors.bg,
+
+    border: `1px solid ${codeColors.border}`,
+    color: codeColors.color,
+
+    cursor: "text",
+    ...textStyle,
+  };
+});

--- a/packages/jds/src/components/Code/Code.tsx
+++ b/packages/jds/src/components/Code/Code.tsx
@@ -1,0 +1,12 @@
+import { StyledCode } from "./Code.styles";
+import type { CodeProps } from "./Code.types";
+
+export const Code = ({ children, size = "md", className, ...restProps }: CodeProps) => {
+  return (
+    <StyledCode $size={size} className={className} {...restProps}>
+      {children}
+    </StyledCode>
+  );
+};
+
+Code.displayName = "Code";

--- a/packages/jds/src/components/Code/Code.types.ts
+++ b/packages/jds/src/components/Code/Code.types.ts
@@ -1,0 +1,12 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+export type CodeSize = "lg" | "md" | "sm" | "xs";
+
+export interface CodeProps extends HTMLAttributes<HTMLElement> {
+  children: ReactNode;
+  size?: CodeSize;
+}
+
+export interface CodeStyleProps {
+  $size: CodeSize;
+}

--- a/packages/jds/src/components/Kbd/Kbd.stories.tsx
+++ b/packages/jds/src/components/Kbd/Kbd.stories.tsx
@@ -1,5 +1,4 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
-
 import { FlexRow, FlexColumn } from "@storybook-utils/layout";
 
 import { Kbd } from "./Kbd";

--- a/packages/jds/src/components/Kbd/Kbd.style.ts
+++ b/packages/jds/src/components/Kbd/Kbd.style.ts
@@ -1,6 +1,6 @@
 import isPropValid from "@emotion/is-prop-valid";
+import type { Theme } from "@emotion/react";
 import styled from "@emotion/styled";
-import { Theme } from "@emotion/react";
 import { pxToRem } from "utils";
 
 import type { KbdSize, KbdStyleProps, KbdType } from "./Kbd.types";

--- a/packages/jds/src/components/Kbd/Kbd.tsx
+++ b/packages/jds/src/components/Kbd/Kbd.tsx
@@ -1,5 +1,5 @@
-import type { KbdProps } from "./Kbd.types";
 import { StyledKbd } from "./Kbd.style";
+import type { KbdProps } from "./Kbd.types";
 
 export const Kbd = ({
   children,

--- a/packages/jds/src/components/Kbd/Kbd.types.ts
+++ b/packages/jds/src/components/Kbd/Kbd.types.ts
@@ -1,4 +1,4 @@
-import { HTMLAttributes, ReactNode } from "react";
+import type { HTMLAttributes, ReactNode } from "react";
 
 export type KbdSize = "lg" | "md" | "sm" | "xs";
 export type KbdType = "key" | "text" | "function";


### PR DESCRIPTION
## 💡 작업 내용

- [x] Code 디자인 시스템 구현

## 💡 자세한 설명

> Code 디자인 시스템 구현이 완료되었습니다. 현재 FIgma에는 `Inline Code` 컴포넌트만 존재해 별도의 분리 없이 구현했으니 참고 부탁드립니다. props 변형에 따른 동작 예시는 스토리북에서 확인하실 수 있습니다. 

<img width="924" height="660" alt="스크린샷 2026-03-02 오후 8 52 21" src="https://github.com/user-attachments/assets/d9254a86-4eed-43cb-b37c-e31f7d7859ed" />

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #392 
