### PR TITLE
feat: JDS Link 컴포넌트 구현

### DIFF
--- a/.changeset/link-component.md
+++ b/.changeset/link-component.md
@@ -1,0 +1,27 @@
+---
+"@jects/jds": minor
+---
+
+**Link**
+
+앱 내의 다른 페이지나 외부 웹사이트로 이동시키는 `Link` 컴포넌트를 추가합니다. 자체 크기를 갖지 않고 부모 요소의 텍스트 스타일을 상속받습니다.
+
+- `external`: 외부 리소스로 이동함을 나타냅니다. 외부 링크 아이콘과 스크린리더 레이블이 표시됩니다.
+- `disabled`: 비활성 시 이동을 차단하고 흐리게 표시합니다. (`asChild`와 함께 사용할 수 없습니다)
+- `asChild`: `<a>` 대신 전달한 자식 요소에 스타일을 합성합니다. Next.js, React Router의 `Link` 등 라우팅 컴포넌트와 결합할 때 사용할 수 있습니다.
+
+```tsx
+<p className={getBodyClassName({ size: "md" })}>
+  자세한 내용은 <Link href="/docs">문서</Link>를 참고하세요.
+</p>
+
+// 외부 링크
+<Link href="https://example.com" target="_blank" rel="noopener noreferrer" external>
+  외부 문서
+</Link>
+
+// 라우팅 컴포넌트와 결합
+<Link asChild>
+  <NextLink href="/about">소개</NextLink>
+</Link>
+```

--- a/packages/jds/src/components/Link/Link.stories.tsx
+++ b/packages/jds/src/components/Link/Link.stories.tsx
@@ -1,0 +1,135 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { FlexColumn } from "@storybook-utils/layout";
+
+import { Link } from "./Link";
+
+import { getBodyClassName, getLabelClassName } from "@/utils/typography";
+
+const meta: Meta<typeof Link> = {
+  title: "Components/Link",
+  component: Link,
+  parameters: {
+    layout: "centered",
+    docs: {
+      description: {
+        component:
+          "앱 내의 다른 페이지나 외부 웹사이트로 이동시키는 인라인 텍스트 컴포넌트입니다. 자체 크기를 갖지 않고 부모 요소의 텍스트 스타일을 상속받습니다.",
+      },
+    },
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    children: {
+      control: "text",
+      description: "링크에 표시되는 텍스트입니다.",
+    },
+    href: {
+      control: "text",
+      description: "이동할 페이지의 주소입니다.",
+    },
+    external: {
+      control: "boolean",
+      description:
+        "외부 리소스로 이동함을 나타냅니다. 외부 링크 아이콘과 스크린리더 레이블이 표시됩니다.",
+      table: {
+        defaultValue: { summary: "false" },
+      },
+    },
+    disabled: {
+      control: "boolean",
+      description: "비활성화 여부입니다.",
+      table: {
+        defaultValue: { summary: "false" },
+      },
+    },
+    asChild: {
+      control: "boolean",
+      description: "true이면 <a> 대신 전달한 자식 요소에 스타일을 합성합니다.",
+      table: {
+        defaultValue: { summary: "false" },
+      },
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Link>;
+
+export const Default: Story = {
+  args: {
+    children: "링크",
+    href: "#",
+  },
+  decorators: [
+    Story => (
+      <span className={getBodyClassName({ size: "md" })}>
+        <Story />
+      </span>
+    ),
+  ],
+};
+
+export const InheritsSurroundingText: Story = {
+  render: () => (
+    <FlexColumn gap='16px'>
+      <span className={getBodyClassName({ size: "lg" })}>
+        body / lg 텍스트 안의 <Link href='#'>링크</Link>
+      </span>
+      <span className={getBodyClassName({ size: "md" })}>
+        body / md 텍스트 안의 <Link href='#'>링크</Link>
+      </span>
+      <span className={getBodyClassName({ size: "sm" })}>
+        body / sm 텍스트 안의 <Link href='#'>링크</Link>
+      </span>
+      <span className={getLabelClassName({ size: "lg" })}>
+        label / lg 텍스트 안의 <Link href='#'>링크</Link>
+      </span>
+      <span className={getLabelClassName({ size: "sm" })}>
+        label / sm 텍스트 안의 <Link href='#'>링크</Link>
+      </span>
+    </FlexColumn>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "자체 크기 없이 부모 요소의 텍스트 스타일을 상속받아 표시됩니다.",
+      },
+    },
+  },
+};
+
+export const External: Story = {
+  render: () => (
+    <span className={getBodyClassName({ size: "md" })}>
+      자세한 내용은{" "}
+      <Link href='https://example.com' target='_blank' rel='noopener noreferrer' external>
+        외부 문서
+      </Link>
+      에서 확인하세요.
+    </span>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "외부 링크 아이콘과 스크린리더 레이블을 표시합니다.",
+      },
+    },
+  },
+};
+
+export const Disabled: Story = {
+  render: () => (
+    <span className={getBodyClassName({ size: "md" })}>
+      <Link href='#' disabled>
+        링크
+      </Link>
+    </span>
+  ),
+  parameters: {
+    docs: {
+      description: {
+        story: "페이지 이동을 차단합니다. 포커스는 유지되며 aria-disabled로 비활성을 안내합니다.",
+      },
+    },
+  },
+};

--- a/packages/jds/src/components/Link/Link.stories.tsx
+++ b/packages/jds/src/components/Link/Link.stories.tsx
@@ -43,7 +43,7 @@ const meta: Meta<typeof Link> = {
       },
     },
     asChild: {
-      control: "boolean",
+      control: false,
       description: "true이면 <a> 대신 전달한 자식 요소에 스타일을 합성합니다.",
       table: {
         defaultValue: { summary: "false" },

--- a/packages/jds/src/components/Link/Link.stories.tsx
+++ b/packages/jds/src/components/Link/Link.stories.tsx
@@ -30,7 +30,7 @@ const meta: Meta<typeof Link> = {
     external: {
       control: "boolean",
       description:
-        "외부 리소스로 이동함을 나타냅니다. 외부 링크 아이콘과 스크린리더 레이블이 표시됩니다.",
+        "외부 리소스로 이동함을 나타냅니다. 아이콘, 스크린리더 레이블 표시 외 새 탭 열기가 필요한 경우 target, rel 속성을 직접 명시하세요.",
       table: {
         defaultValue: { summary: "false" },
       },

--- a/packages/jds/src/components/Link/Link.tsx
+++ b/packages/jds/src/components/Link/Link.tsx
@@ -10,10 +10,14 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
   ({ external = false, asChild, disabled = false, className, children, onClick, ...rest }, ref) => {
     const Component = asChild ? Slot.Root : "a";
 
+    const disabledNativeProps =
+      disabled && !asChild ? { href: undefined, role: "link" as const, tabIndex: 0 } : {};
+
     return (
       <Component
         ref={ref}
         {...rest}
+        {...disabledNativeProps}
         className={clsx(root, className)}
         data-disabled={disabled || undefined}
         aria-disabled={disabled || undefined}

--- a/packages/jds/src/components/Link/Link.tsx
+++ b/packages/jds/src/components/Link/Link.tsx
@@ -30,7 +30,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
         }}
       >
         <Slot.Slottable>{children}</Slot.Slottable>
-        {external && <Icon name='external-link-line' aria-hidden />}
+        {external && <Icon name='external-link-line' role='img' aria-label='외부 링크' />}
       </Component>
     );
   },

--- a/packages/jds/src/components/Link/Link.tsx
+++ b/packages/jds/src/components/Link/Link.tsx
@@ -1,0 +1,35 @@
+import { clsx } from "clsx";
+import { Icon } from "components";
+import { Slot } from "radix-ui";
+import { forwardRef } from "react";
+
+import { root } from "./link.css";
+import type { LinkProps } from "./link.types";
+
+export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
+  ({ external = false, asChild, disabled = false, className, children, onClick, ...rest }, ref) => {
+    const Component = asChild ? Slot.Root : "a";
+
+    return (
+      <Component
+        ref={ref}
+        {...rest}
+        className={clsx(root, className)}
+        data-disabled={disabled || undefined}
+        aria-disabled={disabled || undefined}
+        onClick={e => {
+          if (disabled) {
+            e.preventDefault();
+            return;
+          }
+          onClick?.(e);
+        }}
+      >
+        <Slot.Slottable>{children}</Slot.Slottable>
+        {external && <Icon name='external-link-line' aria-hidden />}
+      </Component>
+    );
+  },
+);
+
+Link.displayName = "Link";

--- a/packages/jds/src/components/Link/Link.tsx
+++ b/packages/jds/src/components/Link/Link.tsx
@@ -22,10 +22,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
         data-disabled={disabled || undefined}
         aria-disabled={disabled || undefined}
         onClick={e => {
-          if (disabled) {
-            e.preventDefault();
-            return;
-          }
+          if (disabled) return;
           onClick?.(e);
         }}
       >

--- a/packages/jds/src/components/Link/Link.tsx
+++ b/packages/jds/src/components/Link/Link.tsx
@@ -1,8 +1,8 @@
 import { clsx } from "clsx";
-import { Icon } from "components";
 import { Slot } from "radix-ui";
 import { forwardRef } from "react";
 
+import { Icon } from "../Icon";
 import { root } from "./link.css";
 import type { LinkProps } from "./link.types";
 

--- a/packages/jds/src/components/Link/index.ts
+++ b/packages/jds/src/components/Link/index.ts
@@ -1,0 +1,2 @@
+export * from "./Link";
+export * from "./link.types";

--- a/packages/jds/src/components/Link/link.css.ts
+++ b/packages/jds/src/components/Link/link.css.ts
@@ -19,6 +19,9 @@ const baseStyle = style({
       color: vars.color.semantic.object.subtle,
       cursor: "not-allowed",
     },
+    "[data-disabled] &": {
+      pointerEvents: "none",
+    },
     "&::before, &::after": { inset: 0, borderRadius: "inherit" },
   },
 });

--- a/packages/jds/src/components/Link/link.css.ts
+++ b/packages/jds/src/components/Link/link.css.ts
@@ -9,8 +9,12 @@ const baseStyle = style({
   color: vars.color.semantic.accent.normal,
   gap: vars.scheme.semantic.spacing["2"],
   cursor: "pointer",
-  textDecoration: "underline !important",
   selectors: {
+    // `a[class]` reset이 text-decoration을 덮어써서 `&&`로 specificity를 높임
+    // TODO: reset을 `:where`로 바꾸면 selector 없이 base 속성으로 둘 수 있다.
+    "&&": {
+      textDecoration: "underline",
+    },
     "&:disabled, &[data-disabled], [data-disabled] &": {
       color: vars.color.semantic.object.subtle,
       cursor: "not-allowed",

--- a/packages/jds/src/components/Link/link.css.ts
+++ b/packages/jds/src/components/Link/link.css.ts
@@ -1,0 +1,31 @@
+import { globalStyle, style } from "@vanilla-extract/css";
+import { vars } from "tokens";
+import { overlay, focusRing } from "utils";
+
+const baseStyle = style({
+  position: "relative",
+  display: "inline-flex",
+  fontSize: "inherit",
+  color: vars.color.semantic.accent.normal,
+  gap: vars.scheme.semantic.spacing["2"],
+  cursor: "pointer",
+  textDecoration: "underline !important",
+  selectors: {
+    "&:disabled, &[data-disabled], [data-disabled] &": {
+      color: vars.color.semantic.object.subtle,
+      cursor: "not-allowed",
+    },
+    "&::before, &::after": { inset: 0, borderRadius: "inherit" },
+  },
+});
+
+globalStyle(`${baseStyle} [data-part="icon"] svg`, {
+  width: "0.875em",
+  height: "0.875em",
+});
+
+export const root = style([
+  overlay({ density: "bold", hierarchy: "accent", nativeHover: true }),
+  focusRing(),
+  baseStyle,
+]);

--- a/packages/jds/src/components/Link/link.types.ts
+++ b/packages/jds/src/components/Link/link.types.ts
@@ -1,0 +1,7 @@
+import type { ComponentPropsWithoutRef } from "react";
+
+export type LinkProps = ComponentPropsWithoutRef<"a"> & {
+  external?: boolean;
+  asChild?: boolean;
+  disabled?: boolean;
+};

--- a/packages/jds/src/components/Link/link.types.ts
+++ b/packages/jds/src/components/Link/link.types.ts
@@ -1,7 +1,16 @@
 import type { ComponentPropsWithoutRef } from "react";
 
-export type LinkProps = ComponentPropsWithoutRef<"a"> & {
+type LinkBaseProps = ComponentPropsWithoutRef<"a"> & {
   external?: boolean;
-  asChild?: boolean;
-  disabled?: boolean;
 };
+
+/**
+ * `asChild`와 `disabled`는 동시에 사용할 수 없다.
+ *
+ * asChild로 라우팅 컴포넌트를 전달하면 href가 자식 요소에 있어 Link가 이동을
+ * 제어할 수 없으므로, 두 속성의 조합을 타입 수준에서 차단한다. 비활성 링크는 이동
+ * 대상이 아니므로, 비활성 상태는 asChild 없이 `<Link disabled>`로 표현한다.
+ */
+export type LinkProps =
+  | (LinkBaseProps & { asChild?: false; disabled?: boolean })
+  | (LinkBaseProps & { asChild: true; disabled?: never });

--- a/packages/jds/src/components/index.ts
+++ b/packages/jds/src/components/index.ts
@@ -19,6 +19,7 @@ export * from "./Image";
 export * from "./Thumbnail";
 export * from "./Input";
 export * from "./Kbd";
+export * from "./Link";
 export * from "./Logo";
 export * from "./Menu/MegaMenu";
 export * from "./Menu/MenuItem";


### PR DESCRIPTION
## 💡 작업 내용

- [x] `Link` 컴포넌트 추가
- [x] Storybook, Changeset 문서 작성

## 💡 자세한 설명

### 1. 개요

<img width="840" alt="image" src="https://github.com/user-attachments/assets/4d34b5b0-d312-4d50-8c81-8b9b0df70003" />

`Link`는 앱 내 다른 페이지나 외부 웹사이트로 이동시키는 인라인 텍스트 컴포넌트입니다.

자체적인 타이포그래피를 가지지 않고 부모 요소의 텍스트 스타일을 상속받습니다. `external`, `asChild`, `disabled`를 지원하며, Next.js나 React Router 등의 라우팅 컴포넌트와는 `asChild`를 통해 조합할 수 있도록 설계했습니다.

---

### 2. 타이포그래피 상속

<img width="804" alt="image" src="https://github.com/user-attachments/assets/eaba1984-48d6-4940-ad03-7dbb8a0d3ffa" />

[논의 사항 스레드 (Discord)](https://discord.com/channels/1440700292600561809/1518977496459116554)

링크는 본문이나 라벨 텍스트 안에 인라인으로 포함되는 경우가 대부분이므로, 주변 텍스트와 동일한 크기로 표시되어야 합니다. 시안에 `variant`(label/body/syntax)와 `size`가 존재하는 것도 이러한 사용 맥락을 고려한 것이며, 디자이너 분도 링크가 주변 텍스트 스타일을 따르도록 함을 의도하고 계셨습니다.

다만 시안처럼 `variant`, `size`를 일일이 지정하는 경우 `Checkbox.Label`처럼 텍스트 크기가 상위 컴포넌트 내부에서 결정되는 경우에는 사용자가 적절한 값을 알기 어렵습니다. 따라서 링크가 주변 스타일을 자동으로 따르는 방식이 더 자연스럽다고 생각했습니다.

이에 따라 `link.css`는 색상, 밑줄, 인터랙션 상태만 담당하고, 텍스트 관련 속성은 `font-size: inherit`를 통해 부모 요소를 그대로 상속받습니다.

---

### 3. `external`

`external`은 외부 웹사이트로 이동함을 나타내는 속성입니다. 외부 링크 아이콘에는 `role="img"`와 `aria-label="외부 링크"`를 부여해 스크린 리더 사용자도 외부 이동 여부를 인지할 수 있도록 했습니다.

아이콘 크기는 텍스트 크기에 비례하도록 `0.875em`로 설정했습니다. 다만 기존 `Icon` 컴포넌트가 px 단위 토큰만 지원하고 있어, SVG 크기만 `globalStyle`로 오버라이드 하도록 했습니다.

---

### 4. `disabled`

네이티브 `<a>` 요소는 `disabled` 속성을 지원하지 않아 `href`를 제거해 이동을 차단했습니다.

다만 `href`가 제거되면 포커스 가능 여부와 링크 시맨틱이 함께 사라지므로, `tabIndex={0}`과 `role="link"`를 추가했습니다. 포커스는 시안에 맞춰 유지하도록 했고, 소비자가 전달한 `onClick` 핸들러는 비활성 상태에서 실행되지 않도록 했습니다.

---

### 5. `asChild` + `disabled` 조합

`asChild`는 Radix UI의 `Slot` 기반으로 구현했습니다. `external`이 활성화된 경우 링크 본문과 외부 링크 아이콘을 함께 렌더링해야 하는데, `Slot`은 단일 자식만 허용하기 때문에 `children`을 `Slot.Slottable`로 감싸 슬롯 대상과 아이콘이 함께 렌더링될 수 있도록 했습니다.

한편 `asChild`를 사용하면 실제 페이지 이동은 자식 컴포넌트가 담당하게 됩니다. 이 경우 `href`가 자식에게 존재하므로 상위 `Link` 컴포넌트만으로는 이동을 차단할 수 없어 `asChild`와 `disabled`를 타입 레벨에서 금지했습니다.

```ts
type LinkProps =
  | (LinkBaseProps & { asChild?: false; disabled?: boolean })
  | (LinkBaseProps & { asChild: true; disabled?: never });
```

라우팅 링크와 비활성 링크를 동시에 지원하는 것은 책임이 모호해질 수 있으므로, 비활성 상태에서는 기본 `Link`를 사용하고 라우팅이 필요한 경우에만 `asChild`를 사용하는 것을 권장합니다.

```tsx
function AppLink({ href, disabled, children, ...rest }) {
  if (disabled) return <Link disabled {...rest}>{children}</Link>;
  return (
    <Link asChild {...rest}>
      <NextLink href={href}>{children}</NextLink>
    </Link>
  );
}
```

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #486 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 새 `Link` 컴포넌트가 추가되어 일반 링크, 외부 링크, 비활성 상태, 자식 요소 기반 사용을 지원합니다.
  * 부모 텍스트 스타일을 자연스럽게 상속해 주변 문맥에 맞게 표시됩니다.
  * 스토리북 예시가 추가되어 기본, 외부 링크, 비활성, 스타일 상속 사례를 확인할 수 있습니다.

* **Documentation**
  * 변경 사항 안내 문서가 추가되어 `Link` 사용 예시와 주요 옵션을 설명합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->