### PR TITLE
fix: 아코디언(Accordion) 디자인 시스템 2차 QA 대응

### DIFF
--- a/packages/jds/src/components/Accordion/Accordion.tsx
+++ b/packages/jds/src/components/Accordion/Accordion.tsx
@@ -92,10 +92,10 @@ AccordionTrigger.displayName = "Accordion.Trigger";
  */
 const AccordionContent = forwardRef<HTMLDivElement, AccordionContentProps>(
   ({ children, ...props }, ref) => {
-    const { isStretched } = useAccordionContext();
+    const { isStretched, size } = useAccordionContext();
 
     return (
-      <StyledAccordionContent {...props} ref={ref}>
+      <StyledAccordionContent {...props} ref={ref} $size={size}>
         <StyledAccordionContentText $isStretched={isStretched}>
           {children}
         </StyledAccordionContentText>

--- a/packages/jds/src/components/Accordion/accordion.styles.ts
+++ b/packages/jds/src/components/Accordion/accordion.styles.ts
@@ -17,11 +17,12 @@ export const accordionSizeMap: Record<
   {
     iconSize: IconSize;
     labelSize: LabelSize;
+    contentTextStyle: keyof Theme["textStyle"];
   }
 > = {
-  lg: { iconSize: "sm", labelSize: "lg" },
-  md: { iconSize: "xs", labelSize: "md" },
-  sm: { iconSize: "xs", labelSize: "sm" },
+  lg: { iconSize: "sm", labelSize: "lg", contentTextStyle: "semantic-textStyle-body-lg-normal" },
+  md: { iconSize: "xs", labelSize: "md", contentTextStyle: "semantic-textStyle-body-md-normal" },
+  sm: { iconSize: "xs", labelSize: "sm", contentTextStyle: "semantic-textStyle-body-xs-normal" },
 };
 
 const createInteractionStyles = (theme: Theme, isReadonly: boolean) => {
@@ -91,24 +92,9 @@ export const StyledAccordionTrigger = styled(
     },
 
     "&[data-disabled]": {
+      pointerEvents: "none",
       color: theme.color.semantic.object.subtle,
       ...disabledInteractionStyles.restStyle,
-
-      "&:hover": {
-        ...disabledInteractionStyles.hoverStyle,
-        "::after": {
-          ...interactionStyles.hoverStyle["::after"],
-          transition: `opacity ${theme.environment.semantic.duration[100]} ${theme.environment.semantic.motion.fluent}`,
-        },
-      },
-
-      "&:active": {
-        ...disabledInteractionStyles.activeStyle,
-        "::after": {
-          ...disabledInteractionStyles.activeStyle["::after"],
-          transition: "none",
-        },
-      },
 
       "&:focus-visible": {
         ...disabledInteractionStyles.focusStyle,
@@ -152,10 +138,11 @@ const slideDown = keyframes`
     to { height: var(--radix-accordion-content-height); }
   `;
 
-export const StyledAccordionContent = styled(AccordionPrimitive.Content)(({ theme }) => {
+export const StyledAccordionContent = styled(AccordionPrimitive.Content)<
+  Pick<StyledAccordionContentProps, "$size">
+>(({ theme, $size }) => {
   return {
     overflow: "hidden",
-    ...theme.textStyle["semantic-textStyle-body-sm-normal"],
     color: theme.color.semantic.object.bold,
     willChange: "height",
 
@@ -170,12 +157,14 @@ export const StyledAccordionContent = styled(AccordionPrimitive.Content)(({ them
     '&[data-state="closed"]': {
       animation: `${slideUp} ${theme.environment.semantic.duration[300]} ${theme.environment.semantic.motion.fluent}`,
     },
+
+    ...theme.textStyle[accordionSizeMap[$size].contentTextStyle],
   };
 });
 
-export const StyledAccordionContentText = styled("div")<StyledAccordionContentProps>(
-  ({ theme, $isStretched }) => ({
-    marginTop: theme.scheme.semantic.spacing[12],
-    padding: $isStretched ? 0 : `0 ${theme.scheme.semantic.spacing[16]}`,
-  }),
-);
+export const StyledAccordionContentText = styled("div")<
+  Pick<StyledAccordionContentProps, "$isStretched">
+>(({ theme, $isStretched }) => ({
+  marginTop: theme.scheme.semantic.spacing[12],
+  padding: $isStretched ? 0 : `0 ${theme.scheme.semantic.spacing[16]}`,
+}));

--- a/packages/jds/src/components/Accordion/accordion.types.ts
+++ b/packages/jds/src/components/Accordion/accordion.types.ts
@@ -29,4 +29,5 @@ export interface StyledAccordionTriggerProps {
 
 export interface StyledAccordionContentProps {
   $isStretched: boolean;
+  $size: AccordionSize;
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] accordion size prop 변화에 따라 콘텐츠 글자 크기가 대응되도록 수정
- [x] disabled 시 마우스 이벤트(hover, active) 불가능하도록 수정

## 💡 자세한 설명

### 1. accordion size prop 변화에 따라 콘텐츠 글자 크기가 대응되도록 수정

> size prop이 변경되어도 아코디언 콘텐츠의 텍스트 크기가 그대로인 디자인 이슈가 존재했습니다. 아래처럼 수정했습니다:

- StyledAccordionContentProps에 `$size` 추가
- `accordionSizeMap[$size].contentTextStyle`로 동적 텍스트 스타일 적용
- AccordionContent가 context에서 size를 읽어 `$size={size}`로 전달하도록 수정

<img width="531" height="238" alt="스크린샷 2026-03-17 오후 3 56 53" src="https://github.com/user-attachments/assets/56b44a88-8b1a-4a2e-9643-6d85b76ab052" />

### 2. disabled 시 마우스 이벤트(hover, active) 불가능하도록 수정

> disabled 상태임에도 불구하고 마우스 액션이 발생하는 이슈가 존재했습니다. `&[data-disabled]`에서 hover와 action 스타일 속성을 제거하고,  `pointerEvents: "none"`을 추가했습니다.

<img width="547" height="304" alt="스크린샷 2026-03-17 오후 3 58 33" src="https://github.com/user-attachments/assets/3b5f06af-0bce-4f3b-b314-fe11818f2393" />

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #378 
