### PR TITLE
fix: 셀렉트(Select) 디자인 시스템 2차 QA 대응

### DIFF
--- a/packages/jds/src/components/Select/SelectCheckbox.tsx
+++ b/packages/jds/src/components/Select/SelectCheckbox.tsx
@@ -10,6 +10,7 @@ import {
   StyledSelectItemInputWrapper,
 } from "./select.styles";
 import type { SelectCheckboxProps } from "./select.types";
+import { Checkbox } from "../Checkbox";
 
 export const SelectCheckbox = forwardRef<HTMLDivElement, SelectCheckboxProps>(
   ({ value, isDisabled = false, caption, children, ...restProps }, ref) => {
@@ -37,17 +38,13 @@ export const SelectCheckbox = forwardRef<HTMLDivElement, SelectCheckboxProps>(
         {...restProps}
       >
         <StyledSelectItemInputWrapper>
-          {/* TODO: Checkbox 컴포넌트가 구현되면 여기에 추가 */}
-          <input
-            type='checkbox'
+          <Checkbox.Basic
+            size={size}
             checked={isItemSelected}
             disabled={isDisabled}
-            readOnly
             tabIndex={-1}
-            style={{ pointerEvents: "none" }}
           />
         </StyledSelectItemInputWrapper>
-
         <StyledSelectItemContent>
           <StyledSelectItemText
             as='span'

--- a/packages/jds/src/components/Select/SelectRadio.tsx
+++ b/packages/jds/src/components/Select/SelectRadio.tsx
@@ -10,6 +10,7 @@ import {
   StyledSelectItemInputWrapper,
 } from "./select.styles";
 import type { SelectRadioProps } from "./select.types";
+import { Radio } from "../Radio";
 
 export const SelectRadio = forwardRef<HTMLDivElement, SelectRadioProps>(
   ({ value, isDisabled = false, caption, children, ...restProps }, ref) => {
@@ -37,14 +38,11 @@ export const SelectRadio = forwardRef<HTMLDivElement, SelectRadioProps>(
         {...restProps}
       >
         <StyledSelectItemInputWrapper>
-          {/* TODO: Radio 컴포넌트가 구현되면 여기에 추가 */}
-          <input
-            type='radio'
+          <Radio.Basic
+            radioSize={size}
             checked={isItemSelected}
             disabled={isDisabled}
-            readOnly
             tabIndex={-1}
-            style={{ pointerEvents: "none" }}
           />
         </StyledSelectItemInputWrapper>
         <StyledSelectItemContent>


### PR DESCRIPTION
## 💡 작업 내용

- [x] Select 내부 Checkout/Radio를 JDS 컴포넌트로 교체

## 💡 자세한 설명

> 디자인이 figma와 일치하지 않던 문제를 해결하기 위해 TODO로 설정되어 있던 Select 내부 Checkout/Radio를 JDS 컴포넌트로 교체했습니다. 

<img width="396" height="331" alt="스크린샷 2026-03-18 오전 9 50 51" src="https://github.com/user-attachments/assets/38b223cf-cf3b-4c2a-a156-63975296f9cd" />

<img width="374" height="295" alt="스크린샷 2026-03-18 오전 9 51 04" src="https://github.com/user-attachments/assets/608a592b-3979-4408-b5a7-02a075ceb62c" />

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #400 
