### PR TITLE
fix: 공통 에러 페이지 및 지원 안내 페이지 레이아웃 수정

### DIFF
--- a/apps/web/src/pages/ApplyGuidePage.tsx
+++ b/apps/web/src/pages/ApplyGuidePage.tsx
@@ -161,7 +161,7 @@ function ApplyGuidePage() {
         <LocalNavigation.Title>지원 안내</LocalNavigation.Title>
       </LocalNavigation.Root>
 
-      <section className='flex flex-col gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
+      <section className='flex w-full flex-col gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
         <div className='flex flex-col items-start gap-(--semantic-spacing-16) self-stretch'>
           <div className='flex flex-wrap content-center items-center gap-(--semantic-spacing-8) self-stretch'>
             <Hero size='xs' textAlign='left'>
@@ -189,13 +189,8 @@ function ApplyGuidePage() {
           </Label>
         </div>
 
-        <a
-          href='https://forms.gle/oarw4xzjDezR6mzQA'
-          target='_blank'
-          rel='noopener noreferrer'
-          className='flex gap-3 self-stretch'
-        >
-          <BlockButton.Basic variant='solid' hierarchy='accent' size='lg' className='flex-1'>
+        <a href='https://forms.gle/oarw4xzjDezR6mzQA' target='_blank' rel='noopener noreferrer'>
+          <BlockButton.Basic variant='solid' hierarchy='accent' size='lg' className='w-full'>
             5기 모집 알림 신청하기
           </BlockButton.Basic>
         </a>

--- a/apps/web/src/pages/Maintenance.tsx
+++ b/apps/web/src/pages/Maintenance.tsx
@@ -7,9 +7,9 @@ function Maintenance() {
   return (
     <div>
       <PagesContainer>
-        <div className='desktop:py-(--semantic-margin-2xl) tablet:py-(--semantic-margin-2xl) flex h-dvh w-full justify-center pt-14'>
+        <div className='flex h-dvh w-full justify-center py-(--semantic-margin-2xl)'>
           <div className='h-full px-(--semantic-margin-lg) pt-(--semantic-spacing-0) pb-(--semantic-spacing-80)'>
-            <div className='desktop:w-[600px] tablet:w-[608px] mobile:w-[320px] flex h-full flex-col items-center justify-center gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
+            <div className='flex h-full w-full flex-col items-center justify-center gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
               <Icon
                 className='h-10 w-10 text-(--semantic-feedback-notifying-normal)'
                 name='error-warning-line'

--- a/apps/web/src/pages/NonSpecificError.tsx
+++ b/apps/web/src/pages/NonSpecificError.tsx
@@ -21,34 +21,36 @@ function NonSpecificError() {
     <div>
       <GlobalNavigationBar />
       <PagesContainer>
-        <div className='desktop:py-(--semantic-margin-2xl) tablet:py-(--semantic-margin-2xl) flex h-dvh w-full justify-center pt-14'>
-          <div className='h-full px-(--semantic-margin-lg) pt-(--semantic-spacing-0) pb-(--semantic-spacing-80)'>
-            <div className='desktop:w-[600px] tablet:w-[608px] mobile:w-[320px] flex h-full flex-col items-center justify-center gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
-              <Icon
-                className='h-10 w-10 text-(--semantic-feedback-notifying-normal)'
-                name='error-warning-line'
-              />
-              <div className='flex flex-col items-center justify-center gap-(--semantic-spacing-16)'>
-                <div className='flex items-center justify-center gap-(--semantic-spacing-6)'>
-                  <Title size='lg' textAlign='center' className='text-center'>
-                    현재 페이지를 불러오는 중 <br className='desktop:hidden tablet:hidden' /> 문제가
-                    생겼습니다
-                  </Title>
+        <div className='tablet:pt-[46px] desktop:pt-[56px] flex h-dvh w-full justify-center pt-[44px]'>
+          <div className='h-full py-(--semantic-margin-2xl)'>
+            <div className='h-full px-(--semantic-margin-lg) pb-(--semantic-spacing-80)'>
+              <div className='flex h-full w-full flex-col items-center justify-center gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
+                <Icon
+                  className='h-10 w-10 text-(--semantic-feedback-notifying-normal)'
+                  name='error-warning-line'
+                />
+                <div className='flex flex-col items-center justify-center gap-(--semantic-spacing-16)'>
+                  <div className='flex items-center justify-center gap-(--semantic-spacing-6)'>
+                    <Title size='lg' textAlign='center' className='text-center'>
+                      현재 페이지를 불러오는 중 <br className='desktop:hidden tablet:hidden' />{" "}
+                      문제가 생겼습니다
+                    </Title>
+                  </div>
+                  <span className='textStyle-body-md-normal text-center text-(--semantic-object-bold)'>
+                    일시적인 오류일 수 있으니, 잠시 후 다시 시도해주세요.
+                    <br />
+                    문제가 지속된다면 jectofficial@ject.kr 로 문의해주세요.
+                  </span>
                 </div>
-                <span className='textStyle-body-md-normal text-center text-(--semantic-object-bold)'>
-                  일시적인 오류일 수 있으니, 잠시 후 다시 시도해주세요.
-                  <br />
-                  문제가 지속된다면 jectofficial@ject.kr 로 문의해주세요.
-                </span>
+                <BlockButton.Basic
+                  hierarchy='accent'
+                  size='lg'
+                  suffixIcon='arrow-right-line'
+                  onClick={() => void navigate("/")}
+                >
+                  메인 페이지로
+                </BlockButton.Basic>
               </div>
-              <BlockButton.Basic
-                hierarchy='accent'
-                size='lg'
-                suffixIcon='arrow-right-line'
-                onClick={() => void navigate("/")}
-              >
-                메인 페이지로
-              </BlockButton.Basic>
             </div>
           </div>
         </div>

--- a/apps/web/src/pages/NotFoundError.tsx
+++ b/apps/web/src/pages/NotFoundError.tsx
@@ -11,32 +11,34 @@ function NotFoundError() {
     <div>
       <GlobalNavigationBar />
       <PagesContainer>
-        <div className='flex h-dvh w-full justify-center py-(--semantic-margin-2xl) pt-14'>
-          <div className='h-full px-(--semantic-margin-lg) pt-(--semantic-spacing-0) pb-(--semantic-spacing-80)'>
-            <div className='desktop:w-[600px] tablet:w-[608px] mobile:w-[320px] flex h-full flex-col items-center justify-center gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
-              <div className='text-(--semantic-feedback-notifying-normal)'>
-                <Hero size='lg' color='inherit'>
-                  404
-                </Hero>
-              </div>
-              <div className='flex flex-col items-center justify-center gap-(--semantic-spacing-16)'>
-                <div className='flex gap-(--semantic-spacing-6)'>
-                  <Title size='lg' textAlign='center'>
-                    페이지를 찾을 수 없습니다
-                  </Title>
+        <div className='tablet:pt-[46px] desktop:pt-[56px] flex h-dvh w-full justify-center pt-[44px]'>
+          <div className='h-full py-(--semantic-margin-2xl)'>
+            <div className='h-full px-(--semantic-margin-lg) pb-(--semantic-spacing-80)'>
+              <div className='flex h-full w-full flex-col items-center justify-center gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
+                <div className='text-(--semantic-feedback-notifying-normal)'>
+                  <Hero size='lg' color='inherit'>
+                    404
+                  </Hero>
                 </div>
-                <span className='textStyle-body-md-normal text-(--semantic-object-bold)'>
-                  잘못된 주소를 입력했거나, 삭제된 페이지예요.
-                </span>
+                <div className='flex flex-col items-center justify-center gap-(--semantic-spacing-16)'>
+                  <div className='flex gap-(--semantic-spacing-6)'>
+                    <Title size='lg' textAlign='center'>
+                      페이지를 찾을 수 없습니다
+                    </Title>
+                  </div>
+                  <span className='textStyle-body-md-normal text-(--semantic-object-bold)'>
+                    잘못된 주소를 입력했거나, 삭제된 페이지예요.
+                  </span>
+                </div>
+                <BlockButton.Basic
+                  hierarchy='accent'
+                  size='lg'
+                  suffixIcon='arrow-right-line'
+                  onClick={() => void navigate("/")}
+                >
+                  메인 페이지로
+                </BlockButton.Basic>
               </div>
-              <BlockButton.Basic
-                hierarchy='accent'
-                size='lg'
-                suffixIcon='arrow-right-line'
-                onClick={() => void navigate("/")}
-              >
-                메인 페이지로
-              </BlockButton.Basic>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## 💡 작업 내용

- [x] 지원 안내 페이지 섹션 너비 적용
- [x] 지원 안내 페이지 알림 신청 링크 불필요한 gap 제거
- [x] 공통 에러 페이지(`NonSpecificError`, `NotFoundError`) 기기별 헤더 높이에 맞게 레이아웃 수정
- [x] 공통 에러 페이지, `Maintenance` 페이지 패딩 피그마 시안에 맞게 조정

## 💡 자세한 설명

### 지원 안내 페이지 섹션 너비 미적용 문제 수정

`<section>` 태그에 `w-full`이 누락되어 부모 컨테이너 너비를 채우지 못하는 문제를 수정했습니다.
또한 알림 신청 링크(`<a>`) 에 `gap-3`이 적용되어 있었으나, 내부에 `BlockButton`이 하나뿐인 flex 컨테이너에는 불필요하므로 제거했습니다.

> **(Before)**
> <img width="1400" height="430" alt="image" src="https://github.com/user-attachments/assets/7230f33b-f0be-4913-b06c-23d1c48c6e5d" />
>
> **(After)**
> <img width="1400" height="430" alt="image" src="https://github.com/user-attachments/assets/2cd0bac5-b2e8-4730-8982-28ecca95a99e" />

### 공통 에러 페이지 레이아웃 수정

GNB가 `fixed` 포지셔닝으로 적용되어 있는데, 공통 에러 페이지의 컨텐츠는 GNB 바로 아래에서 시작해야 합니다.
실제 레이아웃을 확인하여 기기별 헤더 높이에 맞게 `padding-top`을 분기 적용했습니다.

| 기기 | 헤더 높이 | 산출 근거 |
|------|----------|----------|
| Mobile | 44px | `margin.sm(12px) × 2 + root 높이(20px)` |
| Tablet | 46px | `spacing[10](10px) × 2 + root 높이(26px)` |
| Desktop | 56px | `spacing[12](12px) × 2 + root 높이(32px)` |

아울러 피그마 시안에 맞게 중간 컨테이너에 `py-(--semantic-margin-2xl)`을 추가하고, 기존 고정 너비를 제거하여 `w-full`로 수정했습니다.

> **(Before)**
> <img height="400" alt="image" src="https://github.com/user-attachments/assets/b15374a3-de47-423d-a74e-85ab7bb8ff08" />
>
> **(After)**
> <img height="400" alt="image" src="https://github.com/user-attachments/assets/8e7c63ae-55f3-4d64-894e-6474944b7635" />

### `Maintenance` 페이지 패딩 정리

`Maintenance`는 GNB 없이 표시되는 페이지이므로 헤더 offset이 불필요합니다.
기존에 breakpoint별로 중복 선언되어 있던 `py`를 `py-(--semantic-margin-2xl)`로 통일했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

작업 중 피그마 기준과 다른 패딩 값이나 간격이 일부 페이지에 섞여 있는 것을 확인했습니다. 피그마와 동일하게 수정하려면 공통 에러 페이지 외에도 GNB 높이만큼 offset이 필요한 페이지가 다수 존재할 것으로 보입니다. 

현재 사용 중인 패딩 값 중 임의로 부여된 값이 있는지 확인 부탁드리며, GNB 높이를 레이아웃에 반영하거나 페이지 간 간격을 통일할 필요가 있는지도 함께 검토 부탁드립니다 🙂

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #409 
