### PR TITLE
fix: 엠티 스테이트(EmptyState) 디자인 시스템 2차 QA 대응

### DIFF
--- a/.changeset/tidy-books-kiss.md
+++ b/.changeset/tidy-books-kiss.md
@@ -1,0 +1,5 @@
+---
+"@jects/jds": patch
+---
+
+2차 QA 대응

--- a/packages/jds/CHANGELOG.md
+++ b/packages/jds/CHANGELOG.md
@@ -8,6 +8,6 @@
 
 ## 0.0.1
 
-### Major Changes
+### Patch Changes
 
 - 050b727: 리팩토링 이전 디자인 시스템 배포 테스트

--- a/packages/jds/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/jds/src/components/EmptyState/EmptyState.stories.tsx
@@ -4,7 +4,7 @@ import { FlexColumn } from "@storybook-utils/layout";
 import { EmptyState } from "./EmptyState";
 
 const SAMPLE_BUTTON = "레이블";
-const SAMPLE_LABEL = "멀티 스테이트 레이블";
+const SAMPLE_LABEL = "엠티 스테이트 레이블";
 const SAMPLE_BODY =
   "해당 엠티 스테이트에 대해 설명하거나 제안하는 콘텐츠 내용을 최대 세 줄 까지 입력할 수 있습니다.";
 

--- a/packages/jds/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/jds/src/components/EmptyState/EmptyState.stories.tsx
@@ -43,6 +43,15 @@ const meta: Meta<typeof EmptyState> = {
       control: "text",
       description: "엠티 스테이트에 표시되는 아이콘 이름 (Icon 컴포넌트)",
     },
+    primaryAction: {
+      control: "object",
+      description: "primary 버튼 설정 (children, onClick, disabled)",
+    },
+    secondaryAction: {
+      control: "object",
+      description:
+        "secondary 버튼 설정 (children, onClick, disabled). primaryAction이 있을 때만 유효",
+    },
   },
 } satisfies Meta<typeof EmptyState>;
 

--- a/packages/jds/src/components/EmptyState/emptyState.types.ts
+++ b/packages/jds/src/components/EmptyState/emptyState.types.ts
@@ -5,7 +5,6 @@ import type { BlockButtonBasicProps } from "../Button/BlockButton";
 type EmptyStateStyleVariant = {
   variant?: "empty" | "outlined" | "alpha";
   layout?: "vertical" | "horizontal";
-  button?: "primary" | "both";
 };
 
 type BlockButtonActionProps = Pick<BlockButtonBasicProps, "children" | "onClick" | "disabled">;


### PR DESCRIPTION
## 💡 작업 내용

- [x] EmptyState 문서(storybook) 오탈자 수정
- [x] primaryAction, secondaryAction 액션을 storybook에서 확인 가능하도록 수정

## 💡 자세한 설명

### 1. EmptyState 문서(storybook) 오탈자 수정

> 문서 혼동을 방지하기 위해 `멀티 스테이트 레이블`을 `엠티 스테이트 레이블`로 변경했습니다. 

<img width="592" height="189" alt="스크린샷 2026-03-18 오전 11 08 51" src="https://github.com/user-attachments/assets/7eca7be6-1147-4875-a07d-5c2e743218b6" />

### 2. primaryAction, secondaryAction 액션을 storybook에서 확인 가능하도록 수정

> storybook args에 primaryAction과 secondaryAction을 추가해 미리 보기에서 확인 가능하도록 수정했습니다. 또한, 사용되지 않는 button style variant를 제거했습니다.

<img width="822" height="938" alt="스크린샷 2026-03-18 오전 11 12 49" src="https://github.com/user-attachments/assets/3cc24e87-b29f-4ed3-a75e-45e1f3a1d8c2" />

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #400 
