### PR TITLE
fix: 카드(Card) 디자인 시스템 2차 QA 대응

### DIFF
--- a/packages/jds/src/components/Card/compound/compound.styles.ts
+++ b/packages/jds/src/components/Card/compound/compound.styles.ts
@@ -240,16 +240,10 @@ const getOverlayPositionStyles = (
 };
 
 const getFocusVisibleStyles = (
-  theme: Theme,
-  isEmptyPost: boolean,
   hasOffset: boolean,
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   interactionParams: Record<string, any>,
 ): CSSObject => {
-  if (isEmptyPost) {
-    return shadow(theme, "raised");
-  }
-
   if (!hasOffset && interactionParams.focus.boxShadow) {
     return { boxShadow: interactionParams.focus.boxShadow };
   }
@@ -425,9 +419,6 @@ export const StyledCardOverlay = styled("a", {
     borderRadius: borderRadius > 0 ? `${borderRadius}px` : 0,
     outline: "none",
     pointerEvents: $isDisabled ? "none" : "auto",
-    transition: isEmptyPost
-      ? `box-shadow ${theme.environment.semantic.duration[150]} ${theme.environment.semantic.motion.fluent}`
-      : undefined,
     "::before": {
       ...interactionParams.rest["::before"],
       transition: `opacity ${theme.environment.semantic.duration[150]} ${theme.environment.semantic.motion.fluent}`,
@@ -438,7 +429,6 @@ export const StyledCardOverlay = styled("a", {
     },
     ...(!$isDisabled && {
       "&:hover": {
-        ...(isEmptyPost && shadow(theme, "raised")),
         "::after": {
           ...interactionParams.hover["::after"],
           transition: `opacity ${theme.environment.semantic.duration[100]} ${theme.environment.semantic.motion.fluent}`,
@@ -451,7 +441,7 @@ export const StyledCardOverlay = styled("a", {
         },
       },
       "&:focus-visible": {
-        ...getFocusVisibleStyles(theme, isEmptyPost, hasOffset, interactionParams),
+        ...getFocusVisibleStyles(hasOffset, interactionParams),
         "::before": {
           ...interactionParams.focus["::before"],
           ...(hasOffset && { opacity: 1 }),


### PR DESCRIPTION
## 💡 작업 내용

- [x] post card의 style이 empty일 때 shadow가 표시되는 이슈 수정

## 💡 자세한 설명

> Post 카드가 `cardStyle=empty`일 때 shadow가 표시되어 figma 디자인 요구 사항과 일치하지 않는 이슈를 수정했습니다. 

<img width="988" height="294" alt="스크린샷 2026-03-18 오전 12 15 20" src="https://github.com/user-attachments/assets/11f9abfc-ac51-44b9-9f34-ab75b7b2ba5f" />

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #400 
