### PR TITLE
refactor: 공통 레이아웃 컴포넌트 추가 및 적용

### DIFF
--- a/apps/web/src/components/layout/ApplyLayout.tsx
+++ b/apps/web/src/components/layout/ApplyLayout.tsx
@@ -6,18 +6,19 @@ import {
   AsyncBoundary,
   DefaultLoadingFallback,
 } from "@/components/common/async-boundary/AsyncBoundary";
+import PageBoard from "@/components/layout/PageBoard";
 import { PATH } from "@/constants/path";
 
 function ApplyLayout() {
   return (
-    <div className='flex flex-1 flex-col items-center self-stretch pt-[calc(var(--semantic-spacing-64)+var(--semantic-margin-2xl))] pb-(--semantic-margin-2xl)'>
+    <PageBoard>
       <AsyncBoundary
         pendingFallback={<ApplyLoadingFallback />}
         rejectedFallback={ApplyErrorFallback}
       >
         <Outlet />
       </AsyncBoundary>
-    </div>
+    </PageBoard>
   );
 }
 

--- a/apps/web/src/components/layout/PageBoard.tsx
+++ b/apps/web/src/components/layout/PageBoard.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+
+interface PageBoardProps {
+  children: ReactNode;
+}
+
+function PageBoard({ children }: PageBoardProps) {
+  return (
+    <div className='flex justify-center pt-[calc(44px+var(--semantic-margin-2xl))] pb-(--semantic-margin-2xl) tablet:pt-[calc(46px+var(--semantic-margin-2xl))] desktop:pt-[calc(56px+var(--semantic-margin-2xl))]'>
+      {children}
+    </div>
+  );
+}
+
+export default PageBoard;

--- a/apps/web/src/components/layout/PageHeroContainer.tsx
+++ b/apps/web/src/components/layout/PageHeroContainer.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+
+interface PageHeroContainerProps {
+  children: ReactNode;
+}
+
+function PageHeroContainer({ children }: PageHeroContainerProps) {
+  return (
+    <div className='flex flex-col gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
+      {children}
+    </div>
+  );
+}
+
+export default PageHeroContainer;

--- a/apps/web/src/components/layout/PageModule.tsx
+++ b/apps/web/src/components/layout/PageModule.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+
+interface PageModuleProps {
+  children: ReactNode;
+}
+
+function PageModule({ children }: PageModuleProps) {
+  return (
+    <div className='w-full max-w-[978px] px-(--semantic-margin-lg) pb-(--semantic-spacing-80)'>
+      {children}
+    </div>
+  );
+}
+
+export default PageModule;

--- a/apps/web/src/components/layout/PageModule.tsx
+++ b/apps/web/src/components/layout/PageModule.tsx
@@ -1,12 +1,19 @@
+import clsx from "clsx";
 import type { ReactNode } from "react";
 
 interface PageModuleProps {
   children: ReactNode;
+  className?: string;
 }
 
-function PageModule({ children }: PageModuleProps) {
+function PageModule({ children, className }: PageModuleProps) {
   return (
-    <div className='w-full max-w-[978px] px-(--semantic-margin-lg) pb-(--semantic-spacing-80)'>
+    <div
+      className={clsx(
+        "w-full max-w-[978px] px-(--semantic-margin-lg) pb-(--semantic-spacing-80)",
+        className,
+      )}
+    >
       {children}
     </div>
   );

--- a/apps/web/src/components/layout/StandardLayout.tsx
+++ b/apps/web/src/components/layout/StandardLayout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from "react-router-dom";
+
+import PageBoard from "./PageBoard";
+
+function StandardLayout() {
+  return (
+    <PageBoard>
+      <Outlet />
+    </PageBoard>
+  );
+}
+
+export default StandardLayout;

--- a/apps/web/src/pages/ApplyGuidePage.tsx
+++ b/apps/web/src/pages/ApplyGuidePage.tsx
@@ -16,6 +16,7 @@ import { theme } from "@jects/jds/tokens";
 import { useNavigate, useParams, useSearchParams, Navigate } from "react-router-dom";
 
 import type { JobFamily } from "@/apis/apply";
+import PageModule from "@/components/layout/PageModule";
 import {
   findJobFamilyOption,
   JOB_FAMILY_OPTIONS,
@@ -155,7 +156,7 @@ function ApplyGuidePage() {
   };
 
   return (
-    <div className='flex w-full max-w-[656px] flex-col items-start px-(--semantic-margin-lg) pb-(--semantic-spacing-80)'>
+    <PageModule className='!max-w-[656px]'>
       <LocalNavigation.Root isStretched={true}>
         <LocalNavigation.BackButton onClick={handleBack} />
         <LocalNavigation.Title>지원 안내</LocalNavigation.Title>
@@ -463,7 +464,7 @@ function ApplyGuidePage() {
           </div>
         </Tab.Content>
       </Tab.Root>
-    </div>
+    </PageModule>
   );
 }
 

--- a/apps/web/src/pages/ApplyListPage.tsx
+++ b/apps/web/src/pages/ApplyListPage.tsx
@@ -5,6 +5,8 @@ import backendImage from "@/assets/images/backend.png";
 import frontendImage from "@/assets/images/frontend.png";
 import productDesignerImage from "@/assets/images/product-designer.png";
 import productManagerImage from "@/assets/images/product-manager.png";
+import PageHeroContainer from "@/components/layout/PageHeroContainer";
+import PageModule from "@/components/layout/PageModule";
 import { PATH } from "@/constants/path";
 
 type FilterValue = "all" | "PM" | "PD" | "FE" | "BE";
@@ -90,9 +92,9 @@ function ApplyListPage() {
   const selectedFilterLabel = FILTER_OPTIONS.find(opt => opt.value === filter)?.label ?? "전체";
 
   return (
-    <div className='flex max-w-[978px] flex-col items-start px-(--semantic-margin-lg) pb-(--semantic-spacing-80)'>
-      <section className='flex flex-col items-start gap-(--semantic-spacing-32) self-stretch pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
-        <div className='flex flex-col items-start gap-(--semantic-spacing-16) self-stretch'>
+    <PageModule>
+      <PageHeroContainer>
+        <div className='flex flex-col items-start gap-(--semantic-spacing-16)'>
           <Hero size='xs' textAlign='left'>
             지원 안내
           </Hero>
@@ -118,7 +120,7 @@ function ApplyListPage() {
             </div>
           )}
         </div>
-      </section>
+      </PageHeroContainer>
 
       <div className='flex flex-col items-start gap-(--semantic-spacing-24) self-stretch'>
         {filteredList.map((item, index) => (
@@ -138,7 +140,7 @@ function ApplyListPage() {
           </Fragment>
         ))}
       </div>
-    </div>
+    </PageModule>
   );
 }
 

--- a/apps/web/src/pages/Faq.tsx
+++ b/apps/web/src/pages/Faq.tsx
@@ -1,7 +1,6 @@
 import { Accordion, Hero, Tab, Title } from "@jects/jds";
 import { useMediaQueryFlags } from "@jects/jds/hooks";
 
-import PageBoard from "@/components/layout/PageBoard";
 import PageHeroContainer from "@/components/layout/PageHeroContainer";
 import PageModule from "@/components/layout/PageModule";
 import { faqActivity, faqApply, faqJect, faqProject } from "@/constants/faqPageData";
@@ -13,8 +12,7 @@ function Faq() {
   const { isMobile } = useMediaQueryFlags();
 
   return (
-    <PageBoard>
-      <PageModule>
+    <PageModule>
         <PageHeroContainer>
           <div className='flex flex-col items-start gap-(--semantic-spacing-16)'>
             <Hero size='xs' textAlign='left'>
@@ -111,7 +109,6 @@ function Faq() {
           </Tab.Root>
         </div>
       </PageModule>
-    </PageBoard>
   );
 }
 

--- a/apps/web/src/pages/Faq.tsx
+++ b/apps/web/src/pages/Faq.tsx
@@ -1,6 +1,9 @@
 import { Accordion, Hero, Tab, Title } from "@jects/jds";
 import { useMediaQueryFlags } from "@jects/jds/hooks";
 
+import PageBoard from "@/components/layout/PageBoard";
+import PageHeroContainer from "@/components/layout/PageHeroContainer";
+import PageModule from "@/components/layout/PageModule";
 import { faqActivity, faqApply, faqJect, faqProject } from "@/constants/faqPageData";
 import { useFaqNavigation } from "@/hooks/useFaqNavigation";
 
@@ -10,16 +13,18 @@ function Faq() {
   const { isMobile } = useMediaQueryFlags();
 
   return (
-    <div className='flex justify-center py-(--semantic-margin-2xl)'>
-      <div className='mobile:w-[360px] tablet:w-[656px] desktop:w-[656px] mt-10 px-(--semantic-margin-lg) pb-(--semantic-spacing-80)'>
-        <div className='flex flex-col gap-(--semantic-spacing-16) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
-          <Hero size='xs' textAlign='left'>
-            FAQ
-          </Hero>
-          <Title size='xs' textAlign='left'>
-            젝트에 대해 자주 묻는 질문들이 정리되어 있어요.
-          </Title>
-        </div>
+    <PageBoard>
+      <PageModule>
+        <PageHeroContainer>
+          <div className='flex flex-col items-start gap-(--semantic-spacing-16)'>
+            <Hero size='xs' textAlign='left'>
+              FAQ
+            </Hero>
+            <Title size='xs' textAlign='left'>
+              젝트에 대해 자주 묻는 질문들이 정리되어 있어요.
+            </Title>
+          </div>
+        </PageHeroContainer>
 
         <div className='flex flex-col gap-(--semantic-spacing-48)'>
           <Tab.Root
@@ -105,8 +110,8 @@ function Faq() {
             </Tab.Content>
           </Tab.Root>
         </div>
-      </div>
-    </div>
+      </PageModule>
+    </PageBoard>
   );
 }
 

--- a/apps/web/src/pages/LiveSession.tsx
+++ b/apps/web/src/pages/LiveSession.tsx
@@ -2,7 +2,6 @@ import { Card, Hero, Title } from "@jects/jds";
 
 import EmptyData from "@/components/common/emptyState/EmptyData";
 import Label from "@/components/common/label/Label";
-import PageBoard from "@/components/layout/PageBoard";
 import PageHeroContainer from "@/components/layout/PageHeroContainer";
 import PageModule from "@/components/layout/PageModule";
 import useJectalksQuery from "@/hooks/useJectalksQuery";
@@ -11,8 +10,7 @@ const LiveSession = () => {
   const { jectalks, isError, isPending } = useJectalksQuery();
 
   return (
-    <PageBoard>
-      <PageModule>
+    <PageModule>
         <PageHeroContainer>
           <div className='flex flex-col items-start gap-(--semantic-spacing-16)'>
             <Hero size='xs' textAlign='left'>
@@ -70,7 +68,6 @@ const LiveSession = () => {
           )}
         </div>
       </PageModule>
-    </PageBoard>
   );
 };
 

--- a/apps/web/src/pages/LiveSession.tsx
+++ b/apps/web/src/pages/LiveSession.tsx
@@ -2,22 +2,27 @@ import { Card, Hero, Title } from "@jects/jds";
 
 import EmptyData from "@/components/common/emptyState/EmptyData";
 import Label from "@/components/common/label/Label";
+import PageBoard from "@/components/layout/PageBoard";
+import PageHeroContainer from "@/components/layout/PageHeroContainer";
+import PageModule from "@/components/layout/PageModule";
 import useJectalksQuery from "@/hooks/useJectalksQuery";
 
 const LiveSession = () => {
   const { jectalks, isError, isPending } = useJectalksQuery();
 
   return (
-    <div className='flex min-h-dvh flex-col items-center bg-(--semantic-surface-standard) px-(--semantic-margin-lg) py-(--semantic-margin-2xl) pt-(--semantic-spacing-64)'>
-      <section className='flex w-full max-w-[922px] flex-col items-center gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-spacing-80)'>
-        <div className='flex w-full flex-col items-start gap-(--semantic-spacing-16)'>
-          <Hero size='xs' textAlign='left'>
-            라이브 세션
-          </Hero>
-          <Title size='xs' textAlign='left'>
-            온/오프라인에서 구성원이 자신의 경험과 기술에 대해 발표하는 콘텐츠입니다.
-          </Title>
-        </div>
+    <PageBoard>
+      <PageModule>
+        <PageHeroContainer>
+          <div className='flex flex-col items-start gap-(--semantic-spacing-16)'>
+            <Hero size='xs' textAlign='left'>
+              라이브 세션
+            </Hero>
+            <Title size='xs' textAlign='left'>
+              온/오프라인에서 구성원이 자신의 경험과 기술에 대해 발표하는 콘텐츠입니다.
+            </Title>
+          </div>
+        </PageHeroContainer>
 
         <div className='flex w-full flex-col gap-(--semantic-spacing-48)'>
           {isError ? (
@@ -64,8 +69,8 @@ const LiveSession = () => {
             </div>
           )}
         </div>
-      </section>
-    </div>
+      </PageModule>
+    </PageBoard>
   );
 };
 

--- a/apps/web/src/pages/MiniStudy.tsx
+++ b/apps/web/src/pages/MiniStudy.tsx
@@ -2,22 +2,27 @@ import { Card, Hero, Title } from "@jects/jds";
 
 import EmptyData from "@/components/common/emptyState/EmptyData";
 import Label from "@/components/common/label/Label";
+import PageBoard from "@/components/layout/PageBoard";
+import PageHeroContainer from "@/components/layout/PageHeroContainer";
+import PageModule from "@/components/layout/PageModule";
 import useMiniStudiesQuery from "@/hooks/useMiniStudiesQuery";
 
 const MiniStudy = () => {
   const { miniStudies, isError, isPending } = useMiniStudiesQuery();
 
   return (
-    <div className='flex min-h-dvh flex-col items-center bg-(--semantic-surface-standard) px-(--semantic-margin-lg) py-(--semantic-margin-2xl) pt-(--semantic-spacing-64)'>
-      <section className='flex w-full max-w-[922px] flex-col items-center gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-spacing-80)'>
-        <div className='flex w-full flex-col items-start gap-(--semantic-spacing-16)'>
-          <Hero size='xs' textAlign='left'>
-            미니 스터디
-          </Hero>
-          <Title size='xs' textAlign='left'>
-            활동 중 팀 프로젝트와 병행할 수 있는, 성장을 위한 스터디입니다.
-          </Title>
-        </div>
+    <PageBoard>
+      <PageModule>
+        <PageHeroContainer>
+          <div className='flex flex-col items-start gap-(--semantic-spacing-16)'>
+            <Hero size='xs' textAlign='left'>
+              미니 스터디
+            </Hero>
+            <Title size='xs' textAlign='left'>
+              활동 중 팀 프로젝트와 병행할 수 있는, 성장을 위한 스터디입니다.
+            </Title>
+          </div>
+        </PageHeroContainer>
 
         <div className='flex w-full flex-col gap-(--semantic-spacing-48)'>
           {isError ? (
@@ -56,8 +61,8 @@ const MiniStudy = () => {
             </div>
           )}
         </div>
-      </section>
-    </div>
+      </PageModule>
+    </PageBoard>
   );
 };
 

--- a/apps/web/src/pages/MiniStudy.tsx
+++ b/apps/web/src/pages/MiniStudy.tsx
@@ -2,7 +2,6 @@ import { Card, Hero, Title } from "@jects/jds";
 
 import EmptyData from "@/components/common/emptyState/EmptyData";
 import Label from "@/components/common/label/Label";
-import PageBoard from "@/components/layout/PageBoard";
 import PageHeroContainer from "@/components/layout/PageHeroContainer";
 import PageModule from "@/components/layout/PageModule";
 import useMiniStudiesQuery from "@/hooks/useMiniStudiesQuery";
@@ -11,8 +10,7 @@ const MiniStudy = () => {
   const { miniStudies, isError, isPending } = useMiniStudiesQuery();
 
   return (
-    <PageBoard>
-      <PageModule>
+    <PageModule>
         <PageHeroContainer>
           <div className='flex flex-col items-start gap-(--semantic-spacing-16)'>
             <Hero size='xs' textAlign='left'>
@@ -62,7 +60,6 @@ const MiniStudy = () => {
           )}
         </div>
       </PageModule>
-    </PageBoard>
   );
 };
 

--- a/apps/web/src/pages/NonSpecificError.tsx
+++ b/apps/web/src/pages/NonSpecificError.tsx
@@ -5,6 +5,8 @@ import { useNavigate, useRouteError } from "react-router-dom";
 
 import Footer from "@/components/common/footer/Footer";
 import GlobalNavigationBar from "@/components/gnb/GlobalNavigationBar";
+import PageBoard from "@/components/layout/PageBoard";
+import PageModule from "@/components/layout/PageModule";
 import PagesContainer from "@/components/layout/PagesContainer";
 
 function NonSpecificError() {
@@ -21,39 +23,37 @@ function NonSpecificError() {
     <div>
       <GlobalNavigationBar />
       <PagesContainer>
-        <div className='tablet:pt-[46px] desktop:pt-[56px] flex h-dvh w-full justify-center pt-[44px]'>
-          <div className='h-full py-(--semantic-margin-2xl)'>
-            <div className='h-full px-(--semantic-margin-lg) pb-(--semantic-spacing-80)'>
-              <div className='flex h-full w-full flex-col items-center justify-center gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
-                <Icon
-                  className='h-10 w-10 text-(--semantic-feedback-notifying-normal)'
-                  name='error-warning-line'
-                />
-                <div className='flex flex-col items-center justify-center gap-(--semantic-spacing-16)'>
-                  <div className='flex items-center justify-center gap-(--semantic-spacing-6)'>
-                    <Title size='lg' textAlign='center' className='text-center'>
-                      현재 페이지를 불러오는 중 <br className='desktop:hidden tablet:hidden' />{" "}
-                      문제가 생겼습니다
-                    </Title>
-                  </div>
-                  <span className='textStyle-body-md-normal text-center text-(--semantic-object-bold)'>
-                    일시적인 오류일 수 있으니, 잠시 후 다시 시도해주세요.
-                    <br />
-                    문제가 지속된다면 jectofficial@ject.kr 로 문의해주세요.
-                  </span>
+        <PageBoard>
+          <PageModule className='h-dvh'>
+            <div className='flex h-full w-full flex-col items-center justify-center gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
+              <Icon
+                className='h-10 w-10 text-(--semantic-feedback-notifying-normal)'
+                name='error-warning-line'
+              />
+              <div className='flex flex-col items-center justify-center gap-(--semantic-spacing-16)'>
+                <div className='flex items-center justify-center gap-(--semantic-spacing-6)'>
+                  <Title size='lg' textAlign='center' className='text-center'>
+                    현재 페이지를 불러오는 중 <br className='desktop:hidden tablet:hidden' /> 문제가
+                    생겼습니다
+                  </Title>
                 </div>
-                <BlockButton.Basic
-                  hierarchy='accent'
-                  size='lg'
-                  suffixIcon='arrow-right-line'
-                  onClick={() => void navigate("/")}
-                >
-                  메인 페이지로
-                </BlockButton.Basic>
+                <span className='textStyle-body-md-normal text-center text-(--semantic-object-bold)'>
+                  일시적인 오류일 수 있으니, 잠시 후 다시 시도해주세요.
+                  <br />
+                  문제가 지속된다면 jectofficial@ject.kr 로 문의해주세요.
+                </span>
               </div>
+              <BlockButton.Basic
+                hierarchy='accent'
+                size='lg'
+                suffixIcon='arrow-right-line'
+                onClick={() => void navigate("/")}
+              >
+                메인 페이지로
+              </BlockButton.Basic>
             </div>
-          </div>
-        </div>
+          </PageModule>
+        </PageBoard>
       </PagesContainer>
       <Footer />
     </div>

--- a/apps/web/src/pages/NotFoundError.tsx
+++ b/apps/web/src/pages/NotFoundError.tsx
@@ -3,6 +3,8 @@ import { useNavigate } from "react-router-dom";
 
 import Footer from "@/components/common/footer/Footer";
 import GlobalNavigationBar from "@/components/gnb/GlobalNavigationBar";
+import PageBoard from "@/components/layout/PageBoard";
+import PageModule from "@/components/layout/PageModule";
 import PagesContainer from "@/components/layout/PagesContainer";
 
 function NotFoundError() {
@@ -11,37 +13,35 @@ function NotFoundError() {
     <div>
       <GlobalNavigationBar />
       <PagesContainer>
-        <div className='tablet:pt-[46px] desktop:pt-[56px] flex h-dvh w-full justify-center pt-[44px]'>
-          <div className='h-full py-(--semantic-margin-2xl)'>
-            <div className='h-full px-(--semantic-margin-lg) pb-(--semantic-spacing-80)'>
-              <div className='flex h-full w-full flex-col items-center justify-center gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
-                <div className='text-(--semantic-feedback-notifying-normal)'>
-                  <Hero size='lg' color='inherit'>
-                    404
-                  </Hero>
-                </div>
-                <div className='flex flex-col items-center justify-center gap-(--semantic-spacing-16)'>
-                  <div className='flex gap-(--semantic-spacing-6)'>
-                    <Title size='lg' textAlign='center'>
-                      페이지를 찾을 수 없습니다
-                    </Title>
-                  </div>
-                  <span className='textStyle-body-md-normal text-(--semantic-object-bold)'>
-                    잘못된 주소를 입력했거나, 삭제된 페이지예요.
-                  </span>
-                </div>
-                <BlockButton.Basic
-                  hierarchy='accent'
-                  size='lg'
-                  suffixIcon='arrow-right-line'
-                  onClick={() => void navigate("/")}
-                >
-                  메인 페이지로
-                </BlockButton.Basic>
+        <PageBoard>
+          <PageModule className='h-dvh'>
+            <div className='flex h-full w-full flex-col items-center justify-center gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
+              <div className='text-(--semantic-feedback-notifying-normal)'>
+                <Hero size='lg' color='inherit'>
+                  404
+                </Hero>
               </div>
+              <div className='flex flex-col items-center justify-center gap-(--semantic-spacing-16)'>
+                <div className='flex gap-(--semantic-spacing-6)'>
+                  <Title size='lg' textAlign='center'>
+                    페이지를 찾을 수 없습니다
+                  </Title>
+                </div>
+                <span className='textStyle-body-md-normal text-(--semantic-object-bold)'>
+                  잘못된 주소를 입력했거나, 삭제된 페이지예요.
+                </span>
+              </div>
+              <BlockButton.Basic
+                hierarchy='accent'
+                size='lg'
+                suffixIcon='arrow-right-line'
+                onClick={() => void navigate("/")}
+              >
+                메인 페이지로
+              </BlockButton.Basic>
             </div>
-          </div>
-        </div>
+          </PageModule>
+        </PageBoard>
       </PagesContainer>
       <Footer />
     </div>

--- a/apps/web/src/pages/TeamProject.tsx
+++ b/apps/web/src/pages/TeamProject.tsx
@@ -3,7 +3,6 @@ import Lottie from "lottie-react";
 import { useState, useRef } from "react";
 
 import loadingSpinner from "@/assets/lottie/ject-loadingSpinner.json";
-import PageBoard from "@/components/layout/PageBoard";
 import PageHeroContainer from "@/components/layout/PageHeroContainer";
 import PageModule from "@/components/layout/PageModule";
 import useCloseOutside from "@/hooks/useCloseOutside";
@@ -46,8 +45,7 @@ const TeamProject = () => {
   const allProjects: Project[] = projectsData?.pages.flatMap(page => page.content) ?? [];
 
   return (
-    <PageBoard>
-      <PageModule>
+    <PageModule>
         <PageHeroContainer>
           <div className='flex flex-col items-start gap-(--semantic-spacing-16)'>
             <Hero size='xs' textAlign='left'>
@@ -112,7 +110,6 @@ const TeamProject = () => {
           )}
         </div>
       </PageModule>
-    </PageBoard>
   );
 };
 

--- a/apps/web/src/pages/TeamProject.tsx
+++ b/apps/web/src/pages/TeamProject.tsx
@@ -83,10 +83,7 @@ const TeamProject = () => {
             <>
               <div className='desktop:grid-cols-3 tablet:grid-cols-2 grid gap-x-5 gap-y-6'>
                 {allProjects.map(project => (
-                  <div
-                    key={project.id}
-                    className='desktop:w-[294px] tablet:w-[350px] mobile:w-[320px]'
-                  >
+                  <div key={project.id} className='w-full'>
                     <Card.Preset.PlateWithTitle.Link
                       href={`/project/${project.id}`}
                       layout='vertical'

--- a/apps/web/src/pages/TeamProject.tsx
+++ b/apps/web/src/pages/TeamProject.tsx
@@ -3,6 +3,9 @@ import Lottie from "lottie-react";
 import { useState, useRef } from "react";
 
 import loadingSpinner from "@/assets/lottie/ject-loadingSpinner.json";
+import PageBoard from "@/components/layout/PageBoard";
+import PageHeroContainer from "@/components/layout/PageHeroContainer";
+import PageModule from "@/components/layout/PageModule";
 import useCloseOutside from "@/hooks/useCloseOutside";
 import { useInfiniteScroll } from "@/hooks/useInfiniteScroll";
 import { useProjectListQuery } from "@/hooks/useProjectListQuery";
@@ -43,10 +46,10 @@ const TeamProject = () => {
   const allProjects: Project[] = projectsData?.pages.flatMap(page => page.content) ?? [];
 
   return (
-    <div className='flex h-full w-full justify-center py-(--semantic-margin-2xl) pt-14'>
-      <div className='px-(--semantic-margin-lg) pt-(--semantic-spacing-0) pb-(--semantic-spacing-80)'>
-        <div className='desktop:w-[922px] tablet:w-[720px] mobile:w-[320px] flex flex-col gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
-          <div className='flex flex-col gap-(--semantic-spacing-16)'>
+    <PageBoard>
+      <PageModule>
+        <PageHeroContainer>
+          <div className='flex flex-col items-start gap-(--semantic-spacing-16)'>
             <Hero size='xs' textAlign='left'>
               팀 프로젝트
             </Hero>
@@ -67,7 +70,7 @@ const TeamProject = () => {
               </div>
             )}
           </div>
-        </div>
+        </PageHeroContainer>
 
         <div>
           {isLoading && (
@@ -111,8 +114,8 @@ const TeamProject = () => {
             </>
           )}
         </div>
-      </div>
-    </div>
+      </PageModule>
+    </PageBoard>
   );
 };
 

--- a/apps/web/src/pages/TeamProjectDetail.tsx
+++ b/apps/web/src/pages/TeamProjectDetail.tsx
@@ -15,7 +15,6 @@ import positionBe from "@/assets/images/position-be.png";
 import positionFe from "@/assets/images/position-fe.png";
 import positionPd from "@/assets/images/position-pd.png";
 import positionPm from "@/assets/images/position-pm.png";
-import PageBoard from "@/components/layout/PageBoard";
 import PageModule from "@/components/layout/PageModule";
 import { PATH } from "@/constants/path";
 import { useProjectDetailQuery } from "@/hooks/useProjectDetailQuery";
@@ -128,8 +127,7 @@ const TeamProjectDetail = () => {
   const isSemester1 = project && projectName.includes(project.name);
 
   return (
-    <PageBoard>
-      <PageModule>
+    <PageModule>
         <LocalNavigation.Root isStretched={true}>
           <LocalNavigation.BackButton onClick={() => void navigate(PATH.teamProject)} />
           <LocalNavigation.Title>팀 프로젝트</LocalNavigation.Title>
@@ -273,7 +271,6 @@ const TeamProjectDetail = () => {
           ))}
         </div>
       </PageModule>
-    </PageBoard>
   );
 };
 

--- a/apps/web/src/pages/TeamProjectDetail.tsx
+++ b/apps/web/src/pages/TeamProjectDetail.tsx
@@ -15,6 +15,8 @@ import positionBe from "@/assets/images/position-be.png";
 import positionFe from "@/assets/images/position-fe.png";
 import positionPd from "@/assets/images/position-pd.png";
 import positionPm from "@/assets/images/position-pm.png";
+import PageBoard from "@/components/layout/PageBoard";
+import PageModule from "@/components/layout/PageModule";
 import { PATH } from "@/constants/path";
 import { useProjectDetailQuery } from "@/hooks/useProjectDetailQuery";
 import { formatDate } from "@/utils/formatDate";
@@ -126,8 +128,8 @@ const TeamProjectDetail = () => {
   const isSemester1 = project && projectName.includes(project.name);
 
   return (
-    <div className='flex h-full w-full justify-center py-(--semantic-margin-2xl) pt-14'>
-      <div className='px-(--semantic-margin-lg) pt-(--semantic-spacing-0) pb-(--semantic-spacing-80)'>
+    <PageBoard>
+      <PageModule>
         <div className='desktop:w-[922px] tablet:w-[720px] mobile:w-[320px]'>
           <LocalNavigation.Root isStretched={true}>
             <LocalNavigation.BackButton onClick={() => void navigate(PATH.teamProject)} />
@@ -272,8 +274,8 @@ const TeamProjectDetail = () => {
             ))}
           </div>
         </div>
-      </div>
-    </div>
+      </PageModule>
+    </PageBoard>
   );
 };
 

--- a/apps/web/src/pages/TeamProjectDetail.tsx
+++ b/apps/web/src/pages/TeamProjectDetail.tsx
@@ -130,149 +130,147 @@ const TeamProjectDetail = () => {
   return (
     <PageBoard>
       <PageModule>
-        <div className='desktop:w-[922px] tablet:w-[720px] mobile:w-[320px]'>
-          <LocalNavigation.Root isStretched={true}>
-            <LocalNavigation.BackButton onClick={() => void navigate(PATH.teamProject)} />
-            <LocalNavigation.Title>팀 프로젝트</LocalNavigation.Title>
-          </LocalNavigation.Root>
+        <LocalNavigation.Root isStretched={true}>
+          <LocalNavigation.BackButton onClick={() => void navigate(PATH.teamProject)} />
+          <LocalNavigation.Title>팀 프로젝트</LocalNavigation.Title>
+        </LocalNavigation.Root>
 
-          <div className='flex flex-col gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
-            {/* 썸네일 */}
+        <div className='flex flex-col gap-(--semantic-spacing-32) pt-(--semantic-margin-xl) pb-(--semantic-margin-3xl)'>
+          {/* 썸네일 */}
+          <Image
+            src={project.bannerImageUrl?.imageUrl}
+            ratio={isSemester1 ? bannerRatio[project.name as ProjectName] : "9:16"}
+            alt={project.name + "썸네일"}
+            orientation='landscape'
+            isReadonly={true}
+          />
+
+          {/* 서비스 샘플 이미지 */}
+          {project.sampleImageUrls && (
+            <div className='flex gap-(--semantic-spacing-16)'>
+              {project.sampleImageUrls.map(img => (
+                <Image
+                  key={img.sequence}
+                  src={img.imageUrl}
+                  ratio='9:16'
+                  alt={project.name + "서비스 샘플 이미지" + img.sequence}
+                  orientation='landscape'
+                  isReadonly={true}
+                  className='*:object-contain'
+                />
+              ))}
+            </div>
+          )}
+
+          {/* 타이틀 정보  */}
+          <div className='flex flex-col gap-(--semantic-spacing-24)'>
+            <div className='flex flex-col gap-(--semantic-spacing-12)'>
+              <div className='flex gap-(--semantic-spacing-6)'>
+                {project.badges.map(badge => (
+                  <ContentBadge.Basic key={badge} size='lg' badgeStyle='outlined'>
+                    {badge}
+                  </ContentBadge.Basic>
+                ))}
+              </div>
+              <div className='flex items-center gap-(--semantic-spacing-8)'>
+                <Hero size='xs' textAlign='left'>
+                  {project.name}
+                </Hero>
+                <a href={project.serviceUrl} target='_blank' rel='noopener noreferrer'>
+                  <IconButton.Basic hierarchy='tertiary' size='2xl' icon='link-line' />
+                </a>
+              </div>
+              <span className='textStyle-body-sm-normal text-(--semantic-object-bold)'>
+                {project.description}
+              </span>
+            </div>
+
+            {/* 프로젝트 정보 - 진행 기간 및 사용 기술 */}
+            <div className='flex flex-col gap-(--semantic-spacing-12)'>
+              <div className='rounded-(--semantic-radius-4) border border-(--semantic-stroke-subtle)'>
+                <div className='flex border-b border-(--semantic-stroke-subtle)'>
+                  <div className='border-r border-(--semantic-stroke-subtle) bg-(--semantic-fill-subtlest) p-(--semantic-spacing-12)'>
+                    <Label size='md' textAlign='left' weight='bold' className='whitespace-nowrap'>
+                      진행 기간
+                    </Label>
+                  </div>
+                  <div className='flex flex-wrap gap-(--semantic-spacing-10) p-(--semantic-spacing-12)'>
+                    <Label size='md' textAlign='left' weight='bold'>
+                      {formatDate(project.startDate)}
+                    </Label>
+                    <Label size='md' textAlign='left' weight='bold'>
+                      -
+                    </Label>
+                    <Label size='md' textAlign='left' weight='bold'>
+                      {formatDate(project.endDate)}
+                    </Label>
+                  </div>
+                </div>
+
+                <div className='flex border-b border-(--semantic-stroke-subtle)'>
+                  <div className='border-r border-(--semantic-stroke-subtle) bg-(--semantic-fill-subtlest) p-(--semantic-spacing-12)'>
+                    <Label size='md' textAlign='left' weight='bold' className='whitespace-nowrap'>
+                      사용 기술
+                    </Label>
+                  </div>
+                  <div className='flex flex-wrap gap-(--semantic-spacing-10) p-(--semantic-spacing-12)'>
+                    {project.techStack.map(stack => (
+                      <Label key={stack} size='md' textAlign='left' weight='bold'>
+                        {stack}
+                      </Label>
+                    ))}
+                  </div>
+                </div>
+              </div>
+
+              {/* 프로젝트 정보 - 팀원 */}
+              <div className='desktop:grid-cols-4 tablet:grid-cols-3 mobile:grid-cols-1 tablet:*:last:col-span-3 desktop:*:last:col-span-1 grid gap-(--semantic-spacing-12)'>
+                <TeammateByPosition
+                  position={"프론트엔드 개발자"}
+                  teammates={project.teamMemberNames.frontendDevelopers}
+                />
+                <TeammateByPosition
+                  position={"백엔드 개발자"}
+                  teammates={project.teamMemberNames.backendDevelopers}
+                />
+                <TeammateByPosition
+                  position={"프로덕트 매니저"}
+                  teammates={project.teamMemberNames.productManagers}
+                />
+                <TeammateByPosition
+                  position={"프로덕트 디자이너"}
+                  teammates={project.teamMemberNames.productDesigners}
+                />
+              </div>
+            </div>
+
+            {/* 버튼 */}
+            <a href={project.serviceUrl} target='_blank' rel='noopener noreferrer'>
+              <BlockButton.Basic
+                hierarchy='accent'
+                size='lg'
+                variant='solid'
+                suffixIcon='external-link-line'
+                className='w-full'
+              >
+                서비스 바로가기
+              </BlockButton.Basic>
+            </a>
+          </div>
+        </div>
+
+        {/* 서비스 소개 */}
+        <div className='flex flex-col gap-(--semantic-spacing-24)'>
+          {project.descriptionImageUrls.map(img => (
             <Image
-              src={project.bannerImageUrl?.imageUrl}
-              ratio={isSemester1 ? bannerRatio[project.name as ProjectName] : "9:16"}
-              alt={project.name + "썸네일"}
+              key={img.sequence}
+              src={img.imageUrl}
+              ratio='9:16'
+              alt={project.name + "서비스 소개 이미지" + img.sequence}
               orientation='landscape'
               isReadonly={true}
             />
-
-            {/* 서비스 샘플 이미지 */}
-            {project.sampleImageUrls && (
-              <div className='flex gap-(--semantic-spacing-16)'>
-                {project.sampleImageUrls.map(img => (
-                  <Image
-                    key={img.sequence}
-                    src={img.imageUrl}
-                    ratio='9:16'
-                    alt={project.name + "서비스 샘플 이미지" + img.sequence}
-                    orientation='landscape'
-                    isReadonly={true}
-                    className='*:object-contain'
-                  />
-                ))}
-              </div>
-            )}
-
-            {/* 타이틀 정보  */}
-            <div className='flex flex-col gap-(--semantic-spacing-24)'>
-              <div className='flex flex-col gap-(--semantic-spacing-12)'>
-                <div className='flex gap-(--semantic-spacing-6)'>
-                  {project.badges.map(badge => (
-                    <ContentBadge.Basic key={badge} size='lg' badgeStyle='outlined'>
-                      {badge}
-                    </ContentBadge.Basic>
-                  ))}
-                </div>
-                <div className='flex items-center gap-(--semantic-spacing-8)'>
-                  <Hero size='xs' textAlign='left'>
-                    {project.name}
-                  </Hero>
-                  <a href={project.serviceUrl} target='_blank' rel='noopener noreferrer'>
-                    <IconButton.Basic hierarchy='tertiary' size='2xl' icon='link-line' />
-                  </a>
-                </div>
-                <span className='textStyle-body-sm-normal text-(--semantic-object-bold)'>
-                  {project.description}
-                </span>
-              </div>
-
-              {/* 프로젝트 정보 - 진행 기간 및 사용 기술 */}
-              <div className='flex flex-col gap-(--semantic-spacing-12)'>
-                <div className='rounded-(--semantic-radius-4) border border-(--semantic-stroke-subtle)'>
-                  <div className='flex border-b border-(--semantic-stroke-subtle)'>
-                    <div className='border-r border-(--semantic-stroke-subtle) bg-(--semantic-fill-subtlest) p-(--semantic-spacing-12)'>
-                      <Label size='md' textAlign='left' weight='bold' className='whitespace-nowrap'>
-                        진행 기간
-                      </Label>
-                    </div>
-                    <div className='flex flex-wrap gap-(--semantic-spacing-10) p-(--semantic-spacing-12)'>
-                      <Label size='md' textAlign='left' weight='bold'>
-                        {formatDate(project.startDate)}
-                      </Label>
-                      <Label size='md' textAlign='left' weight='bold'>
-                        -
-                      </Label>
-                      <Label size='md' textAlign='left' weight='bold'>
-                        {formatDate(project.endDate)}
-                      </Label>
-                    </div>
-                  </div>
-
-                  <div className='flex border-b border-(--semantic-stroke-subtle)'>
-                    <div className='border-r border-(--semantic-stroke-subtle) bg-(--semantic-fill-subtlest) p-(--semantic-spacing-12)'>
-                      <Label size='md' textAlign='left' weight='bold' className='whitespace-nowrap'>
-                        사용 기술
-                      </Label>
-                    </div>
-                    <div className='flex flex-wrap gap-(--semantic-spacing-10) p-(--semantic-spacing-12)'>
-                      {project.techStack.map(stack => (
-                        <Label key={stack} size='md' textAlign='left' weight='bold'>
-                          {stack}
-                        </Label>
-                      ))}
-                    </div>
-                  </div>
-                </div>
-
-                {/* 프로젝트 정보 - 팀원 */}
-                <div className='desktop:grid-cols-4 tablet:grid-cols-3 mobile:grid-cols-1 tablet:*:last:col-span-3 desktop:*:last:col-span-1 grid gap-(--semantic-spacing-12)'>
-                  <TeammateByPosition
-                    position={"프론트엔드 개발자"}
-                    teammates={project.teamMemberNames.frontendDevelopers}
-                  />
-                  <TeammateByPosition
-                    position={"백엔드 개발자"}
-                    teammates={project.teamMemberNames.backendDevelopers}
-                  />
-                  <TeammateByPosition
-                    position={"프로덕트 매니저"}
-                    teammates={project.teamMemberNames.productManagers}
-                  />
-                  <TeammateByPosition
-                    position={"프로덕트 디자이너"}
-                    teammates={project.teamMemberNames.productDesigners}
-                  />
-                </div>
-              </div>
-
-              {/* 버튼 */}
-              <a href={project.serviceUrl} target='_blank' rel='noopener noreferrer'>
-                <BlockButton.Basic
-                  hierarchy='accent'
-                  size='lg'
-                  variant='solid'
-                  suffixIcon='external-link-line'
-                  className='w-full'
-                >
-                  서비스 바로가기
-                </BlockButton.Basic>
-              </a>
-            </div>
-          </div>
-
-          {/* 서비스 소개 */}
-          <div className='flex flex-col gap-(--semantic-spacing-24)'>
-            {project.descriptionImageUrls.map(img => (
-              <Image
-                key={img.sequence}
-                src={img.imageUrl}
-                ratio='9:16'
-                alt={project.name + "서비스 소개 이미지" + img.sequence}
-                orientation='landscape'
-                isReadonly={true}
-              />
-            ))}
-          </div>
+          ))}
         </div>
       </PageModule>
     </PageBoard>

--- a/apps/web/src/router.tsx
+++ b/apps/web/src/router.tsx
@@ -10,6 +10,7 @@ import TeamProjectDetail from "./pages/TeamProjectDetail";
 
 import ApplyLayout from "@/components/layout/ApplyLayout";
 import Layout from "@/components/layout/Layout";
+import StandardLayout from "@/components/layout/StandardLayout";
 import Activity from "@/pages/Activity";
 import ApplyFunnelPage from "@/pages/ApplyFunnelPage";
 import ApplyGuidePage from "@/pages/ApplyGuidePage";
@@ -29,13 +30,18 @@ const router = sentryCreateBrowserRouter([
     children: [
       { path: PATH.main, element: <Main /> },
       { path: PATH.vision, element: <Vision /> },
-      { path: `${PATH.project}/:id`, element: <TeamProjectDetail /> },
       { path: PATH.activity, element: <Activity /> },
-      { path: PATH.miniStudy, element: <MiniStudy /> },
-      { path: PATH.liveSession, element: <LiveSession /> },
       { path: PATH.apply, element: <RecruitmentComplete /> },
-      { path: `${PATH.faq}/:tabId?/:questionId?`, element: <Faq /> },
-      { path: PATH.teamProject, element: <TeamProject /> },
+      {
+        element: <StandardLayout />,
+        children: [
+          { path: PATH.miniStudy, element: <MiniStudy /> },
+          { path: PATH.liveSession, element: <LiveSession /> },
+          { path: `${PATH.faq}/:tabId?/:questionId?`, element: <Faq /> },
+          { path: PATH.teamProject, element: <TeamProject /> },
+          { path: `${PATH.project}/:id`, element: <TeamProjectDetail /> },
+        ],
+      },
       // 레거시 라우트 → /apply로 리다이렉트
       { path: "/apply/verify", element: <Navigate to={PATH.apply} replace /> },
       { path: "/apply/applicant-info", element: <Navigate to={PATH.apply} replace /> },


### PR DESCRIPTION
## 💡 작업 내용

- [x] `PageBoard`, `PageModule`, `PageHeroContainer` 공통 레이아웃 컴포넌트 추가
- [x] 메뉴 페이지, 상세 페이지, `ApplyLayout` 하위 페이지, 공통 에러 페이지에 레이아웃 컴포넌트 적용

## 💡 자세한 설명

### 레이아웃 컴포넌트 구조 분리

피그마 시안을 기준으로 대부분의 화면이 다음과 같은 공통 구조를 따르고 있음을 확인했습니다.

<img width="312" height="191" alt="image" src="https://github.com/user-attachments/assets/4ee97ca3-adfb-4e7c-aa03-9eb278914753" />

```
board
  └── module
        ├── hero container
        └── 페이지별 콘텐츠
```

- **board**
  - 페이지의 최상위 레이아웃 단위
  - 전체 배경 및 섹션 구분 역할

- **module**
  - 실제 콘텐츠를 감싸는 공통 레이아웃 단위
  - 페이지별로 `max-width` 등 일부 스타일만 상이

- **hero container**
  - 페이지별 헤더 영역 (히어로 섹션)
  - 특정 페이지에서 선택적으로 사용

### 분리 배경

- 피그마 시안 전반에서 board - module - (hero-container) 구조가 반복적으로 사용됨
- 지원 관련 페이지 또한 동일한 구조를 따르며, **module의 `max-width` 정도만 차이**가 존재함
- 즉, 레이아웃 구조는 공통이며 일부 스타일만 변형되는 패턴으로 판단

### 적용 방향

- 반복되는 레이아웃 패턴을 컴포넌트 단위로 분리
- 공통 구조는 유지하고, 페이지별 차이는 props 또는 variant로 제어할 수 있도록 설계

### `PageBoard`

GNB가 `fixed`로 렌더링되므로, GNB 높이와 board 상하 여백을 합산하여 `padding-top`을 계산합니다.
기기별 GNB 높이가 다르기 때문에 브레이크포인트별로 분기 적용했습니다.

| 기기 | GNB 높이 |
|------|----------|
| Mobile | 44px |
| Tablet | 46px |
| Desktop | 56px |

추후 `PagesContainer`로 GNB 오프셋을 분리할 경우, `PageBoard`의 `padding-top`을 `semantic/margin/2xl` 단일 값으로 대체할 수 있도록 설계했습니다.
다만 `PagesContainer`는 `Main` 등 전체 페이지를 감싸는 구조이므로, 별도 검토가 필요해 이번 작업 범위에서는 제외했습니다.

### `PageModule`

좌우 패딩(`semantic/margin/lg`), 하단 여백(`semantic/spacing/80`), `max-width`를 담당합니다.
페이지별로 `max-width` 재정의가 필요한 경우를 고려해 `className` prop을 통해 확장 가능하도록 했습니다.

### `PageHeroContainer`

상단 여백(`semantic/margin/xl`), 하단 여백(`semantic/margin/3xl`), 내부 요소 간 gap(`semantic/spacing/32`)을 담당하는 순수 레이아웃 컴포넌트입니다.
`Hero`, `Title` 등 실제 콘텐츠는 각 페이지에서 직접 정의하도록 분리했습니다.

`SelectField`처럼 제목/부제목 바로 하단에 위치해야 하는 요소는 `PageHeroContainer` 내부에 포함해야 합니다.

### `ApplyLayout` 적용 시 고려사항

`ApplyLayout`은 `Layout`의 `children`으로 중첩 렌더링되는 구조이며, 내부에 `PageBoard`를 공통으로 적용하도록 구성했습니다.
이에 따라 `ApplyLayout`을 사용하는 하위 페이지에서는 `PageBoard`를 중복 적용하지 않도록, `PageModule`부터 사용하도록 했습니다.

### `Vision`, `Maintenance` 미적용

- `Vision` 페이지는 `flex flex-col` 레이아웃을 사용하고 있는데, `PageBoard`는 `flex justify-center` 기반이므로 적용하지 않았습니다.

- `Maintenance` 페이지는 GNB를 사용하지 않으며, `PageBoard`는 GNB 오프셋을 포함한 구조이기 때문에 적용하지 않았습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
- closes #412 
