### PR TITLE
feat: Table(테이블) 디자인 시스템 구현

### DIFF
--- a/packages/jds/src/components/Accordion/Accordion.stories.tsx
+++ b/packages/jds/src/components/Accordion/Accordion.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Accordion } from "./Accordion";
 import type { AccordionRootProps } from "./accordion.types";

--- a/packages/jds/src/components/Badge/contentBadge/ContentBadge.stories.tsx
+++ b/packages/jds/src/components/Badge/contentBadge/ContentBadge.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { ContentBadge } from "./ContentBadge";
 import type {

--- a/packages/jds/src/components/Badge/dotBadge/DotBadge.stories.tsx
+++ b/packages/jds/src/components/Badge/dotBadge/DotBadge.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { DotBadge } from "./DotBadge";
 import type { DotBadgeFeedbackProps } from "./DotBadge";

--- a/packages/jds/src/components/Badge/numericBadge/NumericBadge.stories.tsx
+++ b/packages/jds/src/components/Badge/numericBadge/NumericBadge.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { NumericBadge } from "./NumericBadge";
 import type { NumericBadgeBasicProps, NumericBasicBadgeProps } from "./NumericBadge";

--- a/packages/jds/src/components/Banner/BannerBar.stories.tsx
+++ b/packages/jds/src/components/Banner/BannerBar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import type { BannerBarProps } from "./banner.types";
 import { Banner } from "./index";

--- a/packages/jds/src/components/Banner/BannerImage.stories.tsx
+++ b/packages/jds/src/components/Banner/BannerImage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import type { BannerImageProps } from "./banner.types";
 import { Banner } from "./index";

--- a/packages/jds/src/components/Button/BlockButton/BlockButton.stories.tsx
+++ b/packages/jds/src/components/Button/BlockButton/BlockButton.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexRow, FlexColumn, Label } from "@storybook-utils/layout";
 import { BlockButton } from "components";
 

--- a/packages/jds/src/components/Button/IconButton/IconButton.stories.tsx
+++ b/packages/jds/src/components/Button/IconButton/IconButton.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexRow, FlexColumn, Label } from "@storybook-utils/layout";
 import { IconButton } from "components";
 

--- a/packages/jds/src/components/Button/LabelButton/LabelButton.stories.tsx
+++ b/packages/jds/src/components/Button/LabelButton/LabelButton.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexRow, FlexColumn, Label } from "@storybook-utils/layout";
 import { LabelButton } from "components";
 

--- a/packages/jds/src/components/Callout/Callout.stories.tsx
+++ b/packages/jds/src/components/Callout/Callout.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Callout } from "./Callout";
 

--- a/packages/jds/src/components/Card/Card.stories.tsx
+++ b/packages/jds/src/components/Card/Card.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Card } from "./index";
 

--- a/packages/jds/src/components/Checkbox/Checkbox.stories.tsx
+++ b/packages/jds/src/components/Checkbox/Checkbox.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexRow, FlexColumn, Label } from "@storybook-utils/layout";
 import { Checkbox, type CheckedState } from "components";
 import { useState } from "react";

--- a/packages/jds/src/components/Dialog/Dialog.stories.tsx
+++ b/packages/jds/src/components/Dialog/Dialog.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexRow } from "@storybook-utils/layout";
 import { useState } from "react";
 

--- a/packages/jds/src/components/Divider/Divider.stories.tsx
+++ b/packages/jds/src/components/Divider/Divider.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 
 import { Divider } from "./Divider";

--- a/packages/jds/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/jds/src/components/EmptyState/EmptyState.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn } from "@storybook-utils/layout";
 
 import { EmptyState } from "./EmptyState";

--- a/packages/jds/src/components/Footer/Footer.stories.tsx
+++ b/packages/jds/src/components/Footer/Footer.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Footer } from "./Footer";
 import type { FooterSection } from "./footer.types";

--- a/packages/jds/src/components/Hero/Hero.stories.tsx
+++ b/packages/jds/src/components/Hero/Hero.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Hero } from "./Hero";
 

--- a/packages/jds/src/components/Icon/Icon.stories.tsx
+++ b/packages/jds/src/components/Icon/Icon.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Icon } from "./Icon";
 

--- a/packages/jds/src/components/Image/Image.stories.tsx
+++ b/packages/jds/src/components/Image/Image.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Image } from "./Image";
 

--- a/packages/jds/src/components/Input/InputArea/InputArea.stories.tsx
+++ b/packages/jds/src/components/Input/InputArea/InputArea.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 
 import { InputArea } from "./InputArea";

--- a/packages/jds/src/components/Input/SelectField/SelectField.stories.tsx
+++ b/packages/jds/src/components/Input/SelectField/SelectField.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 import { BlockButton } from "components";
 import { useEffect, useState } from "react";

--- a/packages/jds/src/components/Input/TagField/TagField.stories.tsx
+++ b/packages/jds/src/components/Input/TagField/TagField.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 import { BlockButton } from "components";
 import { useEffect, useState } from "react";

--- a/packages/jds/src/components/Input/TextField/TextField.stories.tsx
+++ b/packages/jds/src/components/Input/TextField/TextField.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 import { BlockButton } from "components";
 import { useEffect, useState } from "react";

--- a/packages/jds/src/components/Label/Label.stories.tsx
+++ b/packages/jds/src/components/Label/Label.stories.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import type { Decorator, Meta, StoryObj } from "@storybook/react";
+import type { Decorator, Meta, StoryObj } from "@storybook/react-vite";
 
 import { Label } from "./Label";
 

--- a/packages/jds/src/components/Logo/Logo.stories.tsx
+++ b/packages/jds/src/components/Logo/Logo.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexRow, FlexColumn, Label } from "@storybook-utils/layout";
 import { Logo } from "components";
 

--- a/packages/jds/src/components/Menu/MegaMenu/MegaMenu.stories.tsx
+++ b/packages/jds/src/components/Menu/MegaMenu/MegaMenu.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { MegaMenu } from "./MegaMenu";
 import { MenuItem } from "../MenuItem";

--- a/packages/jds/src/components/Menu/Menu/Menu.stories.tsx
+++ b/packages/jds/src/components/Menu/Menu/Menu.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexRow } from "@storybook-utils/layout";
 
 import { Menu } from "./Menu";

--- a/packages/jds/src/components/Menu/MenuItem/MenuItem.stories.tsx
+++ b/packages/jds/src/components/Menu/MenuItem/MenuItem.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow } from "@storybook-utils/layout";
 
 import { MenuItem } from ".";

--- a/packages/jds/src/components/Navigation/GlobalNavigation/GlobalNavigation.stories.tsx
+++ b/packages/jds/src/components/Navigation/GlobalNavigation/GlobalNavigation.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { GlobalNavigation } from "./GlobalNavigation";
 import { useGlobalNavigationVariant } from "./useGlobalNavigationVariant";

--- a/packages/jds/src/components/Navigation/LocalNavigation/LocalNavigation.stories.tsx
+++ b/packages/jds/src/components/Navigation/LocalNavigation/LocalNavigation.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { LocalNavigation } from "./LocalNavigation";
 import { IconButton } from "../../Button/IconButton";

--- a/packages/jds/src/components/Radio/Radio.stories.tsx
+++ b/packages/jds/src/components/Radio/Radio.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow } from "@storybook-utils/layout";
 
 import { Radio } from "./Radio";

--- a/packages/jds/src/components/Radio/preset/RadioContent.stories.tsx
+++ b/packages/jds/src/components/Radio/preset/RadioContent.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow } from "@storybook-utils/layout";
 import type { FormEvent } from "react";
 import { useState } from "react";

--- a/packages/jds/src/components/SegmentedControl/SegmentedControl.stories.tsx
+++ b/packages/jds/src/components/SegmentedControl/SegmentedControl.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 import { useState } from "react";
 

--- a/packages/jds/src/components/Select/Select.stories.tsx
+++ b/packages/jds/src/components/Select/Select.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { useState } from "react";
 
 import { Select } from "./index";

--- a/packages/jds/src/components/Snackbar/Snackbar.stories.tsx
+++ b/packages/jds/src/components/Snackbar/Snackbar.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn } from "@storybook-utils/layout";
 
 import { Snackbar } from "./Snackbar";

--- a/packages/jds/src/components/Step/Step.stories.tsx
+++ b/packages/jds/src/components/Step/Step.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 import { useState } from "react";
 

--- a/packages/jds/src/components/Tab/tab.stories.tsx
+++ b/packages/jds/src/components/Tab/tab.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Tab } from "./tab";
 

--- a/packages/jds/src/components/Table/ColorChip/ColorChip.styles.ts
+++ b/packages/jds/src/components/Table/ColorChip/ColorChip.styles.ts
@@ -6,10 +6,8 @@ export const StyledColorChip = styled("div", {
 })<{ $color: string }>(({ theme, $color }) => {
   return {
     flexShrink: 0,
-
     width: "1rem",
     height: "1rem",
-
     backgroundColor: $color,
     border: `1px solid ${theme.color.semantic.stroke.subtle}`,
   };

--- a/packages/jds/src/components/Table/ColorChip/ColorChip.styles.ts
+++ b/packages/jds/src/components/Table/ColorChip/ColorChip.styles.ts
@@ -1,0 +1,16 @@
+import isPropValid from "@emotion/is-prop-valid";
+import styled from "@emotion/styled";
+
+export const StyledColorChip = styled("div", {
+  shouldForwardProp: prop => isPropValid(prop) && !prop.startsWith("$"),
+})<{ $color: string }>(({ theme, $color }) => {
+  return {
+    flexShrink: 0,
+
+    width: "1rem",
+    height: "1rem",
+
+    backgroundColor: $color,
+    border: `1px solid ${theme.color.semantic.stroke.subtle}`,
+  };
+});

--- a/packages/jds/src/components/Table/ColorChip/ColorChip.tsx
+++ b/packages/jds/src/components/Table/ColorChip/ColorChip.tsx
@@ -1,0 +1,8 @@
+import { StyledColorChip } from "./ColorChip.styles";
+import type { ColorChipProps } from "./ColorChip.types";
+
+export const ColorChip = ({ color, className, ...restProps }: ColorChipProps) => {
+  return <StyledColorChip $color={color} className={className} {...restProps} />;
+};
+
+ColorChip.displayName = "ColorChip";

--- a/packages/jds/src/components/Table/ColorChip/ColorChip.types.ts
+++ b/packages/jds/src/components/Table/ColorChip/ColorChip.types.ts
@@ -1,0 +1,5 @@
+import type { HTMLAttributes } from "react";
+
+export interface ColorChipProps extends HTMLAttributes<HTMLDivElement> {
+  color: string;
+}

--- a/packages/jds/src/components/Table/Table.stories.tsx
+++ b/packages/jds/src/components/Table/Table.stories.tsx
@@ -1,0 +1,179 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { Table } from ".";
+import type { TableRowItemProps } from "./Table.types";
+
+const meta: Meta<typeof Table.RowItem> = {
+  title: "Components/Table",
+  component: Table.RowItem,
+  parameters: {
+    layout: "padded",
+    docs: {
+      description: {
+        component: `
+테이블은 행과 열 구조를 통해 여러 항목의 정보를 체계적으로 비교·정리해 보여주는 데이터 표현 컴포넌트입니다. 값 간의 관계를 한눈에 파악할 수 있도록 하며, 목록, 비교, 상태 확인처럼 구조화된 정보를 전달하는 데 사용합니다.\n
+Compound Component 패턴 기반으로 구현되었으며, \`Table.RowItem\`의 \`variant\` 속성을 통해 다양한 형태의 데이터를 표현합니다.
+        `,
+      },
+    },
+  },
+  argTypes: {
+    variant: {
+      control: "radio",
+      options: ["label", "code", "badge"],
+      description: "셀의 렌더링 타입",
+    },
+    children: {
+      control: "text",
+      description: "셀 내용 (텍스트)",
+    },
+    description: {
+      control: "text",
+      description: "하단 부가 설명 (label, code 타입 전용)",
+    },
+    color: {
+      control: "color",
+      description: "좌측 컬러 칩 색상 (label 타입 전용)",
+    },
+    prefixIcon: {
+      control: "select",
+      description: "좌측 아이콘 (label 타입 전용)",
+    },
+    hasDivider: {
+      control: "boolean",
+      description: "우측 구분선 표시 여부",
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Table.RowItem>;
+
+export const Basic: StoryObj<TableRowItemProps> = {
+  args: {
+    variant: "label",
+    children: "레이블",
+    description: "설명",
+    hasDivider: true,
+  },
+  render: (args: TableRowItemProps) => (
+    <Table.Root>
+      <Table.Header>
+        <Table.HeaderItem>레이블 (상태 확인 가능)</Table.HeaderItem>
+        <Table.HeaderItem>레이블</Table.HeaderItem>
+        <Table.HeaderItem>레이블</Table.HeaderItem>
+        <Table.HeaderItem>레이블</Table.HeaderItem>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.RowItem {...args}>{args.children}</Table.RowItem>
+          <Table.RowItem variant='label'>레이블</Table.RowItem>
+          <Table.RowItem variant='label'>레이블</Table.RowItem>
+          <Table.RowItem variant='label'>레이블</Table.RowItem>
+        </Table.Row>
+      </Table.Body>
+    </Table.Root>
+  ),
+};
+
+export const VariantLabel: Story = {
+  render: () => (
+    <Table.Root>
+      <Table.Header>
+        <Table.HeaderItem>기본</Table.HeaderItem>
+        <Table.HeaderItem>아이콘 표시</Table.HeaderItem>
+        <Table.HeaderItem>설명 & 컬러 칩 표시</Table.HeaderItem>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.RowItem variant='label'>레이블</Table.RowItem>
+          <Table.RowItem variant='label' prefixIcon='absolute'>
+            레이블
+          </Table.RowItem>
+          <Table.RowItem variant='label' color='#FF5733' description='16진수 색상 코드입니다.'>
+            #FF5733
+          </Table.RowItem>
+        </Table.Row>
+      </Table.Body>
+    </Table.Root>
+  ),
+};
+
+export const VariantCode: Story = {
+  render: () => (
+    <Table.Root>
+      <Table.Header>
+        <Table.HeaderItem>단일</Table.HeaderItem>
+        <Table.HeaderItem>다수</Table.HeaderItem>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.RowItem variant='code' description='단일 패키지 설치'>
+            npm install react
+          </Table.RowItem>
+          <Table.RowItem variant='code' description='필수 의존성 목록'>
+            {["react", "react-dom", "vite"]}
+          </Table.RowItem>
+        </Table.Row>
+      </Table.Body>
+    </Table.Root>
+  ),
+};
+
+export const VariantBadge: Story = {
+  render: () => (
+    <Table.Root>
+      <Table.Header>
+        <Table.HeaderItem>상태</Table.HeaderItem>
+        <Table.HeaderItem>태그</Table.HeaderItem>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.RowItem variant='badge'>Active</Table.RowItem>
+          <Table.RowItem variant='badge'>{["Design", "Develop", "QA"]}</Table.RowItem>
+        </Table.Row>
+      </Table.Body>
+    </Table.Root>
+  ),
+};
+
+export const ComplexTable: Story = {
+  render: () => (
+    <Table.Root>
+      <Table.Header>
+        <Table.HeaderItem>레이블</Table.HeaderItem>
+        <Table.HeaderItem>레이블</Table.HeaderItem>
+        <Table.HeaderItem>레이블</Table.HeaderItem>
+        <Table.HeaderItem>레이블</Table.HeaderItem>
+      </Table.Header>
+      <Table.Body>
+        <Table.Row>
+          <Table.RowItem variant='label' prefixIcon='absolute'>
+            variant
+          </Table.RowItem>
+          <Table.RowItem variant='code'>{["code", "code", "code"]}</Table.RowItem>
+          <Table.RowItem variant='label' description='셀의 형태를 결정합니다.'>
+            Variant Type
+          </Table.RowItem>
+          <Table.RowItem variant='badge'>레이블</Table.RowItem>
+        </Table.Row>
+        <Table.Row>
+          <Table.RowItem variant='label' prefixIcon='absolute'>
+            color
+          </Table.RowItem>
+          <Table.RowItem variant='code'>code</Table.RowItem>
+          <Table.RowItem
+            color='#21a2ff'
+            variant='label'
+            description='라벨 앞에 표시될 색상 칩입니다.'
+          >
+            #21a2ff
+          </Table.RowItem>
+          <Table.RowItem variant='badge'>
+            {["레이블", "레이블", "레이블", "레이블", "레이블"]}
+          </Table.RowItem>
+        </Table.Row>
+      </Table.Body>
+    </Table.Root>
+  ),
+};

--- a/packages/jds/src/components/Table/Table.types.ts
+++ b/packages/jds/src/components/Table/Table.types.ts
@@ -1,0 +1,44 @@
+import type { HTMLAttributes, ReactNode } from "react";
+
+import type { IconName } from "../Icon";
+
+export type TableRowItemVariant = "label" | "code" | "badge";
+
+export interface TableRowItemBaseProps extends HTMLAttributes<HTMLTableCellElement> {
+  hasDivider?: boolean;
+  children: ReactNode;
+}
+
+export interface TableHeaderProps extends HTMLAttributes<HTMLTableCellElement> {
+  children: ReactNode;
+  width?: string | number;
+}
+
+export interface TableRowProps extends HTMLAttributes<HTMLTableRowElement> {
+  children: ReactNode;
+}
+
+export interface TableProps extends HTMLAttributes<HTMLTableElement> {
+  children: ReactNode;
+}
+
+export interface TableRowItemLabelProps extends TableRowItemBaseProps {
+  variant: "label";
+  description?: string;
+  prefixIcon?: IconName;
+  color?: string;
+}
+
+export interface TableRowItemCodeProps extends TableRowItemBaseProps {
+  variant: "code";
+  description?: string;
+}
+
+export interface TableRowItemBadgeProps extends TableRowItemBaseProps {
+  variant: "badge";
+}
+
+export type TableRowItemProps =
+  | TableRowItemLabelProps
+  | TableRowItemCodeProps
+  | TableRowItemBadgeProps;

--- a/packages/jds/src/components/Table/compound/Table.styles.ts
+++ b/packages/jds/src/components/Table/compound/Table.styles.ts
@@ -1,0 +1,84 @@
+import styled from "@emotion/styled";
+
+import type { TableRowItemProps } from "../Table.types";
+
+import { Label } from "@/components/Label";
+
+export const StyledTableRoot = styled.table(({ theme }) => ({
+  width: "100%",
+
+  tableLayout: "fixed",
+  borderSpacing: 0,
+
+  borderRadius: theme.scheme.semantic.radius[6],
+  border: `1px solid ${theme.color.semantic.stroke.subtle}`,
+
+  background: theme.color.semantic.surface.standard,
+}));
+
+export const StyledTableHeader = styled.thead(({ theme }) => ({
+  background: theme.color.semantic.fill.subtlest,
+}));
+
+export const StyledTableHeaderItem = styled.th(({ theme }) => ({
+  padding: theme.scheme.semantic.spacing[12],
+
+  borderBottom: `1px solid ${theme.color.semantic.stroke.subtle}`,
+  borderRight: `1px solid ${theme.color.semantic.stroke.subtle}`,
+
+  "&:last-child": {
+    borderRight: "none",
+  },
+}));
+
+export const StyledTableRow = styled.tr(({ theme }) => ({
+  background: theme.color.semantic.surface.standard,
+
+  "&:last-of-type td": {
+    borderBottom: "none",
+  },
+}));
+
+export const StyledTableRowItem = styled.td<Partial<TableRowItemProps>>(
+  ({ theme, hasDivider }) => ({
+    padding: `${theme.scheme.semantic.spacing[10]} ${theme.scheme.semantic.spacing[12]}`,
+    verticalAlign: "middle",
+
+    borderBottom: `1px solid ${theme.color.semantic.stroke.subtle}`,
+    borderRight: hasDivider ? `1px solid ${theme.color.semantic.stroke.subtle}` : "none",
+
+    "&:last-child": {
+      borderRight: "none",
+    },
+  }),
+);
+
+export const StyledTableItemContent = styled.div(({ theme }) => ({
+  display: "flex",
+  flexDirection: "column",
+  justifyContent: "center",
+  gap: theme.scheme.semantic.spacing[6],
+}));
+
+export const StyledTableItemTitle = styled.div(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  gap: theme.scheme.semantic.spacing[6],
+}));
+
+export const StyledDescription = styled(Label)(({ theme }) => ({
+  color: theme.color.semantic.object.alternative,
+}));
+
+export const StyledCodeWrapper = styled.div(({ theme }) => ({
+  display: "flex",
+  alignItems: "center",
+  flexWrap: "wrap",
+  gap: theme.scheme.semantic.spacing[4],
+}));
+
+export const StyledBadgeWrapper = styled.div(({ theme }) => ({
+  display: "flex",
+  flexWrap: "wrap",
+  gap: theme.scheme.semantic.spacing[6],
+}));

--- a/packages/jds/src/components/Table/compound/TableBody.tsx
+++ b/packages/jds/src/components/Table/compound/TableBody.tsx
@@ -1,0 +1,7 @@
+import type { TableRowProps } from "../Table.types";
+
+export const TableBody = ({ children }: TableRowProps) => {
+  return <tbody>{children}</tbody>;
+};
+
+TableBody.displayName = "TableBody";

--- a/packages/jds/src/components/Table/compound/TableHeader.tsx
+++ b/packages/jds/src/components/Table/compound/TableHeader.tsx
@@ -1,0 +1,8 @@
+import type { TableHeaderProps } from "../Table.types";
+import { StyledTableHeader } from "./Table.styles";
+
+export const TableHeader = ({ children }: Pick<TableHeaderProps, "children">) => (
+  <StyledTableHeader>{children}</StyledTableHeader>
+);
+
+TableHeader.displayName = "TableHeader";

--- a/packages/jds/src/components/Table/compound/TableHeaderItem.tsx
+++ b/packages/jds/src/components/Table/compound/TableHeaderItem.tsx
@@ -1,0 +1,12 @@
+import { StyledTableHeaderItem } from "./Table.styles";
+import type { TableHeaderProps } from "../Table.types";
+
+import { Label } from "@/components/Label";
+
+export const TableHeaderItem = ({ children }: TableHeaderProps) => (
+  <StyledTableHeaderItem>
+    <Label weight='bold'>{children}</Label>
+  </StyledTableHeaderItem>
+);
+
+TableHeaderItem.displayName = "TableHeaderItem";

--- a/packages/jds/src/components/Table/compound/TableRoot.tsx
+++ b/packages/jds/src/components/Table/compound/TableRoot.tsx
@@ -1,0 +1,16 @@
+import { forwardRef } from "react";
+
+import { StyledTableRoot } from "./Table.styles";
+import type { TableProps } from "../Table.types";
+
+export const TableRoot = forwardRef<HTMLTableElement, TableProps>(
+  ({ children, ...restProps }, ref) => {
+    return (
+      <StyledTableRoot ref={ref} {...restProps}>
+        {children}
+      </StyledTableRoot>
+    );
+  },
+);
+
+TableRoot.displayName = "TableRoot";

--- a/packages/jds/src/components/Table/compound/TableRow.tsx
+++ b/packages/jds/src/components/Table/compound/TableRow.tsx
@@ -1,0 +1,8 @@
+import { StyledTableRow } from "./Table.styles";
+import type { TableRowProps } from "../Table.types";
+
+export const TableRow = ({ children, ...restProps }: TableRowProps) => {
+  return <StyledTableRow {...restProps}>{children}</StyledTableRow>;
+};
+
+TableRow.displayName = "TableRow";

--- a/packages/jds/src/components/Table/compound/TableRowItem.tsx
+++ b/packages/jds/src/components/Table/compound/TableRowItem.tsx
@@ -1,0 +1,88 @@
+import { Children } from "react";
+
+import type {
+  TableRowItemProps,
+  TableRowItemCodeProps,
+  TableRowItemLabelProps,
+  TableRowItemBaseProps,
+  TableRowItemBadgeProps,
+} from "../Table.types";
+import {
+  StyledTableRowItem,
+  StyledTableItemContent,
+  StyledTableItemTitle,
+  StyledDescription,
+  StyledCodeWrapper,
+  StyledBadgeWrapper,
+} from "./Table.styles";
+import { ColorChip } from "../ColorChip/ColorChip";
+
+import { ContentBadge } from "@/components/Badge";
+import { Code } from "@/components/Code/Code";
+import { Icon } from "@/components/Icon";
+import { Label } from "@/components/Label";
+
+const BadgeContent = ({ children }: Pick<TableRowItemBaseProps, "children">) => (
+  <StyledBadgeWrapper>
+    {Children.map(children, child => (
+      <ContentBadge.Basic hierarchy='accent' badgeStyle='alpha'>
+        {child}
+      </ContentBadge.Basic>
+    ))}
+  </StyledBadgeWrapper>
+);
+
+const CodeContent = ({ children }: Pick<TableRowItemBaseProps, "children">) => (
+  <StyledCodeWrapper>
+    {Children.map(children, child => (
+      <Code>{child}</Code>
+    ))}
+  </StyledCodeWrapper>
+);
+
+const LabelContent = ({ children, prefixIcon, color }: Omit<TableRowItemLabelProps, "variant">) => (
+  <StyledTableItemTitle>
+    {prefixIcon && <Icon name={prefixIcon} size='sm' aria-hidden='true' focusable={false} />}
+    {color && <ColorChip color={color} />}
+    <Label weight='bold'>{children}</Label>
+  </StyledTableItemTitle>
+);
+
+const BadgeRowItem = ({ children }: TableRowItemBadgeProps) => (
+  <BadgeContent>{children}</BadgeContent>
+);
+
+const CodeRowItem = ({ children, description }: TableRowItemCodeProps) => (
+  <>
+    <CodeContent>{children}</CodeContent>
+    {description && <StyledDescription size='sm'>{description}</StyledDescription>}
+  </>
+);
+
+const LabelRowItem = ({ children, description, prefixIcon, color }: TableRowItemLabelProps) => (
+  <>
+    <LabelContent prefixIcon={prefixIcon} color={color}>
+      {children}
+    </LabelContent>
+    {description && <StyledDescription size='sm'>{description}</StyledDescription>}
+  </>
+);
+
+export const TableRowItem = (props: TableRowItemProps) => {
+  const { variant = "label", hasDivider = true, ...rest } = props;
+
+  const renderContent = () => {
+    if (props.variant === "badge") return <BadgeRowItem {...props} />;
+    if (props.variant === "code") return <CodeRowItem {...props} />;
+
+    return <LabelRowItem {...props} />;
+  };
+
+  return (
+    <StyledTableRowItem variant={variant} hasDivider={hasDivider} {...rest}>
+      <StyledTableItemContent>{renderContent()}</StyledTableItemContent>
+    </StyledTableRowItem>
+  );
+};
+
+TableRowItem.displayName = "TableRowItem";

--- a/packages/jds/src/components/Table/compound/index.ts
+++ b/packages/jds/src/components/Table/compound/index.ts
@@ -1,0 +1,6 @@
+export { TableRoot } from "./TableRoot";
+export { TableHeader } from "./TableHeader";
+export { TableHeaderItem } from "./TableHeaderItem";
+export { TableBody } from "./TableBody";
+export { TableRow } from "./TableRow";
+export { TableRowItem } from "./TableRowItem";

--- a/packages/jds/src/components/Table/index.ts
+++ b/packages/jds/src/components/Table/index.ts
@@ -1,0 +1,17 @@
+import {
+  TableRoot,
+  TableHeader,
+  TableHeaderItem,
+  TableBody,
+  TableRow,
+  TableRowItem,
+} from "./compound";
+
+export const Table = {
+  Root: TableRoot,
+  Header: TableHeader,
+  HeaderItem: TableHeaderItem,
+  Body: TableBody,
+  Row: TableRow,
+  RowItem: TableRowItem,
+};

--- a/packages/jds/src/components/Title/Title.stories.tsx
+++ b/packages/jds/src/components/Title/Title.stories.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from "@emotion/react";
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { Title } from "./Title";
 

--- a/packages/jds/src/components/Toast/Toast.stories.tsx
+++ b/packages/jds/src/components/Toast/Toast.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 
 import { Toast } from "./Toast";

--- a/packages/jds/src/components/Tooltip/Tooltip.stories.tsx
+++ b/packages/jds/src/components/Tooltip/Tooltip.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn, FlexRow, Label } from "@storybook-utils/layout";
 import { Icon, IconButton, Input, Tooltip, BlockButton } from "components";
 import { Label as LabelComponent } from "components";

--- a/packages/jds/src/components/Uploader/UploaderFile.stories.tsx
+++ b/packages/jds/src/components/Uploader/UploaderFile.stories.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from "@emotion/react";
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn } from "@storybook-utils/layout";
 import { useState } from "react";
 

--- a/packages/jds/src/components/Uploader/UploaderImage.stories.tsx
+++ b/packages/jds/src/components/Uploader/UploaderImage.stories.tsx
@@ -1,4 +1,4 @@
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 import { FlexColumn } from "@storybook-utils/layout";
 import { useState } from "react";
 

--- a/packages/jds/src/tokens/Tokens.stories.tsx
+++ b/packages/jds/src/tokens/Tokens.stories.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { useTheme } from "@emotion/react";
 import { css } from "@emotion/react";
-import type { Meta, StoryObj } from "@storybook/react";
+import type { Meta, StoryObj } from "@storybook/react-vite";
 
 const TokenShowcase = () => {
   return <div>Token Showcase</div>;


### PR DESCRIPTION
## 💡 작업 내용

- [x] ColorChip 컴포넌트 구현 (TableRowItem Label에 필요한 atom component)
- [x] Table 디자인 시스템 구현 (compound component 패턴)
  - [x] TableRoot
  - [x] TableHeader
  - [x] TableHeaderItem
  - [x] TableBody
  - [x] TableRow
  - [x] TableRowItem

---

### 추가 수정 사항 

- [x] eslint 에러 표시줄 수정 (`react-vite` 표기 누락)
  
## 💡 자세한 설명

### 1. ColorChip 컴포넌트 구현

> TableRowItem에서 `variant=label`일 경우에만 필요한 ColorChip 컴포넌트 구현을 진행했습니다. 별도의 컴포넌트로 분리해 디자인 시스템 문서를 만들어야 할지, Table에만 종속되는 컴포넌트로 판단해야 할지 동영 님과 이야기 나눈 결과 후자로 결정되었습니다. 관련해서 추가적인 의견 있으시면 코멘트로 남겨 주세요. 

<img width="342" height="158" alt="스크린샷 2026-03-03 오후 2 24 41" src="https://github.com/user-attachments/assets/6a38f043-e3f3-46b8-b04d-b8c0f59f2567" />

### 2. Table 디자인 시스템 구현

> 초기 설계 시 단일 컴포넌트를 고려했을 때, `TableRowItem`의 `variant` 별 대응을 단일 컴포넌트에서 처리하기에는 로직이 거대해지고 props drilling 등의 문제가 발생할 것이라 판단했습니다. 따라서, 디자인 문서를 따라가면서도 디자인 시스템을 사용하는 사용자 또한 직관적으로 조합해 사용할 수 있도록(`HTML Table` 태그들의 속성을 조합해 사용하듯이) `Compound Component` 패턴을 도입해 구현했습니다.

아래 예시처럼 사용 가능합니다. Storybook에서 모든 조합 예시 및 props 변형에 따른 컴포넌트 외형을 확인할 수 있으니 확인 부탁드립니다.

```tsx
    <Table.Root>
      <Table.Header>
        <Table.HeaderItem>헤더 레이블</Table.HeaderItem>
        <Table.HeaderItem>레이블</Table.HeaderItem>
      </Table.Header>
      <Table.Body>
        <Table.Row>
          <Table.RowItem>레이블</Table.RowItem>
          <Table.RowItem>레이블</Table.RowItem>
        </Table.Row>
      </Table.Body>
    </Table.Root>
```

<img width="1079" height="917" alt="스크린샷 2026-03-03 오후 2 33 42" src="https://github.com/user-attachments/assets/889f2121-0ece-4fb5-b578-d399edbbe6b4" />

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #391 
