### PR TITLE
refactor: JDS typography color를 변수 주입 방식으로 변경

### DIFF
--- a/packages/jds/src/components/Badge/contentBadge/contentBadge.css.ts
+++ b/packages/jds/src/components/Badge/contentBadge/contentBadge.css.ts
@@ -11,6 +11,8 @@ import {
   iconButtonAccentDisabledColor,
 } from "../../Button/IconButton/iconButton.css";
 
+import { labelColorVar } from "@/utils/typography.css";
+
 type BadgeSizeConfig = {
   minWidth: number;
   paddingTopBottom: string;
@@ -677,7 +679,9 @@ export const label = style({
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
-  color: badgeTextColor,
+  vars: {
+    [labelColorVar]: badgeTextColor,
+  },
 });
 
 export const icon = style({

--- a/packages/jds/src/components/Badge/numericBadge/numericBadge.css.ts
+++ b/packages/jds/src/components/Badge/numericBadge/numericBadge.css.ts
@@ -7,6 +7,8 @@ import { BADGE_SIZE_OPTIONS } from "../badge.types";
 import type { FeedbackVariant, BadgeSize, BasicHierarchy } from "../badge.types";
 import type { NumericBadgeStyle } from "./numericBadge.types";
 
+import { labelColorVar } from "@/utils/typography.css";
+
 type BadgeSizeConfig = {
   minWidth: number;
   paddingTopBottom: string;
@@ -271,5 +273,7 @@ export const label = style({
   display: "flex",
   justifyContent: "center",
   alignItems: "center",
-  color: badgeTextColor,
+  vars: {
+    [labelColorVar]: badgeTextColor,
+  },
 });

--- a/packages/jds/src/components/Steps/steps.css.ts
+++ b/packages/jds/src/components/Steps/steps.css.ts
@@ -4,6 +4,8 @@ import { pxToRem } from "utils";
 
 import { vars } from "../../tokens/vars.css";
 
+import { labelColorVar } from "@/utils/typography.css";
+
 export const stepsLabel = recipe({
   base: {
     display: "block",
@@ -15,8 +17,8 @@ export const stepsLabel = recipe({
   },
   variants: {
     activated: {
-      true: { color: vars.color.semantic.object.bold },
-      false: { color: vars.color.semantic.object.alternative },
+      true: { vars: { [labelColorVar]: vars.color.semantic.object.bold } },
+      false: { vars: { [labelColorVar]: vars.color.semantic.object.alternative } },
     },
   },
 });

--- a/packages/jds/src/components/Tooltip/tooltip.css.ts
+++ b/packages/jds/src/components/Tooltip/tooltip.css.ts
@@ -2,6 +2,8 @@ import { keyframes, style } from "@vanilla-extract/css";
 import { vars } from "tokens";
 import { pxToRem } from "utils";
 
+import { labelColorVar } from "@/utils/typography.css";
+
 const tooltipFadeIn = keyframes({
   from: { opacity: 0 },
   to: { opacity: 1 },
@@ -16,7 +18,6 @@ const tooltipTransition = `${vars.environment.semantic.duration["200"]} ${vars.e
 
 export const content = style({
   backgroundColor: vars.color.semantic.fill.boldest,
-  color: vars.color.semantic.object.inverse.boldest,
   padding: `${vars.scheme.semantic.spacing["6"]} ${vars.scheme.semantic.spacing["10"]}`,
   borderRadius: vars.scheme.semantic.radius["8"],
   maxWidth: pxToRem(280),
@@ -32,5 +33,9 @@ export const content = style({
     '&[data-state="closed"]': {
       animation: `${tooltipFadeOut} ${tooltipTransition}`,
     },
+  },
+
+  vars: {
+    [labelColorVar]: vars.color.semantic.object.inverse.boldest,
   },
 });

--- a/packages/jds/src/utils/typography.css.ts
+++ b/packages/jds/src/utils/typography.css.ts
@@ -1,4 +1,4 @@
-import { createVar, style } from "@vanilla-extract/css";
+import { createVar, fallbackVar, style } from "@vanilla-extract/css";
 import { recipe } from "@vanilla-extract/recipes";
 
 import type {
@@ -31,10 +31,7 @@ export const label = recipe({
   base: {
     display: "flex",
     alignItems: "center",
-    color: labelColorVar,
-    vars: {
-      [labelColorVar]: vars.color.semantic.object.bold,
-    },
+    color: fallbackVar(labelColorVar, vars.color.semantic.object.bold),
   },
   variants: {
     size: {
@@ -112,11 +109,13 @@ export const label = recipe({
   },
 });
 
+export const titleColorVar = createVar();
+
 export const title = recipe({
   base: {
     display: "flex",
     alignItems: "center",
-    color: vars.color.semantic.object.bolder,
+    color: fallbackVar(titleColorVar, vars.color.semantic.object.bolder),
     cursor: "default",
   },
   variants: {


### PR DESCRIPTION
## 개요

`getLabelClassName` / `getTitleClassName`이 적용된 엘리먼트에서 색을 변경할 때, 같은 엘리먼트에 `color:`를 직접 선언하던 부분을 **CSS 변수(`labelColorVar`) 주입 방식**으로 변경합니다.

## 배경

typography recipe(`label`/`title`)의 base는 `color: fallbackVar(labelColorVar, default)`(명시도 `(0,1,0)`)로 색을 정합니다. 소비자가 같은 엘리먼트에 `color:`를 또 선언하면 **`(0,1,0)` 동점**이 되어, 승자가 CSS extraction/import 순서에 종속되는 fragile한 상태가 됩니다. (VE가 media query를 파일 끝에 강제 배치하는 것과 같은 이유)

→ recipe는 타이포만 책임지고, 색은 소비자가 `labelColorVar`에 주입하도록 하여 동점 자체를 제거합니다.

## 변경 사항

JDS 컴포넌트를 전수 점검하여 `color:` 직접 지정으로 동점이 발생하던 vanilla-extract 소비자를 변수 주입으로 전환했습니다.

- `Tooltip` — `content`
- `Steps` — `stepsLabel` `activated` 변형
- `ContentBadge` — `label`
- `NumericBadge` — `label`

## 검증

<img width="1607" height="627" alt="CleanShot 2026-06-18 at 22 21 08" src="https://github.com/user-attachments/assets/5a9d68d8-2f08-4e94-89db-0d542f72024f" />

- `tsc -b --noEmit` ✅
- `eslint --max-warnings 0` ✅

## 참고

- [관련 논의 쓰레드](https://github.com/JECT-Study/JECT-Official-WebSite-Client/pull/462#discussion_r3411036646)

- 장기적으로 `getLabelClassName({ color })` 같은 공개 API화 / CSS `@layer` 도입도 검토 가능하나, VE layer 추적 이슈([#1112](https://github.com/vanilla-extract-css/vanilla-extract/issues/1112))가 미해결이라 본 PR은 `fallbackVar` 방식으로 처리합니다.

closes #476

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 색상 관리를 CSS 변수 기반으로 전환하여 컴포넌트 간 일관된 스타일 처리 구현
  * 여러 컴포넌트의 색상 적용 방식을 표준화하여 유지보수성 및 확장성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->