### PR TITLE
refactor: JDS 유틸리티 함수 리팩토링

### DIFF
--- a/.changeset/overlay-focus-ring-recipe.md
+++ b/.changeset/overlay-focus-ring-recipe.md
@@ -1,0 +1,36 @@
+---
+"@jects/jds": minor
+---
+
+**Interaction Utility Migration**
+
+`focusRing`과 `overlay` 유틸을 style string export에서 recipe 함수 형태로 변경합니다. 두 유틸은 `@jects/jds/utils`를 통해 외부에 공개되어 있으므로, 외부 소비자가 직접 사용하고 있었다면 호출 방식 변경이 필요합니다.
+
+| AS-IS | TO-BE |
+| --- | --- |
+| `focusRing` | `focusRing()` |
+| `overlay` | `overlay()` |
+
+**AS-IS**
+
+```tsx
+import { focusRing, overlay } from "@jects/jds/utils";
+
+const root = style([focusRing, overlay, baseStyles]);
+```
+
+**TO-BE**
+
+```tsx
+import { focusRing, overlay } from "@jects/jds/utils";
+
+const root = style([focusRing(), overlay(), baseStyles]);
+```
+
+`focusRing`은 `border`, `feedback` variant를 지원하고, `overlay`는 `hierarchy`, `density`, `nativeHover` variant를 지원합니다. `nativeHover`는 `usePressable` / `useContainerPressable`을 거치지 않는 Radix 기반 컴포넌트 등에서 native `:hover` fallback이 필요한 경우에만 명시적으로 opt-in해야 합니다.
+
+```tsx
+overlay({ hierarchy: "secondary", density: "normal", nativeHover: true });
+```
+
+또한 interaction focus 색상과 interaction layer 토큰이 갱신되어, 관련 컴포넌트의 focus ring / hover / pressed 렌더링 결과가 달라질 수 있습니다.

--- a/packages/jds/src/components/Button/BlockButton/blockButton.css.ts
+++ b/packages/jds/src/components/Button/BlockButton/blockButton.css.ts
@@ -287,7 +287,7 @@ const emptyCompoundVariants = BLOCK_BUTTON_HIERARCHY_OPTIONS.map(hierarchy => ({
  * @see {@link focusRing} — focus ring 유틸
  */
 export const basicRoot = recipe({
-  base: [overlay, focusRing, baseStyles],
+  base: [overlay(), focusRing(), baseStyles],
   variants: {
     // hierarchy: overlayColor만 설정. 실제 색상은 compoundVariants에서 variant와 교차하여 결정
     hierarchy: {
@@ -325,7 +325,7 @@ export const basicRoot = recipe({
  * 인터랙션 상태 처리는 {@link basicRoot}와 동일하게 `usePressable` data attribute에 의존한다.
  */
 export const feedbackRoot = recipe({
-  base: [overlay, focusRing, baseStyles],
+  base: [overlay(), focusRing(), baseStyles],
   variants: {
     // feedback은 항상 solid이므로 intent variant에서 색상을 직접 결정
     intent: {

--- a/packages/jds/src/components/Button/IconButton/iconButton.css.ts
+++ b/packages/jds/src/components/Button/IconButton/iconButton.css.ts
@@ -147,7 +147,7 @@ const sizeCondensedCompoundVariants = ICON_BUTTON_SIZE_OPTIONS.flatMap(size => [
 
 export const root = recipe({
   // pseudo-element 정책: ::before=focusRing, ::after=overlay (../../../utils/PSEUDO_ELEMENT_POLICY.md)
-  base: [overlay, focusRing, baseStyles],
+  base: [overlay(), focusRing(), baseStyles],
   variants: {
     hierarchy: {
       accent: {

--- a/packages/jds/src/components/Button/LabelButton/labelButton.css.ts
+++ b/packages/jds/src/components/Button/LabelButton/labelButton.css.ts
@@ -196,7 +196,7 @@ const intentVariants = {
  * @see {@link focusRing} — focus ring 유틸
  */
 export const basicRoot = recipe({
-  base: [overlay, focusRing, baseStyles],
+  base: [overlay(), focusRing(), baseStyles],
   variants: {
     hierarchy: hierarchyVariants satisfies Record<LabelButtonHierarchy, unknown>,
     size: sizeVariants satisfies Record<LabelButtonSize, unknown>,
@@ -211,7 +211,7 @@ export const basicRoot = recipe({
  * 인터랙션 상태 처리는 {@link basicRoot}와 동일하게 `usePressable` data attribute에 의존한다.
  */
 export const feedbackRoot = recipe({
-  base: [overlay, focusRing, baseStyles],
+  base: [overlay(), focusRing(), baseStyles],
   variants: {
     intent: intentVariants satisfies Record<LabelButtonIntent, unknown>,
     size: sizeVariants satisfies Record<LabelButtonSize, unknown>,

--- a/packages/jds/src/components/Radio/radio.css.ts
+++ b/packages/jds/src/components/Radio/radio.css.ts
@@ -271,8 +271,8 @@ globalStyle(`${radioItemAlignRight} > :nth-child(3)`, { gridColumn: "1 / span 2"
 
 const itemBaseStyles = style([
   radioItemGrid,
-  overlay,
-  focusRing,
+  overlay(),
+  focusRing(),
   {
     position: "relative",
     vars: { [overlayColor]: vars.color.semantic.fill.bold },

--- a/packages/jds/src/utils/PSEUDO_ELEMENT_POLICY.md
+++ b/packages/jds/src/utils/PSEUDO_ELEMENT_POLICY.md
@@ -92,21 +92,25 @@ React 컴포넌트는 보통 여러 element의 합성이지만, 정책이 적용
 
 ```ts
 // utils/focusRing.css.ts
-export const focusRing = style({
-  outline: "none",
-  selectors: {
-    "&::before": { content: '""', position: "absolute", pointerEvents: "none" },
-    "&[data-focus-visible]::before": { boxShadow: "...", zIndex: 1 },
+export const focusRing = recipe({
+  base: {
+    outline: "none",
+    selectors: {
+      "&::before": { content: '""', position: "absolute", pointerEvents: "none" },
+      "&[data-focus-visible]::before": { boxShadow: "...", zIndex: 1 },
+    },
   },
 });
 
 // utils/overlay.css.ts
-export const overlay = style({
-  selectors: {
-    "&::after": { content: '""', position: "absolute", pointerEvents: "none", ... },
-    // disabled 상태는 utility가 직접 차단 — 호출자가 잊어도 새지 않음
-    "&[data-hovered]:not([data-disabled])::after": { ... },
-    "&[data-pressed]:not([data-disabled])::after": { ... },
+export const overlay = recipe({
+  base: {
+    selectors: {
+      "&::after": { content: '""', position: "absolute", pointerEvents: "none", ... },
+      // disabled 상태는 utility가 직접 차단 — 호출자가 잊어도 새지 않음
+      "&[data-hovered]:not([data-disabled])::after, &:hover:not(:disabled):not([data-disabled])::after": { ... },
+      "&[data-pressed]:not([data-disabled])::after, &:active:not(:disabled):not([data-disabled])::after": { ... },
+    },
   },
 });
 ```
@@ -169,7 +173,7 @@ condensed 모드처럼 inset과 borderRadius를 컴포넌트별로 다르게 주
 
 ## 새 인터랙티브 컴포넌트 작성 체크리스트
 
-- [ ] recipe `base`에 `[overlay, focusRing, baseStyles]` 합성
+- [ ] recipe `base`에 `[overlay(), focusRing(), baseStyles]` 합성
 - [ ] baseStyles에 `position: relative`
 - [ ] outline 처리는 focusRing 유틸이 자체 책임 — baseStyles에 넣지 않는다
 - [ ] `::before`와 `::after`에 inset과 borderRadius를 명시 (동일한 shape 권장 — `&::before, &::after` 쉼표 selector로 한 줄에)

--- a/packages/jds/src/utils/PSEUDO_ELEMENT_POLICY.md
+++ b/packages/jds/src/utils/PSEUDO_ELEMENT_POLICY.md
@@ -97,7 +97,7 @@ export const focusRing = recipe({
     outline: "none",
     selectors: {
       "&::before": { content: '""', position: "absolute", pointerEvents: "none" },
-      "&[data-focus-visible]::before": { boxShadow: "...", zIndex: 1 },
+      "&[data-focus-visible]::before, &:focus-visible::before": { boxShadow: "...", zIndex: 1 },
     },
   },
 });
@@ -108,8 +108,23 @@ export const overlay = recipe({
     selectors: {
       "&::after": { content: '""', position: "absolute", pointerEvents: "none", ... },
       // disabled 상태는 utility가 직접 차단 — 호출자가 잊어도 새지 않음
-      "&[data-hovered]:not([data-disabled])::after, &:hover:not(:disabled):not([data-disabled])::after": { ... },
+      "&[data-hovered]:not([data-disabled])::after": { ... },
       "&[data-pressed]:not([data-disabled])::after, &:active:not(:disabled):not([data-disabled])::after": { ... },
+    },
+  },
+  variants: {
+    nativeHover: {
+      // useHover를 거치지 않는 컴포넌트만 명시적으로 opt-in
+      true: {
+        "@media": {
+          "(hover: hover) and (pointer: fine)": {
+            selectors: {
+              "&:hover:not(:disabled):not([data-disabled])::after": { ... },
+              "&[data-pressed]:not([data-disabled])::after, &:active:not(:disabled):not([data-disabled])::after": { ... },
+            },
+          },
+        },
+      },
     },
   },
 });
@@ -177,6 +192,7 @@ condensed 모드처럼 inset과 borderRadius를 컴포넌트별로 다르게 주
 - [ ] baseStyles에 `position: relative`
 - [ ] outline 처리는 focusRing 유틸이 자체 책임 — baseStyles에 넣지 않는다
 - [ ] `::before`와 `::after`에 inset과 borderRadius를 명시 (동일한 shape 권장 — `&::before, &::after` 쉼표 selector로 한 줄에)
+- [ ] `usePressable` / `useContainerPressable`을 거치지 않는 컴포넌트는 필요한 경우 `overlay({ nativeHover: true })`로 native hover fallback을 명시적으로 opt-in한다
 - [ ] `::before` / `::after`에 *shape 외의 속성*을 추가하지 않는다 (content, backgroundColor 등은 utility 책임)
 - [ ] 추가 시각 요소가 필요하면 *별도 child element* 또는 element 자체 속성(border, background-image 등)으로 표현
 - [ ] 자식 element들은 정책 밖이므로 자유롭게 pseudo-element 사용 가능
@@ -184,3 +200,5 @@ condensed 모드처럼 inset과 borderRadius를 컴포넌트별로 다르게 주
 ## 함수형 mixin으로 가지 않는 이유
 
 `focusRing({ pseudo: '::before' })` 같은 함수형 mixin은 자원이 풍부한 토큰(색상/spacing 등)에 적합하다. pseudo-element는 한 element당 2개뿐인 희소 자원이라 *고정 매핑이 곧 정책 강제*가 된다. 이 정책이 유효한 한, 함수형 mixin으로의 전환은 **정책의 강제력을 약화시키는 방향**이라 채택하지 않는다.
+
+현재 `focusRing()` / `overlay()`가 recipe 함수 형태인 것은 border, feedback, hierarchy, density, native hover fallback 같은 **시각적 variant**를 선택하기 위한 API다. `::before = focusRing`, `::after = overlay`라는 pseudo-element 할당 자체는 파라미터화하지 않으므로 위 정책과 충돌하지 않는다.

--- a/packages/jds/src/utils/focusRing.css.ts
+++ b/packages/jds/src/utils/focusRing.css.ts
@@ -1,9 +1,20 @@
-import { style } from "@vanilla-extract/css";
+import { createVar } from "@vanilla-extract/css";
+import { recipe } from "@vanilla-extract/recipes";
 
 import { vars } from "../tokens/vars.css";
 
-// TODO: 디자인팀과 정렬 후 토큰화 예정 (예: vars.scheme.semantic.strokeWeight["3"])
-const FOCUS_RING_WIDTH = "3px";
+export type FocusRingBorder = "outside" | "inside";
+export type FocusRingFeedback = "none" | "destructive" | "positive";
+
+const FOCUS_RING_WIDTH = vars.scheme.semantic.strokeWeight["2"];
+const focusVisibleSelector = "&[data-focus-visible]::before, &:focus-visible::before";
+const focusRingColor = createVar();
+
+const focusRingColorMap = {
+  none: vars.color.semantic.accent.alpha.alternative,
+  destructive: vars.color.semantic.feedback.destructive.alpha.alternative,
+  positive: vars.color.semantic.feedback.positive.alpha.alternative,
+} satisfies Record<FocusRingFeedback, string>;
 
 /**
  * @description
@@ -24,31 +35,57 @@ const FOCUS_RING_WIDTH = "3px";
  *   다르므로 이 유틸이 가정하지 않는다.
  *
  * @example
- *   // 케이스 1: 시각 영역 = 탭 영역인 일반 컴포넌트
- *   selectors: {
- *     "&::before": { inset: 0, borderRadius: "inherit" },
- *   }
- *
- * @example
- *   // 케이스 2: 탭 영역이 시각 영역보다 큰 컴포넌트 (IconButton condensed 등)
- *   selectors: {
- *     "&::before": { inset: pxToRem(-4), borderRadius: "4px" },
- *   }
+ *   focusRing()
+ *   focusRing({ border: "inside", feedback: "destructive" })
  */
-export const focusRing = style({
-  outline: "none",
-  selectors: {
-    "&::before": {
-      content: '""',
-      position: "absolute",
-      pointerEvents: "none",
+export const focusRing = recipe({
+  base: {
+    outline: "none",
+    selectors: {
+      "&::before": {
+        content: '""',
+        position: "absolute",
+        pointerEvents: "none",
+      },
+      [focusVisibleSelector]: {
+        // overlay(::after)는 ::before 다음에 그려지므로 기본 stacking에서 위에 온다.
+        // condensed 모드에서 ::before/::after가 같은 영역을 점유할 때 hover+focus 동시 발생 시
+        // overlay가 focus ring 가장자리를 덮는 시각 버그를 방지하기 위해 ::before를 위로 올린다.
+        zIndex: 1,
+      },
     },
-    "&[data-focus-visible]::before": {
-      boxShadow: `0 0 0 ${FOCUS_RING_WIDTH} ${vars.color.semantic.accent.alpha.alternative}`,
-      // overlay(::after)는 ::before 다음에 그려지므로 기본 stacking에서 위에 온다.
-      // condensed 모드에서 ::before/::after가 같은 영역을 점유할 때 hover+focus 동시 발생 시
-      // overlay가 focus ring 가장자리를 덮는 시각 버그를 방지하기 위해 ::before를 위로 올린다.
-      zIndex: 1,
-    },
+  },
+  variants: {
+    border: {
+      outside: {
+        selectors: {
+          [focusVisibleSelector]: {
+            boxShadow: `0 0 0 ${FOCUS_RING_WIDTH} ${focusRingColor}`,
+          },
+        },
+      },
+      inside: {
+        selectors: {
+          [focusVisibleSelector]: {
+            boxShadow: `inset 0 0 0 ${FOCUS_RING_WIDTH} ${focusRingColor}`,
+          },
+        },
+      },
+    } satisfies Record<FocusRingBorder, object>,
+    feedback: {
+      none: {
+        vars: { [focusRingColor]: focusRingColorMap.none },
+      },
+      destructive: {
+        vars: { [focusRingColor]: focusRingColorMap.destructive },
+      },
+      positive: {
+        vars: { [focusRingColor]: focusRingColorMap.positive },
+      },
+    } satisfies Record<FocusRingFeedback, object>,
+  },
+  defaultVariants: {
+    border: "outside",
+    feedback: "none",
   },
 });

--- a/packages/jds/src/utils/overlay.css.ts
+++ b/packages/jds/src/utils/overlay.css.ts
@@ -70,6 +70,12 @@ const pressedSelector =
  * @example
  *   overlay()
  *   overlay({ density: "normal", hierarchy: "secondary" })
+ *   overlay({ density: "normal", hierarchy: "secondary", nativeHover: true })
+ *
+ * @example
+ *   // usePressable/useContainerPressable을 쓰지 않는 Radix 기반 컴포넌트 등은
+ *   // native hover fallback을 명시적으로 opt-in한다.
+ *   overlay({ nativeHover: true })
  *
  * @example
  *   // 케이스 1: 시각 영역 = 탭 영역인 일반 컴포넌트

--- a/packages/jds/src/utils/overlay.css.ts
+++ b/packages/jds/src/utils/overlay.css.ts
@@ -40,8 +40,8 @@ export const overlayColor = createVar();
 export const overlayHoverOpacity = createVar();
 export const overlayPressedOpacity = createVar();
 
-const hoverSelector =
-  "&[data-hovered]:not([data-disabled])::after, &:hover:not(:disabled):not([data-disabled])::after";
+const hoverSelector = "&[data-hovered]:not([data-disabled])::after";
+const nativeHoverSelector = "&:hover:not(:disabled):not([data-disabled])::after";
 const pressedSelector =
   "&[data-pressed]:not([data-disabled])::after, &:active:not(:disabled):not([data-disabled])::after";
 
@@ -127,5 +127,28 @@ export const overlay = recipe({
         },
       },
     } satisfies Record<OverlayDensity, object>,
+    nativeHover: {
+      false: {},
+      true: {
+        // Radix 등 useHover를 거치지 않는 컴포넌트를 위한 native hover fallback.
+        // touch 환경에서는 sticky hover가 남을 수 있어 hover 가능한 fine pointer에서만 허용한다.
+        "@media": {
+          "(hover: hover) and (pointer: fine)": {
+            selectors: {
+              [nativeHoverSelector]: {
+                opacity: fallbackVar(overlayHoverOpacity, overlayOpacityMap.bold.hover),
+              },
+              // media query 안의 native hover가 pressed보다 뒤에서 생성될 수 있어
+              // hover 가능한 환경에서도 pressed 우선순위를 다시 보장한다.
+              [pressedSelector]: {
+                opacity: fallbackVar(overlayPressedOpacity, overlayOpacityMap.bold.pressed),
+                // pressed는 즉각 반응이 자연스러워 transition을 끈다
+                transition: "none",
+              },
+            },
+          },
+        },
+      },
+    },
   },
 });

--- a/packages/jds/src/utils/overlay.css.ts
+++ b/packages/jds/src/utils/overlay.css.ts
@@ -1,6 +1,28 @@
-import { createVar, fallbackVar, style } from "@vanilla-extract/css";
+import { createVar, fallbackVar } from "@vanilla-extract/css";
+import { recipe } from "@vanilla-extract/recipes";
 
 import { vars } from "../tokens/vars.css";
+
+export type OverlayDensity = "normal" | "bold";
+export type OverlayHierarchy = "accent" | "primary" | "secondary" | "tertiary";
+
+export const overlayColorMap = {
+  accent: vars.color.semantic.accent.normal,
+  primary: vars.color.semantic.fill.boldest,
+  secondary: vars.color.semantic.fill.bold,
+  tertiary: vars.color.semantic.fill.normal,
+} satisfies Record<OverlayHierarchy, string>;
+
+export const overlayOpacityMap = {
+  normal: {
+    hover: `calc(${vars.scheme.semantic.opacity["5"]} / 100)`,
+    pressed: `calc(${vars.scheme.semantic.opacity["8"]} / 100)`,
+  },
+  bold: {
+    hover: `calc(${vars.scheme.semantic.opacity["8"]} / 100)`,
+    pressed: `calc(${vars.scheme.semantic.opacity["12"]} / 100)`,
+  },
+} satisfies Record<OverlayDensity, { hover: string; pressed: string }>;
 
 /**
  * @description
@@ -10,13 +32,18 @@ export const overlayColor = createVar();
 
 /**
  * @description
- * hover / pressed opacity — 외부 override 가능 (기본 0.08 / 0.12)
+ * hover / pressed opacity — 외부 override 가능 (기본 bold: 0.08 / 0.12)
  *
  * destructive에서 hover만 진하게, light/dark에서 opacity 차이 등의
  * 사용처별 변형이 필요할 때 사용처에서 assignInlineVars로 덮는다.
  */
 export const overlayHoverOpacity = createVar();
 export const overlayPressedOpacity = createVar();
+
+const hoverSelector =
+  "&[data-hovered]:not([data-disabled])::after, &:hover:not(:disabled):not([data-disabled])::after";
+const pressedSelector =
+  "&[data-pressed]:not([data-disabled])::after, &:active:not(:disabled):not([data-disabled])::after";
 
 /**
  * @description
@@ -41,6 +68,10 @@ export const overlayPressedOpacity = createVar();
  *   이 속성을 보고 overlay를 차단한다 (`usePressable`은 자동으로 부여).
  *
  * @example
+ *   overlay()
+ *   overlay({ density: "normal", hierarchy: "secondary" })
+ *
+ * @example
  *   // 케이스 1: 시각 영역 = 탭 영역인 일반 컴포넌트
  *   selectors: {
  *     "&::after": { inset: 0, borderRadius: "inherit" },
@@ -52,25 +83,49 @@ export const overlayPressedOpacity = createVar();
  *     "&::after": { inset: pxToRem(-4), borderRadius: "4px" },
  *   }
  */
-export const overlay = style({
-  selectors: {
-    "&::after": {
-      content: '""',
-      position: "absolute",
-      pointerEvents: "none",
-      backgroundColor: overlayColor,
-      opacity: 0,
-      transition: `opacity ${vars.environment.semantic.duration[100]} ${vars.environment.semantic.motion.fluent}`,
+export const overlay = recipe({
+  base: {
+    selectors: {
+      "&::after": {
+        content: '""',
+        position: "absolute",
+        pointerEvents: "none",
+        backgroundColor: fallbackVar(overlayColor, overlayColorMap.primary),
+        opacity: 0,
+        transition: `opacity ${vars.environment.semantic.duration[100]} ${vars.environment.semantic.motion.fluent}`,
+      },
+      [hoverSelector]: {
+        opacity: fallbackVar(overlayHoverOpacity, overlayOpacityMap.bold.hover),
+      },
+      // hover + pressed 동시 상태(마우스 클릭 holding)는 specificity 동등 →
+      // 후행 선언인 pressed 스타일이 적용된다. 의도된 동작 — pressed가 hover 위에
+      [pressedSelector]: {
+        opacity: fallbackVar(overlayPressedOpacity, overlayOpacityMap.bold.pressed),
+        // pressed는 즉각 반응이 자연스러워 transition을 끈다
+        transition: "none",
+      },
     },
-    "&[data-hovered]:not([data-disabled])::after": {
-      opacity: fallbackVar(overlayHoverOpacity, "0.08"),
-    },
-    // hover + pressed 동시 상태(마우스 클릭 holding)는 specificity 동등 →
-    // 후행 선언인 pressed 스타일이 적용된다. 의도된 동작 — pressed가 hover 위에
-    "&[data-pressed]:not([data-disabled])::after": {
-      opacity: fallbackVar(overlayPressedOpacity, "0.12"),
-      // pressed는 즉각 반응이 자연스러워 transition을 끈다
-      transition: "none",
-    },
+  },
+  variants: {
+    hierarchy: {
+      accent: { vars: { [overlayColor]: overlayColorMap.accent } },
+      primary: { vars: { [overlayColor]: overlayColorMap.primary } },
+      secondary: { vars: { [overlayColor]: overlayColorMap.secondary } },
+      tertiary: { vars: { [overlayColor]: overlayColorMap.tertiary } },
+    } satisfies Record<OverlayHierarchy, object>,
+    density: {
+      normal: {
+        vars: {
+          [overlayHoverOpacity]: overlayOpacityMap.normal.hover,
+          [overlayPressedOpacity]: overlayOpacityMap.normal.pressed,
+        },
+      },
+      bold: {
+        vars: {
+          [overlayHoverOpacity]: overlayOpacityMap.bold.hover,
+          [overlayPressedOpacity]: overlayOpacityMap.bold.pressed,
+        },
+      },
+    } satisfies Record<OverlayDensity, object>,
   },
 });


### PR DESCRIPTION
## 💡 작업 내용

- [x] focusRing, overlay 유틸 함수를 recipe 형식으로 리팩토링
- [x] 기존 컴포넌트에 수정된 유틸 함수 적용 

## 💡 자세한 설명

> Tabs PR(https://github.com/JECT-Study/JECT-Official-WebSite-Client/pull/453) 에서 공통 유틸리티 함수 리팩토링 부분을 별도 PR로 분리했습니다. 

피그마 디자인 스펙에 정의된 다양한 Interaction Layer / Focus Ring의 Variants를 코드에서도 명시적으로 다룰 수 있도록 Recipe 패턴으로 리팩토링했습니다.

### focusRing

- 옵션 추가: `border` (outside | inside), `feedback` (none | destructive | positive)
- 기존 사용처를 깨지 않기 위해 인자 없이 `focusRing()`만 호출해도 기본 스타일이 적용되도록 유지했습니다.

### overlay (Interaction Layer)

- 옵션 추가: `density` (normal | bold), `hierarchy` (accent | primary | secondary | tertiary)
- 기존 Button 컴포넌트 사용처를 확인했을 때 overlayColor를 직접 할당하는 코드가 존재하여 공통 정의된 variants를 넘기는 방식과 overlayColor를 직접 주입하는 방식을 모두 지원하도록 했습니다.

```ts
overlay() // 1. 기본값
overlay({ density: "normal", hierarchy: "secondary" }) // 2. Recipe variants 할당
vars: { [overlayColor]: vars.color.semantic.interaction.normal } // 3. 색상 직접 주입
```

+) 
`focusRing`과 `overlay`가 hook 기반 data attribute를 기본으로 사용하되, 필요한 경우 브라우저 native 상태도 함께 처리할 수 있도록 확장했습니다.

기존에는 `usePressable` / `useFocusRing`이 부여하는 `data-focus-visible`, `data-hovered`, `data-pressed` 속성이 있어야만 focus / hover / active 스타일이 적용되었습니다. 이번 변경으로 `focusRing`은 native `:focus-visible`을 함께 처리하고, `overlay`는 기본적으로 `data-hovered`, `data-pressed`를 사용하되 외부 primitive처럼 `useHover`를 거치지 않는 컴포넌트에서만 `nativeHover` 옵션으로 native `:hover` fallback을 명시적으로 opt-in할 수 있도록 했습니다.

터치 환경에서 native `:hover`가 sticky하게 남는 문제를 방지하기 위해, `nativeHover`는 hover가 가능한 정밀 포인터 환경에서만 적용됩니다.

```ts
const focusVisibleSelector =
  "&[data-focus-visible]::before, &:focus-visible::before";

const hoverSelector =
  "&[data-hovered]:not([data-disabled])::after";

const nativeHoverSelector =
  "&:hover:not(:disabled):not([data-disabled])::after";

const pressedSelector =
  "&[data-pressed]:not([data-disabled])::after, &:active:not(:disabled):not([data-disabled])::after";
```

```ts
overlay({ nativeHover: true }); // native hover fallback을 명시적으로 opt-in
```

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #457 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * 버튼 및 라디오 컴포넌트의 기본 스타일 생성 방식이 변경되어 포커스·호버·프레스 시 시각적 동작이 개선 및 일관화되었습니다.
  * 포커스 링과 오버레이 유틸이 변형(variants)을 지원하는 새로운 스타일 시스템으로 전환되어 다양한 상태·밀도·계층 조합을 더 유연하게 표현합니다.
* **Documentation**
  * 사용법 및 마이그레이션 안내 문서가 추가되어 새로운 호출 기반 패턴과 선택적 네이티브 호버 옵션을 설명합니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->