### PR TITLE
feat: 5기 모집 알림 버튼 활성화 및 랜딩 페이지 통계 업데이트

### DIFF
--- a/apps/web/src/components/main/sections/IntroSection.tsx
+++ b/apps/web/src/components/main/sections/IntroSection.tsx
@@ -78,7 +78,7 @@ const IntroSection = () => {
                 ))}
               </div>
               <Label as='span' size='sm' weight='normal' color='var(--semantic-object-assistive)'>
-                *현 3기 기준, 진행 완료 및 진행중 프로젝트 포함.
+                *현 4기 기준, 진행 완료 및 진행중 프로젝트 포함.
               </Label>
             </div>
 

--- a/apps/web/src/constants/mainPageData.tsx
+++ b/apps/web/src/constants/mainPageData.tsx
@@ -10,12 +10,12 @@ interface StatItem {
 export const statData: StatItem[] = [
   {
     id: 1,
-    title: "102",
+    title: "163",
     description: "누적 동아리원",
   },
   {
     id: 2,
-    title: "12",
+    title: "18",
     description: "진행한 프로젝트",
   },
   {

--- a/apps/web/src/pages/ApplyGuidePage.tsx
+++ b/apps/web/src/pages/ApplyGuidePage.tsx
@@ -189,17 +189,16 @@ function ApplyGuidePage() {
           </Label>
         </div>
 
-        <div className='flex gap-3 self-stretch'>
-          <BlockButton.Basic
-            variant='solid'
-            hierarchy='accent'
-            size='lg'
-            className='flex-1'
-            disabled
-          >
-            모집이 마감되었습니다
+        <a
+          href='https://forms.gle/oarw4xzjDezR6mzQA'
+          target='_blank'
+          rel='noopener noreferrer'
+          className='flex gap-3 self-stretch'
+        >
+          <BlockButton.Basic variant='solid' hierarchy='accent' size='lg' className='flex-1'>
+            5기 모집 알림 신청하기
           </BlockButton.Basic>
-        </div>
+        </a>
       </section>
 
       <Tab.Root


### PR DESCRIPTION
## 💡 작업 내용

- [x] 통계 수치 및 문구 수정
- [x] 모집 알림 버튼 활성화 및 링크 연결

## 💡 자세한 설명

- 랜딩 페이지의 통계 수치와 문구를 4기 기준으로 업데이트했습니다.
<img width="1018" height="348" alt="image" src="https://github.com/user-attachments/assets/d641bf6f-6438-4347-971c-f19f3824a155" />

- 4기 모집 마감으로 비활성화된 버튼을 5기 모집 알림 신청 버튼으로 전환했습니다. 기존 `BlockButton`을 `<a>` 태그로 감싸 외부 링크(Google Forms)로 연결되도록 수정하고, 버튼 텍스트를 수정했습니다.
<img width="1018" height="339" alt="image" src="https://github.com/user-attachments/assets/817f8fc3-6fdc-4e58-9371-6afc8dfaa251" />

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #402 
