### PR TITLE
refactor: JDS Checkbox, Radio 타입 안정성 개선

### DIFF
--- a/packages/jds/src/components/Checkbox/checkbox.css.ts
+++ b/packages/jds/src/components/Checkbox/checkbox.css.ts
@@ -229,6 +229,7 @@ export const checkboxItem = recipe({
 
 export const checkboxLabel = style({
   whiteSpace: "nowrap",
+  zIndex: 10,
   vars: { [labelColorVar]: vars.color.semantic.object.bolder },
   selectors: {
     "[data-disabled] &": { vars: { [labelColorVar]: vars.color.semantic.object.subtle } },

--- a/packages/jds/src/components/Checkbox/checkbox.types.ts
+++ b/packages/jds/src/components/Checkbox/checkbox.types.ts
@@ -7,8 +7,6 @@ export type CheckboxSize = (typeof CHECKBOX_SIZE_OPTIONS)[number];
 export type CheckboxVariant = (typeof CHECKBOX_VARIANT_OPTIONS)[number];
 export type CheckedState = boolean | "indeterminate";
 
-// Checkbox.Root
-
 type CheckboxRootControlledProps = {
   value: string[];
   defaultValue?: never;
@@ -33,18 +31,13 @@ type CheckboxRootBaseProps = {
 export type CheckboxRootProps = CheckboxRootBaseProps &
   (CheckboxRootControlledProps | CheckboxRootUncontrolledProps);
 
-// Checkbox.Item
-
-export interface CheckboxItemProps extends ComponentPropsWithoutRef<"label"> {
+export type CheckboxItemProps = ComponentPropsWithoutRef<"label"> & {
   size?: CheckboxSize;
   variant?: CheckboxVariant;
   disabled?: boolean;
   isInvalid?: boolean;
   children: ReactNode;
-}
-
-// Checkbox.Basic
-// Checkbox.Root 안에서 사용 시 value가 그룹 내 식별자가 되며 checked 상태는 그룹이 관리한다.
+};
 
 type CheckboxBasicControlledProps = {
   checked: CheckedState;
@@ -71,14 +64,10 @@ type CheckboxBasicBaseProps = Omit<
 export type CheckboxBasicProps = CheckboxBasicBaseProps &
   (CheckboxBasicControlledProps | CheckboxBasicUncontrolledProps);
 
-// Checkbox.Label
-
-export interface CheckboxLabelProps {
+export type CheckboxLabelProps = {
   children: ReactNode;
-}
+};
 
-// Checkbox.Helper
-
-export interface CheckboxHelperProps {
+export type CheckboxHelperProps = {
   children: ReactNode;
-}
+};

--- a/packages/jds/src/components/Checkbox/checkbox.types.ts
+++ b/packages/jds/src/components/Checkbox/checkbox.types.ts
@@ -60,7 +60,7 @@ type CheckboxBasicUncontrolledProps = {
 
 type CheckboxBasicBaseProps = Omit<
   ComponentPropsWithoutRef<"input">,
-  "size" | "checked" | "defaultChecked" | "onChange"
+  "size" | "checked" | "defaultChecked" | "onChange" | "type"
 > & {
   size?: CheckboxSize;
   value?: string;

--- a/packages/jds/src/components/Radio/radio.types.ts
+++ b/packages/jds/src/components/Radio/radio.types.ts
@@ -29,8 +29,10 @@ type RadioRootBaseProps = {
 export type RadioRootProps = RadioRootBaseProps &
   (RadioRootControlledProps | RadioRootUncontrolledProps);
 
-export interface RadioBasicProps
-  extends Omit<ComponentPropsWithoutRef<"input">, "value" | "size"> {
+export interface RadioBasicProps extends Omit<
+  ComponentPropsWithoutRef<"input">,
+  "value" | "size" | "type"
+> {
   size?: RadioSize;
   value: string;
 }

--- a/packages/jds/src/components/Radio/radio.types.ts
+++ b/packages/jds/src/components/Radio/radio.types.ts
@@ -29,25 +29,25 @@ type RadioRootBaseProps = {
 export type RadioRootProps = RadioRootBaseProps &
   (RadioRootControlledProps | RadioRootUncontrolledProps);
 
-export interface RadioBasicProps extends Omit<
+export type RadioBasicProps = Omit<
   ComponentPropsWithoutRef<"input">,
   "value" | "size" | "type"
-> {
+> & {
   size?: RadioSize;
   value: string;
-}
+};
 
-export interface RadioItemProps extends ComponentPropsWithoutRef<"label"> {
+export type RadioItemProps = ComponentPropsWithoutRef<"label"> & {
   size?: RadioSize;
   variant?: RadioVariant;
   disabled?: boolean;
   children: ReactNode;
-}
+};
 
-export interface RadioLabelProps {
+export type RadioLabelProps = {
   children: ReactNode;
-}
+};
 
-export interface RadioHelperProps {
+export type RadioHelperProps = {
   children: ReactNode;
-}
+};


### PR DESCRIPTION
## 💡 작업 내용

- [x] Checkbox/Radio의 input `type` prop 외부 오버라이드 차단
- [x] `*.types.ts` 내부 `interface`/`type` 혼용을 `type`으로 통일
- [x] Checkbox.Label z-index 추가

## 💡 자세한 설명

외부에서 `input`의 `type`을 전달하면 `type="checkbox"`/`type="radio"`가 덮어써져 해당 `type` 셀렉터에 의존하는 스타일까지 깨질 수 있어, `type`을 prop으로 받지 않도록 막았습니다. 아울러 두 컴포넌트의 타입 정의에서 `interface`와 `type`이 혼용되어 있던 부분도 `type`으로 통일했습니다.

작업 중 `Checkbox.Label`의 `z-index`가 누락된 부분을 발견해 함께 반영했습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #501 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 체크박스 라벨의 겹침 문제를 줄여, 일부 화면에서 선택 영역이 더 안정적으로 보이도록 개선했습니다.
* **Refactor**
  * 체크박스와 라디오 관련 입력 요소의 타입 정의를 정리해 유지보수성을 높였습니다.
  * 내부적으로 더 이상 노출되지 않아야 하는 속성 구성을 정돈했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->