### PR TITLE
fix: Menu.Trigger에 asChild 추가하여 스토리북에서 메뉴 정상 동작하도록 수정

### DIFF
--- a/packages/jds/src/components/Menu/Menu/Menu.stories.tsx
+++ b/packages/jds/src/components/Menu/Menu/Menu.stories.tsx
@@ -34,7 +34,7 @@ type Story = StoryObj<typeof meta>;
 export const Default: Story = {
   render: args => (
     <Menu.Root {...args}>
-      <Menu.Trigger>
+      <Menu.Trigger asChild>
         <IconButton icon='menu-line' />
       </Menu.Trigger>
       <Menu.Content side='right' align='start' sideOffset={10}>
@@ -66,7 +66,7 @@ export const MenuStyles: Story = {
     <FlexRow>
       <span className={getLabelClassName()}>solid style</span>
       <Menu.Root menuStyle='solid'>
-        <Menu.Trigger>
+        <Menu.Trigger asChild>
           <IconButton icon='menu-line' />
         </Menu.Trigger>
         <Menu.Content align='end'>
@@ -83,7 +83,7 @@ export const MenuStyles: Story = {
       </Menu.Root>
       <span className={getLabelClassName()}>empty style</span>
       <Menu.Root menuStyle='empty'>
-        <Menu.Trigger>
+        <Menu.Trigger asChild>
           <IconButton icon='menu-line' />
         </Menu.Trigger>
         <Menu.Content align='start' sideOffset={10}>


### PR DESCRIPTION
## 개요
`#461`의 커밋 `6412197`을 `dev` 기준으로 다시 분기하여 체리픽한 PR입니다.
기존 PR은 `refactor/455-jds-menu-migration` 브랜치에서 분기되어 있어, 병합 시점이 불확실한 마이그레이션 브랜치 의존성을 제거하기 위해 `dev` 기반으로 재생성했습니다.

## 변경 사항
Menu.Trigger 내부에 IconButton이 들어가 button이 중첩되면서 Radix Trigger가 정상 동작하지 않아 스토리북에서 메뉴가 열리지 않던 문제를 수정합니다. Radix Trigger 사용 방식에 맞게 `asChild`를 명시했습니다.

- `packages/jds/src/components/Menu/Menu/Menu.stories.tsx`의 `Menu.Trigger`에 `asChild` 추가 (3곳)

## 참고
- 원본 PR: #461 (cherry-pick from `6412197`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **문서화**
  * Menu 컴포넌트의 Storybook 예제가 업데이트되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->