### PR TITLE
fix: usePressable/useContainerPressable 트리거 키보드(Enter/Space) 충돌 해결

### DIFF
--- a/packages/jds/src/hooks/useContainerPressable.ts
+++ b/packages/jds/src/hooks/useContainerPressable.ts
@@ -19,9 +19,18 @@ export function useContainerPressable({ disabled = false }: UseContainerPressabl
   const { pressProps, isPressed } = usePress({ isDisabled: disabled });
   const { focusProps, isFocusVisible } = useFocusRing({ within: true });
 
+  // `usePress`의 onKeyDown은 Enter/Space에서 `preventDefault()`를 호출한다. 이 컨테이너는
+  // 자식 native 폼 요소(input 등)의 keydown이 버블되어 들어오는데(`nodeContains` 통과),
+  // 여기서 preventDefault가 걸리면 (1) 자식 폼 요소의 네이티브 키보드 동작을 방해할 수 있고
+  // (2) 이 컨테이너를 Radix `Trigger asChild`로 쓸 때 합성된 트리거 onKeyDown이 스킵된다.
+  // (cf. `usePressable`의 동일 이슈) 컨테이너 자신은 포커스/키보드 활성화 대상이 아니라
+  // (실제 활성화는 자식 input이 담당) onKeyDown을 비워도 잃는 동작이 없다.
+  // NOTE: 키보드 누름 시 컨테이너 press 오버레이만 빠지며, CSS `:active` fallback이 커버한다.
+  const resolvedPressProps = { ...pressProps, onKeyDown: undefined };
+
   return {
     containerPressableProps: {
-      ...mergeProps(hoverProps, pressProps, focusProps),
+      ...mergeProps(hoverProps, resolvedPressProps, focusProps),
       "data-hovered": isHovered || undefined,
       "data-pressed": isPressed || undefined,
       "data-focus-visible": isFocusVisible || undefined,

--- a/packages/jds/src/hooks/usePressable.ts
+++ b/packages/jds/src/hooks/usePressable.ts
@@ -25,10 +25,22 @@ export function usePressable<T extends HTMLElement>(
   const { hoverProps, isHovered } = useHover({ isDisabled: disabled });
   const { focusProps, isFocusVisible } = useFocusRing();
 
+  // native `<button>`는 브라우저가 Enter/Space 활성화를 직접 처리한다.
+  // 반면 `useButton`(react-aria)의 onKeyDown은 Enter/Space에서 `preventDefault()`를 호출하는데,
+  // 이는 `event.defaultPrevented`를 true로 만들어 같은 엘리먼트에 합성된 다른 onKeyDown
+  // (예: Radix `Trigger`를 `asChild`로 감쌌을 때의 핸들러)을 건너뛰게 한다.
+  // (Radix `composeEventHandlers`가 `checkForDefaultPrevented`로 검사) → IconButton/LabelButton/
+  // BlockButton을 메뉴·팝오버 트리거로 쓰면 마우스/↓는 열리지만 Enter/Space로는 안 열리는 버그.
+  // 따라서 native button에서는 react-aria의 onKeyDown을 비우고 브라우저 기본 동작에 맡긴다.
+  // (button이 아닌 elementType은 키보드 활성화 합성이 필요하므로 react-aria 동작을 유지한다.)
+  // NOTE: native button 키보드 누름 시 press 오버레이는 CSS `:active` fallback이 커버한다.
+  const resolvedButtonProps =
+    elementType === "button" ? { ...buttonProps, onKeyDown: undefined } : buttonProps;
+
   return {
     ref,
     pressableProps: {
-      ...mergeProps(buttonProps, hoverProps, focusProps),
+      ...mergeProps(resolvedButtonProps, hoverProps, focusProps),
       "data-hovered": isHovered || undefined,
       "data-pressed": isPressed || undefined,
       "data-focus-visible": isFocusVisible || undefined,


### PR DESCRIPTION
## 문제

`usePressable`(react-aria `useButton`) 기반 버튼(IconButton/LabelButton/BlockButton)과
`useContainerPressable`(react-aria `usePress`) 컨테이너를 Radix `Trigger asChild`로 쓰면 **마우스/↓로는 열리지만 Enter/Space로는 안 열린다.**

## 원인

react-aria의 `usePress.onKeyDown`이 활성화 키(Enter/Space)에서 `e.preventDefault()`를 호출한다
(native click 중복 발화 방지 목적) → `event.defaultPrevented = true`.

Radix Trigger의 onKeyDown은 `composeEventHandlers(props.onKeyDown, ..., { checkForDefaultPrevented: true })`로
감싸져 있어, `defaultPrevented`면 내부 핸들러(`onOpenToggle`)를 **스킵**한다.

Slot 합성 순서상 child(react-aria) 핸들러가 slot(Radix)보다 먼저 실행되는 것도 조건.

- **ArrowDown / pointerdown**: preventDefault 대상이 아니라 정상 동작 → 열림 ✅
- **Enter / Space**: preventDefault → Radix 토글 스킵 → 안 열림 ❌

## 해결

react-aria의 `onKeyDown`을 비워 충돌 제거.

- **`usePressable`**: native `<button>`은 브라우저가 Enter/Space 활성화를 직접 처리하므로
  `elementType === "button"`일 때 react-aria onKeyDown 제거. (button이 아닌 elementType은 유지)
- **`useContainerPressable`**: 컨테이너 자신은 포커스/활성화 대상이 아니고 실제 활성화는
  자식 input이 담당하므로 onKeyDown 제거. 오히려 자식 폼요소로 버블되던 preventDefault 방해도 제거됨.

> **트레이드오프**: 키보드 누름 시 react-aria `data-pressed` 오버레이는 빠지지만,
> press 오버레이 셀렉터에 native `:active` fallback이 함께 있어 체감 회귀는 거의 없음.

| as-is | to-be |
| - | - |
| <img height="334" alt="Image" src="https://github.com/user-attachments/assets/f17f045d-1c7d-445e-9fe0-181f68351ba4" /> | <img  height="334" alt="CleanShot 2026-06-26 at 20 36 46" src="https://github.com/user-attachments/assets/b887c4b7-fc78-45a2-bec5-2d987da9f702" /> |

## 영향 범위

usePressable/useContainerPressable을 쓰는 모든 버튼·컨테이너 + 이를 트리거로 쓰는 모든 오버레이/메뉴/팝오버.

## 검증

- [x] `tsc -b --noEmit` 통과
- [x] `eslint` 통과
- [x] Storybook에서 Menu 트리거(IconButton) Enter/Space 오픈 동작 확인 (수정 전엔 ↓만 동작)

Closes #491
