### PR TITLE
docs: Menu.Trigger에 asChild 추가하여 스토리북에서 메뉴 정상 동작하도록 수정

### DIFF
--- a/packages/jds/src/components/Menu/Menu/Menu.stories.tsx
+++ b/packages/jds/src/components/Menu/Menu/Menu.stories.tsx
@@ -34,7 +34,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: args => (
     <Menu.Root {...args}>
-      <Menu.Trigger>
+      <Menu.Trigger asChild>
         <IconButton icon='menu-line' />
       </Menu.Trigger>
       <Menu.Content side='right' align='start' sideOffset={10}>
@@ -66,7 +66,7 @@ export const MenuStyles: Story = {
     <FlexRow>
       <span className={getLabelClassName()}>solid style</span>
       <Menu.Root menuStyle='solid'>
-        <Menu.Trigger>
+        <Menu.Trigger asChild>
           <IconButton icon='menu-line' />
         </Menu.Trigger>
         <Menu.Content align='end'>
@@ -83,7 +83,7 @@ export const MenuStyles: Story = {
       </Menu.Root>
       <span className={getLabelClassName()}>empty style</span>
       <Menu.Root menuStyle='empty'>
-        <Menu.Trigger>
+        <Menu.Trigger asChild>
           <IconButton icon='menu-line' />
         </Menu.Trigger>
         <Menu.Content align='start' sideOffset={10}>


### PR DESCRIPTION
## 💡 작업 내용

- [x] `Menu.stories.tsx`의 `Menu.Trigger`에 `asChild` prop 추가 (3곳)

## 💡 자세한 설명

Storybook에서 `Menu.Trigger` 클릭 시 메뉴가 열리지 않는 문제가 있었습니다.

`Menu.Trigger` 내부에 `IconButton`이 들어가면서 `button`이 중첩되어 Radix Trigger가 정상적으로 동작하지 않은 것이 원인입니다. Radix Trigger 사용 방식에 맞게 `asChild`를 명시하여, Trigger가 별도 `button`을 렌더링하지 않고 자식 요소(`IconButton`)에 동작을 위임하도록 수정했습니다.

```tsx
<Menu.Trigger asChild>
  <IconButton icon="menu-line" />
</Menu.Trigger>
```

<img width="800" height="377" alt="CleanShot 2026-06-14 at 14 55 01" src="https://github.com/user-attachments/assets/da8a4af9-4ea8-4a0b-8270-857817f6b26d" />


## 📗 참고 자료 (선택)

- 리뷰 코멘트: https://github.com/JECT-Study/JECT-Official-WebSite-Client/pull/460#discussion_r3408109517

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요? (base: `refactor/455-jds-menu-migration`)
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
