### PR TITLE
refactor: Hero 컴포넌트 QA 대응

### DIFF
--- a/packages/jds/src/components/Hero/Hero.stories.tsx
+++ b/packages/jds/src/components/Hero/Hero.stories.tsx
@@ -1,13 +1,10 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Hero } from "./Hero";
 
 const meta = {
   title: "Components/Hero",
   component: Hero,
-  parameters: {
-    layout: "padded",
-  },
   argTypes: {
     children: {
       control: "text",

--- a/packages/jds/src/components/Hero/Hero.stories.tsx
+++ b/packages/jds/src/components/Hero/Hero.stories.tsx
@@ -6,7 +6,7 @@ const meta = {
   title: "Components/Hero",
   component: Hero,
   parameters: {
-    layout: "centered",
+    layout: "padded",
   },
   argTypes: {
     children: {
@@ -34,12 +34,6 @@ export const Test: Story = {
     size: "lg",
     textAlign: "left",
     children: "히어로",
+    style: { width: "500px", border: "1px solid red" },
   },
-  render: args => (
-    <div style={{ width: "500px", border: "1px solid red" }}>
-      <Hero size={args.size} textAlign={args.textAlign}>
-        {args.children}
-      </Hero>
-    </div>
-  ),
 };

--- a/packages/jds/src/components/Hero/Hero.tsx
+++ b/packages/jds/src/components/Hero/Hero.tsx
@@ -4,7 +4,7 @@ import { forwardRef } from "react";
 import type { HeroSize, HeroTextAlign } from "./Hero.style";
 import { HeroDiv } from "./Hero.style";
 
-export interface HeroProps {
+export interface HeroProps extends React.HTMLAttributes<HTMLDivElement> {
   size?: HeroSize;
   textAlign?: HeroTextAlign;
   color?: string;


### PR DESCRIPTION
## 💡 작업 내용

- [x] Hero 컴포넌트의 Props가 기본 HTML div 속성(`React.HTMLAttributes<HTMLDivElement>`)을 상속받도록 수정
- [x] Hero 컴포넌트 Storybook에서 컨테이너 요소를 제거하고 Hero 자체에 style을 적용하여 테스트하도록 수정

## 💡 자세한 설명

기존에 Hero 컴포넌트는 `style`, `className` 등 기본적인 HTML 요소의 속성을 받을 수 없는 구조였습니다.
이로 인해 Storybook 등에서 컴포넌트의 레이아웃이나 스타일을 테스트하기 위해 불필요하게 부모 `div` 컨테이너로 감싸야 했습니다.

`HeroProps`가 `React.HTMLAttributes<HTMLDivElement>`를 확장(extend)하도록 수정하여, 스타일이나 이벤트 핸들러 등의 기본 속성들을 전달하고 제어할 수 있게 개선했습니다.
또한 Storybook에서 `Test` 스토리를 렌더링할 때 컨테이너 `div` 없이 직접 `style`을 주입하는 방식으로 변경했습니다.

## 📗 참고 자료 (선택)

- JDS Hero 컴포넌트 속성 확장

## 📢 리뷰 요구 사항 (선택)

- 

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #378 
