### PR TITLE
fix: 필드(Field) 디자인 시스템 2차 QA 대응

### DIFF
--- a/packages/jds/src/components/Input/InputArea/InputArea.stories.tsx
+++ b/packages/jds/src/components/Input/InputArea/InputArea.stories.tsx
@@ -18,14 +18,6 @@ const meta = {
         defaultValue: { summary: "outlined" },
       },
     },
-    layout: {
-      control: "select",
-      options: ["vertical", "horizontal"],
-      description: "레이블과 필드의 레이아웃 관계",
-      table: {
-        defaultValue: { summary: "vertical" },
-      },
-    },
     validation: {
       control: "select",
       options: ["none", "error"],
@@ -102,7 +94,7 @@ export const Default: Story = {
     label: "피드백",
     helperText: "자유롭게 피드백을 작성해주세요",
     value: "",
-    onChange: () => { },
+    onChange: () => {},
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -125,7 +117,7 @@ export const FixedHeight: Story = {
     height: 200,
     helperText: "높이가 200px로 고정되어 있습니다. 내용 초과 시 스크롤됩니다.",
     value: "",
-    onChange: () => { },
+    onChange: () => {},
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -149,7 +141,7 @@ export const DynamicHeight: Story = {
     helperText: "최소 150px이며, 내용 입력 또는 우측 하단 핸들로 크기를 조절할 수 있습니다",
     maxLength: 1000,
     value: "",
-    onChange: () => { },
+    onChange: () => {},
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -172,7 +164,7 @@ export const CSSHeightValue: Story = {
     minHeight: "10rem",
     helperText: "minHeight를 10rem으로 설정했습니다",
     value: "",
-    onChange: () => { },
+    onChange: () => {},
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -196,7 +188,7 @@ export const WithCount: Story = {
     maxLength: 500,
     minHeight: 180,
     value: "",
-    onChange: () => { },
+    onChange: () => {},
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -220,7 +212,7 @@ export const Error: Story = {
     helperText: "10자 이상 입력해주세요",
     maxLength: 100,
     value: "",
-    onChange: () => { },
+    onChange: () => {},
   },
   render: function Render(args) {
     const [value, setValue] = useState("짧은 글");
@@ -243,7 +235,7 @@ export const Disabled: Story = {
     interaction: "disabled",
     helperText: "현재 입력이 비활성화되어 있습니다",
     value: "",
-    onChange: () => { },
+    onChange: () => {},
   },
   render: function Render(args) {
     const [value, setValue] = useState("비활성화된 상태입니다");
@@ -266,7 +258,7 @@ export const ReadOnly: Story = {
     interaction: "readOnly",
     helperText: "읽기 전용 모드입니다",
     value: "",
-    onChange: () => { },
+    onChange: () => {},
   },
   render: function Render(args) {
     const [value, setValue] = useState("이 텍스트는 읽기 전용입니다. 수정할 수 없습니다.");
@@ -289,7 +281,7 @@ export const EmptyStyle: Story = {
     style: "empty",
     helperText: "테두리가 없는 깔끔한 스타일",
     value: "",
-    onChange: () => { },
+    onChange: () => {},
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -306,36 +298,13 @@ export const EmptyStyle: Story = {
   },
 };
 
-export const HorizontalLayout: Story = {
-  args: {
-    label: "가로 레이아웃",
-    layout: "horizontal",
-    helperText: "레이블이 왼쪽에 위치합니다",
-    value: "",
-    onChange: () => { },
-  },
-  render: function Render(args) {
-    const [value, setValue] = useState("");
-    return (
-      <div style={{ width: "560px" }}>
-        <InputArea
-          {...args}
-          value={value}
-          onChange={e => setValue(e.target.value)}
-          placeholder='가로 레이아웃'
-        />
-      </div>
-    );
-  },
-};
-
 export const WithLabelIcon: Story = {
   args: {
     label: "추가 정보",
     labelIcon: "information-line",
     helperText: "아이콘을 호버하면 추가 정보를 볼 수 있습니다",
     value: "",
-    onChange: () => { },
+    onChange: () => {},
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -357,7 +326,7 @@ export const HelperOnly: Story = {
     label: "Helper만",
     helperText: "Helper 텍스트만 표시됩니다",
     value: "",
-    onChange: () => { },
+    onChange: () => {},
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -379,7 +348,7 @@ export const CountOnly: Story = {
     label: "Count만",
     maxLength: 100,
     value: "",
-    onChange: () => { },
+    onChange: () => {},
   },
   render: function Render(args) {
     const [value, setValue] = useState("");
@@ -402,7 +371,7 @@ export const HiddenLabel: Story = {
     labelVisible: false,
     helperText: "레이블이 숨겨진 상태입니다",
     value: "",
-    onChange: () => { },
+    onChange: () => {},
   },
   render: function Render(args) {
     const [value, setValue] = useState("");

--- a/packages/jds/src/components/Input/InputArea/InputArea.tsx
+++ b/packages/jds/src/components/Input/InputArea/InputArea.tsx
@@ -19,7 +19,6 @@ export const InputArea = forwardRef<HTMLTextAreaElement, InputAreaProps>(
   (
     {
       style = "outlined",
-      layout = "vertical",
       validation = "none",
       interaction = "enabled",
       label,
@@ -42,9 +41,9 @@ export const InputArea = forwardRef<HTMLTextAreaElement, InputAreaProps>(
     const hasHelperContainer = Boolean(helperText) || Boolean(maxLength);
 
     return (
-      <StyledFieldContainer $layout={layout}>
+      <StyledFieldContainer>
         {label && labelVisible && (
-          <StyledLabelContainer $layout={layout} $disabled={isDisabled} $readOnly={isReadOnly}>
+          <StyledLabelContainer $disabled={isDisabled} $readOnly={isReadOnly}>
             <StyledFieldLabel
               as='label'
               htmlFor={inputId}
@@ -52,7 +51,6 @@ export const InputArea = forwardRef<HTMLTextAreaElement, InputAreaProps>(
               weight='normal'
               $disabled={isDisabled}
               $readOnly={isReadOnly}
-              $layout={layout}
             >
               {label}
             </StyledFieldLabel>

--- a/packages/jds/src/components/Input/InputArea/inputArea.types.ts
+++ b/packages/jds/src/components/Input/InputArea/inputArea.types.ts
@@ -11,7 +11,6 @@ export type InputAreaStatus = "placeholder" | "filled";
 
 export interface InputAreaPublicProps extends Omit<ComponentPropsWithoutRef<"textarea">, "style"> {
   style?: InputAreaStyle;
-  layout?: InputAreaLayout;
   validation?: InputAreaValidation;
   interaction?: InputInteraction;
   label?: ReactNode;

--- a/packages/jds/src/components/Input/SelectField/SelectField.stories.tsx
+++ b/packages/jds/src/components/Input/SelectField/SelectField.stories.tsx
@@ -21,14 +21,6 @@ const meta = {
         defaultValue: { summary: "outlined" },
       },
     },
-    layout: {
-      control: "select",
-      options: ["vertical", "horizontal"],
-      description: "레이아웃 방향",
-      table: {
-        defaultValue: { summary: "vertical" },
-      },
-    },
     validation: {
       control: "select",
       options: ["none", "error", "success"],
@@ -465,57 +457,6 @@ export const AllStyles: Story = {
           "**스타일 변형**\n\n" +
           "- `outlined`: 테두리가 있는 스타일 (기본값)\n" +
           "- `empty`: 테두리가 없는 스타일",
-      },
-    },
-  },
-};
-
-export const Layouts: Story = {
-  args: {
-    value: "",
-  },
-  render: function Render() {
-    const [isOpen1, setIsOpen1] = useState(false);
-    const [isOpen2, setIsOpen2] = useState(false);
-    const [value1] = useState("");
-    const [value2] = useState("");
-
-    return (
-      <FlexColumn gap='32px'>
-        <div>
-          <Label>Vertical Layout:</Label>
-          <SelectField
-            layout='vertical'
-            label='지역'
-            placeholder='선택하세요'
-            helperText='세로 방향 레이아웃'
-            value={value1}
-            isOpen={isOpen1}
-            onClick={() => setIsOpen1(!isOpen1)}
-          />
-        </div>
-        <div>
-          <Label>Horizontal Layout:</Label>
-          <SelectField
-            layout='horizontal'
-            label='지역'
-            placeholder='선택하세요'
-            helperText='가로 방향 레이아웃'
-            value={value2}
-            isOpen={isOpen2}
-            onClick={() => setIsOpen2(!isOpen2)}
-          />
-        </div>
-      </FlexColumn>
-    );
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "**레이아웃 방향**\n\n" +
-          "- `vertical`: 세로 방향 (기본값)\n" +
-          "- `horizontal`: 가로 방향",
       },
     },
   },

--- a/packages/jds/src/components/Input/SelectField/SelectField.tsx
+++ b/packages/jds/src/components/Input/SelectField/SelectField.tsx
@@ -85,7 +85,6 @@ export const SelectField = forwardRef<HTMLDivElement, SelectFieldProps>(
   (
     {
       style = "outlined",
-      layout = "vertical",
       validation = "none",
       interaction = "enabled",
       isWithInfoIcon = false,
@@ -98,14 +97,13 @@ export const SelectField = forwardRef<HTMLDivElement, SelectFieldProps>(
     return (
       <FormField
         style={style}
-        layout={layout}
         validation={validation}
         interaction={interaction}
         label={label}
         isWithInfoIcon={isWithInfoIcon}
         helperText={helperText}
       >
-        <StyledFieldContainer $layout={layout}>
+        <StyledFieldContainer>
           <FormField.Label />
           <FormField.Content>
             <SelectFieldInput ref={ref} {...restProps} />

--- a/packages/jds/src/components/Input/SelectField/SelectFieldButton.tsx
+++ b/packages/jds/src/components/Input/SelectField/SelectFieldButton.tsx
@@ -19,7 +19,6 @@ export const SelectFieldButton = forwardRef<HTMLDivElement, SelectFieldButtonPro
   (
     {
       style = "outlined",
-      layout = "vertical",
       validation = "none",
       interaction = "enabled",
       label,
@@ -48,9 +47,9 @@ export const SelectFieldButton = forwardRef<HTMLDivElement, SelectFieldButtonPro
     };
 
     return (
-      <StyledFieldContainer $layout={layout}>
+      <StyledFieldContainer>
         {label && (
-          <StyledLabelContainer $layout={layout}>
+          <StyledLabelContainer>
             <StyledFieldLabel
               as='label'
               htmlFor={fieldId}
@@ -58,7 +57,6 @@ export const SelectFieldButton = forwardRef<HTMLDivElement, SelectFieldButtonPro
               weight='normal'
               $disabled={isDisabled}
               $readOnly={isReadOnly}
-              $layout={layout}
             >
               {label}
             </StyledFieldLabel>
@@ -67,7 +65,7 @@ export const SelectFieldButton = forwardRef<HTMLDivElement, SelectFieldButtonPro
         )}
 
         <StyledInputColumn>
-          <StyledInputRow $style={style} $layout={layout}>
+          <StyledInputRow $style={style}>
             <StyledSelectWrapper
               ref={ref}
               id={fieldId}

--- a/packages/jds/src/components/Input/SelectField/selectField.styles.ts
+++ b/packages/jds/src/components/Input/SelectField/selectField.styles.ts
@@ -195,7 +195,7 @@ export const StyledSelectWrapper = styled("div", {
     border: "none",
     boxShadow: baseBorderStyle,
     borderRadius: theme.scheme.semantic.radius[6],
-    cursor: $disabled ? "not-allowed" : "pointer",
+    cursor: $disabled ? "not-allowed" : $readOnly ? "text" : "pointer",
     transition: `box-shadow ${theme.environment.semantic.duration[100]} ${theme.environment.semantic.motion.fluent}`,
 
     "::after": {
@@ -271,6 +271,7 @@ export const StyledSelectValue = styled("span", {
     userSelect: "none",
     overflow: "hidden",
     textOverflow: "ellipsis",
+    cursor: $readOnly ? "text" : "inherit",
   };
 });
 

--- a/packages/jds/src/components/Input/TagField/TagField.stories.tsx
+++ b/packages/jds/src/components/Input/TagField/TagField.stories.tsx
@@ -21,14 +21,6 @@ const meta = {
         defaultValue: { summary: "outlined" },
       },
     },
-    layout: {
-      control: "select",
-      options: ["vertical", "horizontal"],
-      description: "레이아웃 방향",
-      table: {
-        defaultValue: { summary: "vertical" },
-      },
-    },
     validation: {
       control: "select",
       options: ["none", "error", "success"],
@@ -455,60 +447,6 @@ export const AllStyles: Story = {
           "**스타일 변형**\n\n" +
           "- `outlined`: 테두리가 있는 스타일 (기본값)\n" +
           "- `empty`: 테두리가 없는 스타일",
-      },
-    },
-  },
-};
-
-export const Layouts: Story = {
-  args: {
-    tags: [],
-    onTagsChange: () => { },
-  },
-  render: function Render() {
-    const [tags1, setTags1] = useState<Tag[]>([
-      { id: "1", label: "React" },
-      { id: "2", label: "Vue" },
-    ]);
-    const [tags2, setTags2] = useState<Tag[]>([
-      { id: "1", label: "Angular" },
-      { id: "2", label: "Svelte" },
-    ]);
-
-    return (
-      <FlexColumn gap='32px'>
-        <div>
-          <Label>Vertical Layout:</Label>
-          <TagField
-            layout='vertical'
-            label='기술 스택'
-            placeholder='태그를 입력하세요'
-            helperText='Enter로 태그를 추가하세요'
-            tags={tags1}
-            onTagsChange={setTags1}
-          />
-        </div>
-        <div>
-          <Label>Horizontal Layout:</Label>
-          <TagField
-            layout='horizontal'
-            label='기술 스택'
-            placeholder='태그를 입력하세요'
-            helperText='Enter로 태그를 추가하세요'
-            tags={tags2}
-            onTagsChange={setTags2}
-          />
-        </div>
-      </FlexColumn>
-    );
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "**레이아웃 방향**\n\n" +
-          "- `vertical`: 세로 방향 (기본값)\n" +
-          "- `horizontal`: 가로 방향",
       },
     },
   },

--- a/packages/jds/src/components/Input/TagField/TagField.tsx
+++ b/packages/jds/src/components/Input/TagField/TagField.tsx
@@ -188,7 +188,6 @@ export const TagField = forwardRef<HTMLInputElement, TagFieldProps>(
   (
     {
       style = "outlined",
-      layout = "vertical",
       validation = "none",
       interaction = "enabled",
       isWithInfoIcon = false,
@@ -201,14 +200,13 @@ export const TagField = forwardRef<HTMLInputElement, TagFieldProps>(
     return (
       <FormField
         style={style}
-        layout={layout}
         validation={validation}
         interaction={interaction}
         label={label}
         isWithInfoIcon={isWithInfoIcon}
         helperText={helperText}
       >
-        <StyledFieldContainer $layout={layout}>
+        <StyledFieldContainer>
           <FormField.Label />
           <FormField.Content>
             <TagFieldInput ref={ref} {...restProps} />

--- a/packages/jds/src/components/Input/TagField/TagFieldButton.tsx
+++ b/packages/jds/src/components/Input/TagField/TagFieldButton.tsx
@@ -179,6 +179,7 @@ export const TagFieldButton = forwardRef<HTMLInputElement, TagFieldButtonProps>(
                       size='xs'
                       hierarchy='secondary'
                       badgeStyle='alpha'
+                      isMuted={isDisabled}
                       withIcon={isInteractive}
                     >
                       {tag.label}

--- a/packages/jds/src/components/Input/TagField/TagFieldButton.tsx
+++ b/packages/jds/src/components/Input/TagField/TagFieldButton.tsx
@@ -30,7 +30,6 @@ export const TagFieldButton = forwardRef<HTMLInputElement, TagFieldButtonProps>(
   (
     {
       style = "outlined",
-      layout = "vertical",
       validation = "none",
       interaction = "enabled",
       label,
@@ -142,9 +141,9 @@ export const TagFieldButton = forwardRef<HTMLInputElement, TagFieldButtonProps>(
     );
 
     return (
-      <StyledFieldContainer $layout={layout}>
+      <StyledFieldContainer>
         {label && (
-          <StyledLabelContainer $layout={layout}>
+          <StyledLabelContainer>
             <StyledFieldLabel
               as='label'
               htmlFor={inputId}
@@ -152,7 +151,6 @@ export const TagFieldButton = forwardRef<HTMLInputElement, TagFieldButtonProps>(
               weight='normal'
               $disabled={isDisabled}
               $readOnly={isReadOnly}
-              $layout={layout}
             >
               {label}
             </StyledFieldLabel>
@@ -161,7 +159,7 @@ export const TagFieldButton = forwardRef<HTMLInputElement, TagFieldButtonProps>(
         )}
 
         <StyledInputColumn>
-          <StyledInputRow $style={style} $layout={layout}>
+          <StyledInputRow $style={style}>
             <StyledTagInputWrapper
               $style={style}
               $validation={validation}

--- a/packages/jds/src/components/Input/TagField/TagItem.tsx
+++ b/packages/jds/src/components/Input/TagField/TagItem.tsx
@@ -13,7 +13,7 @@ export interface TagItemProps {
 }
 
 export const TagItem = ({ tag, isSelected, onSelect, onRemove }: TagItemProps) => {
-  const { isInteractive } = useFormField();
+  const { isInteractive, isDisabled } = useFormField();
 
   const handleRemoveIconClick = (e: MouseEvent) => {
     e.stopPropagation();
@@ -38,6 +38,7 @@ export const TagItem = ({ tag, isSelected, onSelect, onRemove }: TagItemProps) =
         size='xs'
         hierarchy='secondary'
         badgeStyle='alpha'
+        isMuted={isDisabled}
         withIcon={isInteractive}
         onIconClick={isInteractive ? handleRemoveIconClick : undefined}
       >

--- a/packages/jds/src/components/Input/TagField/tagField.types.ts
+++ b/packages/jds/src/components/Input/TagField/tagField.types.ts
@@ -10,7 +10,7 @@ export interface Tag {
 
 export interface TagFieldPublicProps
   extends
-    FieldPublicProps,
+    Omit<FieldPublicProps, "layout">,
     Omit<
       ComponentPropsWithoutRef<"input">,
       "value" | "onChange" | "defaultValue" | "style" | "type"

--- a/packages/jds/src/components/Input/TextField/TextField.stories.tsx
+++ b/packages/jds/src/components/Input/TextField/TextField.stories.tsx
@@ -21,14 +21,6 @@ const meta = {
         defaultValue: { summary: "outlined" },
       },
     },
-    layout: {
-      control: "select",
-      options: ["vertical", "horizontal"],
-      description: "레이아웃 방향",
-      table: {
-        defaultValue: { summary: "vertical" },
-      },
-    },
     validation: {
       control: "select",
       options: ["none", "error", "success"],
@@ -375,54 +367,6 @@ export const AllStyles: Story = {
           "**스타일 변형**\n\n" +
           "- `outlined`: 테두리가 있는 스타일 (기본값)\n" +
           "- `empty`: 테두리가 없는 스타일 (하단 보더만)",
-      },
-    },
-  },
-};
-
-export const Layouts: Story = {
-  args: {
-    value: "",
-    onChange: () => { },
-  },
-  render: function Render() {
-    const [value1, setValue1] = useState("");
-    const [value2, setValue2] = useState("");
-
-    return (
-      <FlexColumn gap='32px'>
-        <div>
-          <Label>Vertical Layout:</Label>
-          <TextField
-            layout='vertical'
-            label='이름'
-            placeholder='이름을 입력하세요'
-            helperText='실명을 입력해주세요'
-            value={value1}
-            onChange={e => setValue1(e.target.value)}
-          />
-        </div>
-        <div>
-          <Label>Horizontal Layout:</Label>
-          <TextField
-            layout='horizontal'
-            label='이름'
-            placeholder='이름을 입력하세요'
-            helperText='실명을 입력해주세요'
-            value={value2}
-            onChange={e => setValue2(e.target.value)}
-          />
-        </div>
-      </FlexColumn>
-    );
-  },
-  parameters: {
-    docs: {
-      description: {
-        story:
-          "**레이아웃 방향**\n\n" +
-          "- `vertical`: 세로 방향 (기본값)\n" +
-          "- `horizontal`: 가로 방향",
       },
     },
   },

--- a/packages/jds/src/components/Input/TextField/TextField.tsx
+++ b/packages/jds/src/components/Input/TextField/TextField.tsx
@@ -47,7 +47,6 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
   (
     {
       style = "outlined",
-      layout = "vertical",
       validation = "none",
       interaction = "enabled",
       isWithInfoIcon = false,
@@ -60,14 +59,13 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     return (
       <FormField
         style={style}
-        layout={layout}
         validation={validation}
         interaction={interaction}
         label={label}
         isWithInfoIcon={isWithInfoIcon}
         helperText={helperText}
       >
-        <StyledFieldContainer $layout={layout}>
+        <StyledFieldContainer>
           <FormField.Label />
           <FormField.Content>
             <TextFieldInput ref={ref} {...restProps} />

--- a/packages/jds/src/components/Input/TextField/TextFieldButton.tsx
+++ b/packages/jds/src/components/Input/TextField/TextFieldButton.tsx
@@ -17,7 +17,6 @@ export const TextFieldButton = forwardRef<HTMLInputElement, TextFieldButtonProps
   (
     {
       style = "outlined",
-      layout = "vertical",
       validation = "none",
       disabled = false,
       readOnly = false,
@@ -34,9 +33,9 @@ export const TextFieldButton = forwardRef<HTMLInputElement, TextFieldButtonProps
     const inputId = useId();
 
     return (
-      <StyledFieldContainer $layout={layout}>
+      <StyledFieldContainer>
         {label && (
-          <StyledLabelContainer $layout={layout}>
+          <StyledLabelContainer>
             <StyledFieldLabel
               as='label'
               htmlFor={inputId}
@@ -44,7 +43,6 @@ export const TextFieldButton = forwardRef<HTMLInputElement, TextFieldButtonProps
               weight='bold'
               $disabled={disabled}
               $readOnly={readOnly}
-              $layout={layout}
             >
               {label}
             </StyledFieldLabel>
@@ -53,7 +51,7 @@ export const TextFieldButton = forwardRef<HTMLInputElement, TextFieldButtonProps
         )}
 
         <StyledInputColumn>
-          <StyledInputRow $style={style} $layout={layout}>
+          <StyledInputRow $style={style}>
             <StyledInputWrapper
               $style={style}
               $validation={validation}

--- a/packages/jds/src/components/Input/index.ts
+++ b/packages/jds/src/components/Input/index.ts
@@ -5,7 +5,6 @@ import { TextField } from "./TextField";
 
 export type {
   InputStyle,
-  InputLayout,
   InputValidation,
   FieldPublicProps,
   FieldInputPublicProps,

--- a/packages/jds/src/components/Input/input.types.ts
+++ b/packages/jds/src/components/Input/input.types.ts
@@ -2,15 +2,12 @@ import type { ComponentPropsWithoutRef } from "react";
 
 export type InputStyle = "outlined" | "empty";
 
-export type InputLayout = "vertical" | "horizontal";
-
 export type InputValidation = "none" | "error" | "success";
 
 export type InputInteraction = "enabled" | "disabled" | "readOnly";
 
 export interface FieldPublicProps {
   style?: InputStyle;
-  layout?: InputLayout;
   validation?: InputValidation;
   interaction?: InputInteraction;
 }

--- a/packages/jds/src/components/Input/shared/FormField.tsx
+++ b/packages/jds/src/components/Input/shared/FormField.tsx
@@ -15,14 +15,14 @@ interface FormFieldLabelProps {
 }
 
 export const FormFieldLabel = ({ children }: FormFieldLabelProps) => {
-  const { fieldId, label, isWithInfoIcon, layout, isDisabled, isReadOnly } = useFormField();
+  const { fieldId, label, isWithInfoIcon, isDisabled, isReadOnly } = useFormField();
 
   if (!label && !children) {
     return null;
   }
 
   return (
-    <StyledLabelContainer $layout={layout}>
+    <StyledLabelContainer>
       <StyledFieldLabel
         as='label'
         htmlFor={fieldId}
@@ -30,7 +30,6 @@ export const FormFieldLabel = ({ children }: FormFieldLabelProps) => {
         weight='normal'
         $disabled={isDisabled}
         $readOnly={isReadOnly}
-        $layout={layout}
       >
         {children || label}
       </StyledFieldLabel>
@@ -78,7 +77,6 @@ interface FormFieldProps extends Omit<FormFieldProviderProps, "children"> {
 
 export const FormField = ({
   style,
-  layout,
   validation,
   interaction,
   label,
@@ -89,7 +87,6 @@ export const FormField = ({
   return (
     <FormFieldProvider
       style={style}
-      layout={layout}
       validation={validation}
       interaction={interaction}
       label={label}

--- a/packages/jds/src/components/Input/shared/FormFieldContext.tsx
+++ b/packages/jds/src/components/Input/shared/FormFieldContext.tsx
@@ -1,12 +1,11 @@
 import { createContext, useContext, useId, type ReactNode } from "react";
 
-import type { InputStyle, InputLayout, InputValidation, InputInteraction } from "../input.types";
+import type { InputStyle, InputValidation, InputInteraction } from "../input.types";
 import { getInteractionStates } from "../input.types";
 
 export interface FormFieldContextValue {
   fieldId: string;
   style: InputStyle;
-  layout: InputLayout;
   validation: InputValidation;
   interaction: InputInteraction;
   isDisabled: boolean;
@@ -29,7 +28,6 @@ export const useFormField = (): FormFieldContextValue => {
 
 export interface FormFieldProviderProps {
   style?: InputStyle;
-  layout?: InputLayout;
   validation?: InputValidation;
   interaction?: InputInteraction;
   label?: ReactNode;
@@ -40,7 +38,6 @@ export interface FormFieldProviderProps {
 
 export const FormFieldProvider = ({
   style = "outlined",
-  layout = "vertical",
   validation = "none",
   interaction = "enabled",
   label,
@@ -54,7 +51,6 @@ export const FormFieldProvider = ({
   const value: FormFieldContextValue = {
     fieldId,
     style,
-    layout,
     validation,
     interaction,
     isDisabled,

--- a/packages/jds/src/components/Input/shared/field.styles.ts
+++ b/packages/jds/src/components/Input/shared/field.styles.ts
@@ -1,11 +1,10 @@
 import isPropValid from "@emotion/is-prop-valid";
 import type { Theme } from "@emotion/react";
 import styled from "@emotion/styled";
-import { pxToRem } from "utils";
 
 import { Icon } from "../../Icon";
 import { Label } from "../../Label";
-import type { InputLayout, InputStyle, InputValidation } from "../input.types";
+import type { InputStyle, InputValidation } from "../input.types";
 
 export const getLabelColor = (theme: Theme, disabled: boolean, readOnly: boolean): string => {
   if (disabled) {
@@ -66,24 +65,23 @@ export const getHelperTextColor = (
 
 export const StyledFieldContainer = styled("div", {
   shouldForwardProp: prop => isPropValid(prop) && !prop.startsWith("$"),
-})<{ $layout: InputLayout }>(({ theme, $layout }) => ({
+})(({ theme }) => ({
   display: "flex",
   padding: 0,
   width: "100%",
-  flexDirection: $layout === "vertical" ? "column" : "row",
-  justifyContent: $layout === "vertical" ? "center" : undefined,
+  flexDirection: "column",
+  justifyContent: "center",
   alignItems: "flex-start",
-  gap:
-    $layout === "vertical" ? theme.scheme.semantic.spacing[6] : theme.scheme.semantic.spacing[16],
+  gap: theme.scheme.semantic.spacing[6],
 }));
 
 export const StyledLabelContainer = styled("div", {
   shouldForwardProp: prop => isPropValid(prop) && !prop.startsWith("$"),
-})<{ $layout?: InputLayout; $disabled?: boolean; $readOnly?: boolean }>(
-  ({ theme, $layout, $disabled = false, $readOnly = false }) => ({
+})<{ $disabled?: boolean; $readOnly?: boolean }>(
+  ({ theme, $disabled = false, $readOnly = false }) => ({
     display: "flex",
     padding: 0,
-    alignItems: $layout === "horizontal" ? "flex-start" : "center",
+    alignItems: "center",
     alignSelf: "stretch",
     gap: theme.scheme.semantic.spacing[4],
     color: getLabelColor(theme, $disabled, $readOnly),
@@ -98,16 +96,9 @@ export const StyledLabelIcon = styled(Icon, {
 
 export const StyledFieldLabel = styled(Label, {
   shouldForwardProp: prop => !prop.startsWith("$"),
-})<{ $disabled: boolean; $readOnly: boolean; $layout?: InputLayout }>(
-  ({ theme, $disabled, $readOnly, $layout }) => ({
-    color: getLabelColor(theme, $disabled, $readOnly),
-    ...($layout === "horizontal" && {
-      height: pxToRem(40),
-      minWidth: pxToRem(80),
-      maxWidth: pxToRem(120),
-    }),
-  }),
-);
+})<{ $disabled: boolean; $readOnly: boolean }>(({ theme, $disabled, $readOnly }) => ({
+  color: getLabelColor(theme, $disabled, $readOnly),
+}));
 
 export const StyledHelperText = styled(Label, {
   shouldForwardProp: prop => !prop.startsWith("$"),
@@ -132,10 +123,8 @@ export const StyledInputRow = styled("div", {
   shouldForwardProp: prop => isPropValid(prop) && !prop.startsWith("$"),
 })<{
   $style?: InputStyle;
-  $layout?: InputLayout;
-}>(({ theme, $style, $layout }) => {
-  const isEmptyVertical = $style === "empty" && $layout === "vertical";
-  const gapValue = isEmptyVertical ? 20 : 12;
+}>(({ theme, $style }) => {
+  const gapValue = $style === "empty" ? 20 : 12;
 
   return {
     display: "flex",


### PR DESCRIPTION
## 💡 작업 내용

- [x] Input 디자인 시스템 내부 layout property 제거
- [x] SelectField가 `readonly`일 때 Mouse cursor가 pointer로 활성화되는 이슈 수정
- [x] TagField가 `disabled`일 때 내부 배지가 mute 되지 않는 이슈 수정

## 💡 자세한 설명

### 1. Input 디자인 시스템 내부 layout property 제거

> Input 디자인 시스템 내부에 있던 `layout` property가 figma 디자인 명세에서 deprecated 되어 삭제 처리를 진행했습니다. 모든 Input Field가 기본 레이아웃 속성인 `vertical`로 고정 적용됩니다. 

### 2. SelectField가 `readonly`일 때 Mouse cursor가 pointer로 활성화되는 이슈

> `readonly`일 경우 사용자가 컴포넌트와의 상호 작용이 불가능해야 하므로, 디자인 요구 사항에 맞춰 `cursor: text`로 변경해 주었습니다.

### 3. TagField가 `disabled`일 때 내부 배지가 mute 되지 않는 이슈

> 기존에는 TagField가 `disabled` 상태임에도 내부 배지가 mute 표시되지 않는 이슈가 존재했습니다. 내부 요소들도 모두 접근 불가능한 것처럼 보이도록 `disabled`일 시 `isMuted`가 활성화되도록 수정했습니다.

<img width="361" height="141" alt="스크린샷 2026-03-18 오전 1 52 39" src="https://github.com/user-attachments/assets/32101cdf-dccf-45c7-949a-c6d521676dc6" />

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #400 
