### PR TITLE
fix: Checkbox.Item 클릭 영역 불일치 및 구조 수정

### DIFF
--- a/packages/jds/src/components/Checkbox/migration/Checkbox.stories.tsx
+++ b/packages/jds/src/components/Checkbox/migration/Checkbox.stories.tsx
@@ -181,7 +181,11 @@ export const CheckboxGroupSelectAll: Story = {
 
       const isAllChecked = selected.length === ALL.length;
       const isSomeChecked = selected.length > 0 && !isAllChecked;
-      const parentState: CheckedState = isAllChecked ? true : isSomeChecked ? "indeterminate" : false;
+      const parentState: CheckedState = isAllChecked
+        ? true
+        : isSomeChecked
+          ? "indeterminate"
+          : false;
 
       return (
         <FlexColumn>

--- a/packages/jds/src/components/Checkbox/migration/Checkbox.tsx
+++ b/packages/jds/src/components/Checkbox/migration/Checkbox.tsx
@@ -2,7 +2,7 @@ import { useCheckbox, useCheckboxGroup, useCheckboxGroupItem } from "@react-aria
 import { mergeProps, useObjectRef } from "@react-aria/utils";
 import { clsx } from "clsx";
 import { Icon } from "components";
-import type { ForwardedRef, InputHTMLAttributes } from "react";
+import type { ForwardedRef, InputHTMLAttributes, ReactNode, Ref } from "react";
 import { forwardRef, useId, useLayoutEffect, useState } from "react";
 import { useCheckboxGroupState, useToggleState } from "react-stately";
 import type { CheckboxGroupState } from "react-stately";
@@ -66,14 +66,13 @@ const CheckboxRoot = ({
 
 CheckboxRoot.displayName = "Checkbox.Root";
 
-const CheckboxItem = forwardRef<HTMLDivElement, CheckboxItemProps>(
+const CheckboxItem = forwardRef<HTMLLabelElement, CheckboxItemProps>(
   (
     {
       size: sizeProp,
       variant: variantProp,
       disabled = false,
       isInvalid: isInvalidProp,
-      controlId: controlIdProp,
       children,
       className,
       ...restProps
@@ -81,13 +80,12 @@ const CheckboxItem = forwardRef<HTMLDivElement, CheckboxItemProps>(
     ref,
   ) => {
     const parentContext = useCheckboxContext();
-    const checkboxId = useId();
+    const labelId = useId();
 
     const size = sizeProp ?? parentContext?.size ?? "md";
     const isDisabled = disabled || (parentContext?.disabled ?? false);
     const variant = variantProp ?? parentContext?.variant ?? "hollow";
     const isInvalid = isInvalidProp ?? parentContext?.isInvalid ?? false;
-    const controlId = controlIdProp ?? checkboxId;
 
     const [childChecked, setChildChecked] = useState<CheckedState>(false);
     const isEffectiveInvalid = isInvalid && childChecked === false;
@@ -102,12 +100,12 @@ const CheckboxItem = forwardRef<HTMLDivElement, CheckboxItemProps>(
           variant,
           disabled: isDisabled,
           isInvalid,
-          controlId,
+          labelId,
           onChildCheckedChange: setChildChecked,
           withinItem: true,
         }}
       >
-        <div
+        <label
           ref={ref}
           {...mergeProps(containerPressableProps, restProps)}
           data-invalid={isEffectiveInvalid || undefined}
@@ -118,7 +116,7 @@ const CheckboxItem = forwardRef<HTMLDivElement, CheckboxItemProps>(
           )}
         >
           {children}
-        </div>
+        </label>
       </CheckboxProvider>
     );
   },
@@ -126,12 +124,61 @@ const CheckboxItem = forwardRef<HTMLDivElement, CheckboxItemProps>(
 
 CheckboxItem.displayName = "Checkbox.Item";
 
+interface CheckboxControlProps {
+  isWithinItem: boolean;
+  labelId?: string;
+  isEffectiveInvalid: boolean;
+  size: CheckboxSize;
+  interaction: "on" | "off";
+  inputRef: Ref<HTMLInputElement>;
+  inputProps: InputHTMLAttributes<HTMLInputElement>;
+  icon: ReactNode;
+}
+
+const CheckboxControl = ({
+  isWithinItem,
+  labelId,
+  isEffectiveInvalid,
+  size,
+  interaction,
+  inputRef,
+  inputProps,
+  icon,
+}: CheckboxControlProps) => {
+  const className = clsx(checkboxRootLabel, checkboxControlSlot);
+  const content = (
+    <>
+      <input
+        {...inputProps}
+        ref={inputRef}
+        aria-invalid={isEffectiveInvalid || undefined}
+        aria-labelledby={isWithinItem ? labelId : undefined}
+        className={checkboxInput}
+      />
+      <span className={checkboxVisual({ size, interaction })} aria-hidden='true'>
+        {icon}
+      </span>
+    </>
+  );
+
+  return isWithinItem ? (
+    <span className={className} data-invalid={isEffectiveInvalid || undefined}>
+      {content}
+    </span>
+  ) : (
+    <label className={className} data-invalid={isEffectiveInvalid || undefined}>
+      {content}
+    </label>
+  );
+};
+
 interface CheckboxBasicGroupedProps {
   size: CheckboxSize;
   value: string;
   isDisabled: boolean;
   isInvalid: boolean;
-  controlId: string;
+  isWithinItem: boolean;
+  labelId?: string;
   interaction: "on" | "off";
   state: CheckboxGroupState;
   onChildCheckedChange?: (checked: CheckedState) => void;
@@ -144,7 +191,8 @@ const CheckboxBasicGrouped = ({
   value,
   isDisabled,
   isInvalid,
-  controlId,
+  isWithinItem,
+  labelId,
   interaction,
   state,
   onChildCheckedChange,
@@ -164,22 +212,16 @@ const CheckboxBasicGrouped = ({
   const iconSize = checkboxSizeMap[size].icon;
 
   return (
-    <label
-      htmlFor={controlId}
-      className={clsx(checkboxRootLabel, checkboxControlSlot)}
-      data-invalid={isEffectiveInvalid || undefined}
-    >
-      <input
-        {...mergeProps(inputProps, restProps)}
-        ref={ref}
-        id={controlId}
-        aria-invalid={isEffectiveInvalid || undefined}
-        className={checkboxInput}
-      />
-      <span className={checkboxVisual({ size, interaction })} aria-hidden='true'>
-        <Icon name='check-line' size={iconSize} />
-      </span>
-    </label>
+    <CheckboxControl
+      isWithinItem={isWithinItem}
+      labelId={labelId}
+      isEffectiveInvalid={isEffectiveInvalid}
+      size={size}
+      interaction={interaction}
+      inputRef={ref}
+      inputProps={mergeProps(inputProps, restProps)}
+      icon={<Icon name='check-line' size={iconSize} />}
+    />
   );
 };
 
@@ -188,7 +230,8 @@ interface CheckboxBasicStandaloneProps {
   isDisabled: boolean;
   isInvalid: boolean;
   interaction: "on" | "off";
-  controlId: string;
+  isWithinItem: boolean;
+  labelId?: string;
   checked?: boolean | "indeterminate";
   defaultChecked?: boolean;
   onCheckedChange?: (checked: boolean | "indeterminate") => void;
@@ -202,7 +245,8 @@ const CheckboxBasicStandalone = ({
   isDisabled,
   isInvalid,
   interaction,
-  controlId,
+  isWithinItem,
+  labelId,
   checked,
   defaultChecked,
   onCheckedChange,
@@ -241,21 +285,16 @@ const CheckboxBasicStandalone = ({
   const iconSize = checkboxSizeMap[size].icon;
 
   return (
-    <label
-      htmlFor={controlId}
-      className={clsx(checkboxRootLabel, checkboxControlSlot)}
-      data-invalid={isEffectiveInvalid || undefined}
-    >
-      <input
-        {...mergeProps(inputProps, restProps)}
-        ref={ref}
-        id={controlId}
-        className={checkboxInput}
-      />
-      <span className={checkboxVisual({ size, interaction })} aria-hidden='true'>
-        <Icon name={isIndeterminate ? "subtract-line" : "check-line"} size={iconSize} />
-      </span>
-    </label>
+    <CheckboxControl
+      isWithinItem={isWithinItem}
+      labelId={labelId}
+      isEffectiveInvalid={isEffectiveInvalid}
+      size={size}
+      interaction={interaction}
+      inputRef={ref}
+      inputProps={mergeProps(inputProps, restProps)}
+      icon={<Icon name={isIndeterminate ? "subtract-line" : "check-line"} size={iconSize} />}
+    />
   );
 };
 
@@ -274,13 +313,13 @@ const CheckboxBasic = forwardRef<HTMLInputElement, CheckboxBasicProps>(
     forwardedRef,
   ) => {
     const context = useCheckboxContext();
-    const checkboxId = useId();
 
     const size = sizeProp ?? context?.size ?? "md";
     const isDisabled = (disabled ?? false) || (context?.disabled ?? false);
     const isInvalid = (isInvalidProp ?? false) || (context?.isInvalid ?? false);
-    const interaction = context?.withinItem ? "off" : "on";
-    const controlId = context?.controlId ?? checkboxId;
+    const isWithinItem = context?.withinItem ?? false;
+    const interaction = isWithinItem ? "off" : "on";
+    const labelId = context?.labelId;
 
     if (context?.state) {
       if (!value) {
@@ -298,7 +337,8 @@ const CheckboxBasic = forwardRef<HTMLInputElement, CheckboxBasicProps>(
           interaction={interaction}
           state={context.state}
           onChildCheckedChange={context?.onChildCheckedChange}
-          controlId={controlId}
+          isWithinItem={isWithinItem}
+          labelId={labelId}
           forwardedRef={forwardedRef}
           restProps={restProps}
         />
@@ -311,7 +351,8 @@ const CheckboxBasic = forwardRef<HTMLInputElement, CheckboxBasicProps>(
         isDisabled={isDisabled}
         isInvalid={isInvalid}
         interaction={interaction}
-        controlId={controlId}
+        isWithinItem={isWithinItem}
+        labelId={labelId}
         checked={checked}
         defaultChecked={defaultChecked}
         onCheckedChange={onCheckedChange}
@@ -325,13 +366,13 @@ const CheckboxBasic = forwardRef<HTMLInputElement, CheckboxBasicProps>(
 
 CheckboxBasic.displayName = "Checkbox.Basic";
 
-const CheckboxLabel = forwardRef<HTMLLabelElement, CheckboxLabelProps>(({ children }, ref) => {
+const CheckboxLabel = forwardRef<HTMLSpanElement, CheckboxLabelProps>(({ children }, ref) => {
   const context = useCheckboxContext();
   const size = context?.size ?? "md";
   return (
-    <label
+    <span
       ref={ref}
-      htmlFor={context?.controlId}
+      id={context?.labelId}
       className={clsx(
         getLabelClassName({ size: checkboxSizeMap[size].label }),
         checkboxTextLabel,
@@ -339,7 +380,7 @@ const CheckboxLabel = forwardRef<HTMLLabelElement, CheckboxLabelProps>(({ childr
       )}
     >
       {children}
-    </label>
+    </span>
   );
 });
 

--- a/packages/jds/src/components/Checkbox/migration/Checkbox.tsx
+++ b/packages/jds/src/components/Checkbox/migration/Checkbox.tsx
@@ -81,6 +81,7 @@ const CheckboxItem = forwardRef<HTMLLabelElement, CheckboxItemProps>(
   ) => {
     const parentContext = useCheckboxContext();
     const labelId = useId();
+    const helperId = useId();
 
     const size = sizeProp ?? parentContext?.size ?? "md";
     const isDisabled = disabled || (parentContext?.disabled ?? false);
@@ -88,6 +89,7 @@ const CheckboxItem = forwardRef<HTMLLabelElement, CheckboxItemProps>(
     const isInvalid = isInvalidProp ?? parentContext?.isInvalid ?? false;
 
     const [childChecked, setChildChecked] = useState<CheckedState>(false);
+    const [hasHelper, setHasHelper] = useState(false);
     const isEffectiveInvalid = isInvalid && childChecked === false;
 
     const { containerPressableProps } = useContainerPressable({ disabled: isDisabled });
@@ -101,6 +103,9 @@ const CheckboxItem = forwardRef<HTMLLabelElement, CheckboxItemProps>(
           disabled: isDisabled,
           isInvalid,
           labelId,
+          helperId,
+          hasHelper,
+          onHelperMountChange: setHasHelper,
           onChildCheckedChange: setChildChecked,
           withinItem: true,
         }}
@@ -127,6 +132,7 @@ CheckboxItem.displayName = "Checkbox.Item";
 interface CheckboxControlProps {
   isWithinItem: boolean;
   labelId?: string;
+  describedById?: string;
   isEffectiveInvalid: boolean;
   size: CheckboxSize;
   interaction: "on" | "off";
@@ -138,6 +144,7 @@ interface CheckboxControlProps {
 const CheckboxControl = ({
   isWithinItem,
   labelId,
+  describedById,
   isEffectiveInvalid,
   size,
   interaction,
@@ -153,6 +160,7 @@ const CheckboxControl = ({
         ref={inputRef}
         aria-invalid={isEffectiveInvalid || undefined}
         aria-labelledby={isWithinItem ? labelId : undefined}
+        aria-describedby={describedById}
         className={checkboxInput}
       />
       <span className={checkboxVisual({ size, interaction })} aria-hidden='true'>
@@ -179,6 +187,7 @@ interface CheckboxBasicGroupedProps {
   isInvalid: boolean;
   isWithinItem: boolean;
   labelId?: string;
+  describedById?: string;
   interaction: "on" | "off";
   state: CheckboxGroupState;
   onChildCheckedChange?: (checked: CheckedState) => void;
@@ -193,6 +202,7 @@ const CheckboxBasicGrouped = ({
   isInvalid,
   isWithinItem,
   labelId,
+  describedById,
   interaction,
   state,
   onChildCheckedChange,
@@ -215,6 +225,7 @@ const CheckboxBasicGrouped = ({
     <CheckboxControl
       isWithinItem={isWithinItem}
       labelId={labelId}
+      describedById={describedById}
       isEffectiveInvalid={isEffectiveInvalid}
       size={size}
       interaction={interaction}
@@ -232,6 +243,7 @@ interface CheckboxBasicStandaloneProps {
   interaction: "on" | "off";
   isWithinItem: boolean;
   labelId?: string;
+  describedById?: string;
   checked?: boolean | "indeterminate";
   defaultChecked?: boolean;
   onCheckedChange?: (checked: boolean | "indeterminate") => void;
@@ -247,6 +259,7 @@ const CheckboxBasicStandalone = ({
   interaction,
   isWithinItem,
   labelId,
+  describedById,
   checked,
   defaultChecked,
   onCheckedChange,
@@ -288,6 +301,7 @@ const CheckboxBasicStandalone = ({
     <CheckboxControl
       isWithinItem={isWithinItem}
       labelId={labelId}
+      describedById={describedById}
       isEffectiveInvalid={isEffectiveInvalid}
       size={size}
       interaction={interaction}
@@ -320,6 +334,7 @@ const CheckboxBasic = forwardRef<HTMLInputElement, CheckboxBasicProps>(
     const isWithinItem = context?.withinItem ?? false;
     const interaction = isWithinItem ? "off" : "on";
     const labelId = context?.labelId;
+    const describedById = isWithinItem && context?.hasHelper ? context?.helperId : undefined;
 
     if (context?.state) {
       if (!value) {
@@ -339,6 +354,7 @@ const CheckboxBasic = forwardRef<HTMLInputElement, CheckboxBasicProps>(
           onChildCheckedChange={context?.onChildCheckedChange}
           isWithinItem={isWithinItem}
           labelId={labelId}
+          describedById={describedById}
           forwardedRef={forwardedRef}
           restProps={restProps}
         />
@@ -353,6 +369,7 @@ const CheckboxBasic = forwardRef<HTMLInputElement, CheckboxBasicProps>(
         interaction={interaction}
         isWithinItem={isWithinItem}
         labelId={labelId}
+        describedById={describedById}
         checked={checked}
         defaultChecked={defaultChecked}
         onCheckedChange={onCheckedChange}
@@ -389,9 +406,17 @@ CheckboxLabel.displayName = "Checkbox.Label";
 const CheckboxHelper = forwardRef<HTMLDivElement, CheckboxHelperProps>(({ children }, ref) => {
   const context = useCheckboxContext();
   const size = context?.size ?? "md";
+  const onHelperMountChange = context?.onHelperMountChange;
+
+  useLayoutEffect(() => {
+    onHelperMountChange?.(true);
+    return () => onHelperMountChange?.(false);
+  }, [onHelperMountChange]);
+
   return (
     <div
       ref={ref}
+      id={context?.helperId}
       className={clsx(
         getLabelClassName({ size: checkboxSizeMap[size].helper, weight: "subtle" }),
         checkboxHelper,

--- a/packages/jds/src/components/Checkbox/migration/Checkbox.tsx
+++ b/packages/jds/src/components/Checkbox/migration/Checkbox.tsx
@@ -403,7 +403,7 @@ const CheckboxLabel = forwardRef<HTMLSpanElement, CheckboxLabelProps>(({ childre
 
 CheckboxLabel.displayName = "Checkbox.Label";
 
-const CheckboxHelper = forwardRef<HTMLDivElement, CheckboxHelperProps>(({ children }, ref) => {
+const CheckboxHelper = forwardRef<HTMLSpanElement, CheckboxHelperProps>(({ children }, ref) => {
   const context = useCheckboxContext();
   const size = context?.size ?? "md";
   const onHelperMountChange = context?.onHelperMountChange;
@@ -414,7 +414,7 @@ const CheckboxHelper = forwardRef<HTMLDivElement, CheckboxHelperProps>(({ childr
   }, [onHelperMountChange]);
 
   return (
-    <div
+    <span
       ref={ref}
       id={context?.helperId}
       className={clsx(
@@ -424,7 +424,7 @@ const CheckboxHelper = forwardRef<HTMLDivElement, CheckboxHelperProps>(({ childr
       )}
     >
       {children}
-    </div>
+    </span>
   );
 });
 

--- a/packages/jds/src/components/Checkbox/migration/CheckboxContext.tsx
+++ b/packages/jds/src/components/Checkbox/migration/CheckboxContext.tsx
@@ -9,6 +9,9 @@ export interface CheckboxContextValue {
   disabled: boolean;
   isInvalid: boolean;
   labelId?: string;
+  helperId?: string;
+  hasHelper?: boolean;
+  onHelperMountChange?: (mounted: boolean) => void;
   state?: CheckboxGroupState;
   onChildCheckedChange?: (checked: CheckedState) => void;
   withinItem?: boolean;

--- a/packages/jds/src/components/Checkbox/migration/CheckboxContext.tsx
+++ b/packages/jds/src/components/Checkbox/migration/CheckboxContext.tsx
@@ -8,7 +8,7 @@ export interface CheckboxContextValue {
   variant: CheckboxVariant;
   disabled: boolean;
   isInvalid: boolean;
-  controlId?: string;
+  labelId?: string;
   state?: CheckboxGroupState;
   onChildCheckedChange?: (checked: CheckedState) => void;
   withinItem?: boolean;

--- a/packages/jds/src/components/Checkbox/migration/checkbox.types.ts
+++ b/packages/jds/src/components/Checkbox/migration/checkbox.types.ts
@@ -35,7 +35,7 @@ export type CheckboxRootProps = CheckboxRootBaseProps &
 
 // Checkbox.Item
 
-export interface CheckboxItemProps extends ComponentPropsWithoutRef<"div"> {
+export interface CheckboxItemProps extends ComponentPropsWithoutRef<"label"> {
   size?: CheckboxSize;
   variant?: CheckboxVariant;
   disabled?: boolean;

--- a/packages/jds/src/components/Checkbox/migration/checkbox.types.ts
+++ b/packages/jds/src/components/Checkbox/migration/checkbox.types.ts
@@ -40,7 +40,6 @@ export interface CheckboxItemProps extends ComponentPropsWithoutRef<"div"> {
   variant?: CheckboxVariant;
   disabled?: boolean;
   isInvalid?: boolean;
-  controlId?: string;
   children: ReactNode;
 }
 


### PR DESCRIPTION
## 💡 자세한 설명

> 기존에는 visual 요소나 `Label`을 클릭하는 경우에만 토글되도록 되어 있었지만, `useContainerPressable`의 hover/press overlay는 `Item`에 적용되어 있어 패딩이나 헬퍼 영역을 눌렀을 때 시각적으로만 반응하고 실제 토글은 발생하지 않는 불일치가 있었습니다.

- `Checkbox.Item`을 단일 `<label>`로 수정하여 children 전체(컨트롤 / 레이블 / 헬퍼)를 포함하도록 변경했고, `input`이 `label` 내부에 위치하게 하여 클릭 시 토글이 동작하도록 정리했습니다.

- 내부 컨트롤 wrapper와 `Checkbox.Label`은 `<span>`으로 변경했으며, grouped / standalone 렌더링은 `CheckboxControl` 컴포넌트로 통합했습니다.

- `<label>`이 헬퍼까지 감싸면서 accessible name에 헬퍼가 포함되는 문제를 방지하기 위해 `aria-labelledby`를 통해 라벨 텍스트만 참조하도록 했고, 헬퍼는 `aria-describedby`로만 연결하여 스크린리더에서 보조 설명으로만 노출되도록 했습니다.

- 헬퍼는 실제로 존재하는 경우에만 `aria-describedby`를 연결하여 존재하지 않는 id 참조를 방지했습니다.

- 기존 `controlId / htmlFor` 연결은 제거하고, `labelId`와 `helperId`만 컨텍스트로 공유하여 접근성 연결을 유지했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [ ] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?
