### PR TITLE
chore: (JDS) Chromatic 스토리북 빌드를 용도별로 분리

### DIFF
--- a/.github/workflows/storybook-alpha.yml
+++ b/.github/workflows/storybook-alpha.yml
@@ -20,6 +20,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/storybook-alpha.yml
+++ b/.github/workflows/storybook-alpha.yml
@@ -9,6 +9,10 @@ on:
 jobs:
   deploy-alpha:
     if: github.event.label.name == 'alpha-storybook'
+    # 같은 PR에서 레이블을 연달아 붙이면 이전 알파 빌드를 취소하여 중복 빌드 방지
+    concurrency:
+      group: storybook-alpha-${{ github.event.pull_request.number }}
+      cancel-in-progress: true
     runs-on: ubuntu-22.04
 
     permissions:

--- a/.github/workflows/storybook-alpha.yml
+++ b/.github/workflows/storybook-alpha.yml
@@ -117,3 +117,7 @@ jobs:
                 console.error(`❌ 레이블 삭제 오류: ${error.message}`);
               }
             }
+
+      - name: Fail if Chromatic failed
+        if: steps.chromatic.outcome == 'failure'
+        run: exit 1

--- a/.github/workflows/storybook-alpha.yml
+++ b/.github/workflows/storybook-alpha.yml
@@ -1,0 +1,117 @@
+name: Storybook Alpha Deployment
+
+on:
+  # 알파 버전: PR에 alpha-storybook 레이블을 붙일 때만 빌드 (원하는 시점에만 생성)
+  pull_request:
+    types:
+      - labeled
+
+jobs:
+  deploy-alpha:
+    if: github.event.label.name == 'alpha-storybook'
+    runs-on: ubuntu-22.04
+
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Publish to Chromatic (Alpha)
+        id: chromatic
+        uses: chromaui/action@latest
+        continue-on-error: true
+        with:
+          projectToken: ${{ secrets.CHROMATIC_ALPHA_PROJECT_TOKEN }}
+          workingDir: packages/jds
+          # 참고용 스냅샷이라 회귀 검토 불필요 → 미검토 빌드가 쌓이지 않게 자동 승인
+          autoAcceptChanges: true
+
+      - name: Comment deployment URL
+        uses: actions/github-script@v7
+        if: steps.chromatic.outcome == 'success'
+        with:
+          script: |
+            const storybookUrl = '${{ steps.chromatic.outputs.storybookUrl }}';
+            const buildUrl = '${{ steps.chromatic.outputs.buildUrl }}';
+            const prNumber = context.payload.pull_request.number;
+
+            const comment = `## 🎨 스토리북 알파 배포 완료
+
+            ### 📦 배포 주소
+            - **스토리북:** ${storybookUrl}
+            - **빌드 상세:** ${buildUrl}
+
+            ### ℹ️ 정보
+            - PR: #${prNumber}
+            - 워크플로: [실행 내역 보기](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})
+            `;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: comment
+            });
+            console.log(`PR #${prNumber}에 코멘트 추가 완료`);
+
+      - name: Comment deployment failure
+        uses: actions/github-script@v7
+        if: steps.chromatic.outcome == 'failure'
+        with:
+          script: |
+            const prNumber = context.payload.pull_request.number;
+
+            const comment = `## ❌ 스토리북 알파 배포 실패
+
+            ### ℹ️ 정보
+            - PR: #${prNumber}
+            - 워크플로: [실행 내역 보기](https://github.com/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId})
+
+            배포 중 오류가 발생했습니다. 워크플로 실행 내역을 확인해 주세요.
+            `;
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              body: comment
+            });
+            console.log(`PR #${prNumber}에 실패 코멘트 추가 완료`);
+
+      - name: Remove alpha-storybook label
+        uses: actions/github-script@v7
+        if: always()
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const prNumber = context.payload.pull_request.number;
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner,
+                repo,
+                issue_number: prNumber,
+                name: 'alpha-storybook'
+              });
+              console.log(`✅ PR #${prNumber}에서 'alpha-storybook' 레이블 삭제 완료`);
+            } catch (error) {
+              if (error.status === 404) {
+                console.log(`ℹ️ PR #${prNumber}에 'alpha-storybook' 레이블이 없습니다. 이미 삭제되었을 수 있습니다.`);
+              } else {
+                console.error(`❌ 레이블 삭제 오류: ${error.message}`);
+              }
+            }

--- a/.github/workflows/storybook-alpha.yml
+++ b/.github/workflows/storybook-alpha.yml
@@ -12,6 +12,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     permissions:
+      contents: read
       pull-requests: write
 
     steps:

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -1,36 +1,75 @@
 name: Storybook Deployment and Visual Testing
-run-name: ${{ github.actor }}의 스토리북 배포 및 테스트
 
 on:
+  # 안정 버전: dev 브랜치에 머지될 때만 빌드 → 항상 최신 안정 상태를 가리키는 고정 링크
+  push:
+    branches:
+      - dev
+    paths:
+      - "packages/jds/**"
+      - ".github/workflows/storybook.yml"
+  # PR 시각 회귀 테스트: dev로 향하는 PR이 jds를 건드릴 때만 실행
   pull_request:
     branches:
       - dev
-jobs:
-  storybook:
-    runs-on: ubuntu-22.04
-    defaults:
-      run:
-        working-directory: packages/jds
+    paths:
+      - "packages/jds/**"
 
+# 같은 ref의 이전 실행은 취소하여 Chromatic 스냅샷 낭비 방지
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  # PR 시각 회귀 (리뷰 보조): 변경점이 있으면 Chromatic에서 리뷰 대기
+  pr-regression:
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-22.04
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Cache node_modules
-        id: cache
-        uses: actions/cache@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
         with:
-          path: '**/node_modules'
-          key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}-storybook
+          node-version: 22
+          cache: "npm"
 
       - name: Install dependencies
-        if: steps.cache.outputs.cache-hit != 'true'
+        run: npm ci
+
+      - name: Publish to Chromatic (PR 회귀)
+        uses: chromaui/action@latest
+        with:
+          projectToken: ${{ secrets.CHROMATIC_TOKEN }}
+          workingDir: packages/jds
+          autoAcceptChanges: false
+
+  # 안정 버전: dev 머지 시 자동 승인하여 dev permalink를 항상 최신 안정 상태로 유지
+  deploy-stable:
+    if: github.event_name == 'push'
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "npm"
+
+      - name: Install dependencies
         run: npm ci
 
       - name: Publish to Chromatic
         uses: chromaui/action@latest
         with:
+          # dev permalink가 고정 안정 링크이고, PR 빌드는 이 링크를 바꾸지 않는다.
           projectToken: ${{ secrets.CHROMATIC_TOKEN }}
           workingDir: packages/jds
+          autoAcceptChanges: true

--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -30,6 +30,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -56,6 +57,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v4


### PR DESCRIPTION
## 💡 작업 내용

- [x] `storybook.yml`을 PR 검사용과 안정(dev) 빌드용으로 분리
- [x] 알파 빌드 워크플로(`storybook-alpha.yml`) 추가
- [x] `packages/jds/**` 경로 필터 추가로 불필요한 트리거 제거

## 💡 자세한 설명

### 1. 배경

기존에는 PR 생성 및 커밋이 푸시될 때마다 스토리북이 새로 빌드되면서 다음과 같은 문제가 있었습니다.

- 항상 최신 상태를 가리키는 고정된 스토리북 링크가 없음 (빌드마다 URL 변경)
- 온보딩 문서에 연결된 링크가 오래되어 항상 최신을 가리키는 안정 참조 링크 필요
- `apps/web`(공식 홈페이지) 변경만 있어도 JDS 스토리북 워크플로가 실행

이에 따라 Chromatic 빌드를 용도별로 분리하여 PR 빌드는 시각 회귀 검증에 집중하고, 안정/알파 빌드는 참조용 고정 링크를 제공하도록 역할을 분리합니다.

---

### 2. 빌드 용도 분리

| 역할 | 트리거 | 토큰 | autoAccept |
| --------- | ------------------------------- | ------------------------------- | ---------- |
| PR 시각 회귀 | `pull_request` → dev (JDS 변경 시) | `CHROMATIC_TOKEN` | false |
| 안정(고정 링크) | `push` → dev (JDS 변경 시) | `CHROMATIC_TOKEN` | true |
| 알파 | `alpha-storybook` 레이블 | `CHROMATIC_ALPHA_PROJECT_TOKEN` | true |

- **안정 빌드**
  - dev 브랜치 머지 시 자동 실행되며 `autoAcceptChanges: true`로 설정
  - `https://dev--<appid>.chromatic.com` 형태의 고정 permalink를 항상 최신 상태로 유지
  - PR 빌드와 동일 프로젝트/토큰을 사용하여 dev 기준 회귀 비교가 가능

- **PR 시각 회귀**
  - 안정과 동일한 Chromatic 프로젝트(`CHROMATIC_TOKEN`)를 사용
  - PR 단위의 변경 사항을 dev 기준으로 비교하는 역할
  - 별도 프로젝트 분리 없이 동일 환경에서 회귀 검증 수행

- **알파 빌드**
  - 특정 시점에만 생성되는 on-demand 스냅샷
  - 별도 프로젝트(`CHROMATIC_ALPHA_PROJECT_TOKEN`)로 분리
  - 회귀 비교 목적이 아니므로 `autoAcceptChanges: true`로 설정

이에 따라 알파용 Chromatic 프로젝트를 신규로 생성했으며, 안정/PR은 기존 프로젝트를 사용합니다.

---

### 3. 경로 필터

PR 및 push 워크플로 모두 `paths: packages/jds/**`로 제한하여 `apps/web`만 변경된 경우에는 스토리북 워크플로가 실행되지 않도록 했습니다.

추가로 push 트리거에는 워크플로 파일 변경 경로도 포함하여 워크플로 수정이 dev에 반영될 때 최소 1회 검증을 수행합니다.

---

### 4. 동시 실행 제어

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: true
```

동일 PR에 커밋이 연속으로 푸시될 경우 이전 실행을 자동 취소하여 Chromatic 스냅샷을 불필요하게 소비하지 않도록 합니다. 서로 다른 PR에는 영향을 주지 않습니다.

---

### 5. 알파 빌드 동작

`alpha-storybook` 레이블이 추가되면 알파 빌드가 실행되며, 완료 후 스토리북 URL을 PR 코멘트로 남깁니다. 이후 레이블은 자동으로 제거됩니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #498 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR에 특정 라벨이 붙으면 알파 스토리북 배포가 자동으로 실행되며, 결과가 PR 코멘트로 안내됩니다.
  * PR용 미리보기와 dev 브랜치용 안정 배포가 분리되어, 변경 확인과 고정 링크 확인이 더 명확해졌습니다.
* **Bug Fixes**
  * 동일한 워크플로우가 중복 실행될 때 이전 작업이 자동으로 취소되도록 개선되었습니다.
  * 배포 라벨이 없거나 일부 단계가 실패해도 후속 정리 작업이 계속 진행되도록 안정성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->