### PR TITLE
fix: 파일 아이템(FileItem) 디자인 시스템 2차 QA 대응

### DIFF
--- a/packages/jds/src/components/FileItem/FileItem.tsx
+++ b/packages/jds/src/components/FileItem/FileItem.tsx
@@ -47,6 +47,7 @@ export const FileItem = forwardRef<HTMLButtonElement, FileItemProps>(
               weight='subtle'
               $disabled={disabled}
               $readonly={readonly}
+              $hasError={hasError}
               className='file-name'
             >
               {fileName}
@@ -60,12 +61,14 @@ export const FileItem = forwardRef<HTMLButtonElement, FileItemProps>(
             >
               {fileSize}
             </FileSizeLabel>
-            {!readonly && removeable && <IconButton.Basic
-              hierarchy='tertiary'
-              size='lg'
-              icon='close-line'
-              onClick={onRemove}
-            />}
+            {!readonly && removeable && (
+              <IconButton.Basic
+                hierarchy='tertiary'
+                size='lg'
+                icon='close-line'
+                onClick={onRemove}
+              />
+            )}
           </FileItemDataContainer>
         </FileItemSectionDiv>
         {hasError && errorMessage && <FileErrorSpan role='alert'>{errorMessage}</FileErrorSpan>}

--- a/packages/jds/src/components/FileItem/fileItem.styles.ts
+++ b/packages/jds/src/components/FileItem/fileItem.styles.ts
@@ -17,7 +17,7 @@ const interactionStyles = (theme: Theme, disabled: boolean, readonly: boolean): 
     InteractionLayer({
       theme,
       state,
-      variant: "accent",
+      variant: "normal",
       density: "assistive",
       fillColor: "default",
       isReadonly: disabled || readonly,

--- a/packages/jds/src/components/FileItem/fileItem.styles.ts
+++ b/packages/jds/src/components/FileItem/fileItem.styles.ts
@@ -95,7 +95,7 @@ export const FileItemWrapButton = styled.button<FileItemWrapButtonProps>(
       flexDirection: "column",
       gap: theme.scheme.semantic.spacing[8],
       ...interaction,
-      cursor: $disabled || $readonly ? "default" : "pointer",
+      cursor: $disabled || $readonly || $hasError ? "default" : "pointer",
       color: $hasError
         ? theme.color.semantic.object.bold
         : $disabled
@@ -129,10 +129,14 @@ export const FileItemIcon = styled(Icon)(() => {
   };
 });
 
-export const FileItemLabel = styled(Label)<FileItemLabelProps>(({ $disabled, $readonly }) => {
+export const FileItemLabel = styled(Label)<FileItemLabelProps>(({
+  $disabled,
+  $readonly,
+  $hasError,
+}) => {
   return {
     flex: "1",
-    cursor: $disabled || $readonly ? "default" : "pointer",
+    cursor: $disabled || $readonly || $hasError ? "default" : "pointer",
     color: "inherit",
   };
 });


### PR DESCRIPTION
## 💡 작업 내용

- [x] `interactionLayer`의 `variant`가 잘못 설정된 이슈
- [x] `hasError=true`인 경우에도 상호작용이 가능한 이슈

## 💡 자세한 설명

### 1. `interactionLayer`의 `variant`가 잘못 설정된 이슈

> interaction 시 `interactionLayer`의 variant가 디자인 요구 사항과 다른 이슈가 존재했습니다. `accent → normal`로 수정되었습니다. 

<img width="442" height="52" alt="스크린샷 2026-03-18 오전 12 54 31" src="https://github.com/user-attachments/assets/503eb2c8-7375-4801-af59-e685b53cf66b" />

### 2. `hasError=true`인 경우에도 상호작용이 가능한 이슈

> hasError가 true인 경우에는 파일 다운로드가 불가능해야 하므로 사용자가 해당 컴포넌트와 상호작용이 불가능한 것처럼 표시되어야 합니다. 기존에는 `cursor=pointer`가 적용되어 있어 `default`로 변경해 주었습니다.

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #400 
