### PR TITLE
refactor: (JDS) 오버레이 레이어 우선순위 토큰 정립 및 하드코딩 z-index 정리

### DIFF
--- a/.changeset/overlay-layer-zindex.md
+++ b/.changeset/overlay-layer-zindex.md
@@ -1,0 +1,12 @@
+---
+"@jects/jds": patch
+---
+
+**Toast, Snackbar, Tooltip**
+
+화면 위에 겹쳐 뜨는 컴포넌트의 `z-index`를 레이어 토큰으로 정리합니다. Dialog가 `zIndex.overlay`를 단독으로 쓰고, Toast, Snackbar, Tooltip은 `zIndex.floated`를 씁니다. 소비처에서 고칠 코드는 없습니다.
+
+**동작 변경 (코드 수정 불필요)**
+
+- Toast, Snackbar 스택 컨테이너의 `z-index`가 `zIndex.overlay`(400)에서 `zIndex.floated`(300)로 바뀝니다. Dialog가 열려 있는 동안 뜬 Toast, Snackbar는 이제 포털 생성 순서와 관계없이 Dialog 뒤에 놓입니다.
+- Tooltip 콘텐츠의 `z-index`가 `9999`에서 `zIndex.floated`(300)로 바뀝니다. Dialog 안에서 연 Tooltip은 Dialog 뒤에 가려집니다.

--- a/packages/jds/src/components/Snackbar/snackbar.css.ts
+++ b/packages/jds/src/components/Snackbar/snackbar.css.ts
@@ -23,7 +23,7 @@ export const stackContainer = style({
   position: "fixed",
   right: 0,
   bottom: 0,
-  zIndex: vars.environment.semantic.zIndex.overlay,
+  zIndex: vars.environment.semantic.zIndex.floated,
   display: "flex",
   flexDirection: "column-reverse",
   gap: vars.scheme.semantic.spacing["16"],

--- a/packages/jds/src/components/Toast/toast.css.ts
+++ b/packages/jds/src/components/Toast/toast.css.ts
@@ -23,7 +23,7 @@ export const stackContainer = style({
   position: "fixed",
   right: 0,
   bottom: 0,
-  zIndex: vars.environment.semantic.zIndex.overlay,
+  zIndex: vars.environment.semantic.zIndex.floated,
   display: "flex",
   flexDirection: "column-reverse",
   gap: vars.scheme.semantic.spacing["16"],

--- a/packages/jds/src/components/Tooltip/tooltip.css.ts
+++ b/packages/jds/src/components/Tooltip/tooltip.css.ts
@@ -23,7 +23,7 @@ export const content = style({
   maxWidth: pxToRem(280),
   overflowWrap: "break-word",
   textAlign: "center",
-  zIndex: 9999,
+  zIndex: vars.environment.semantic.zIndex.floated,
   boxShadow: vars.environment.semantic.shadow.overlay,
 
   selectors: {


### PR DESCRIPTION
## 💡 작업 내용

- [x] Toast, Snackbar의 z-index를 `zIndex.overlay` → `zIndex.floated`로 변경
- [x] Tooltip의 하드코딩된 `z-index: 9999`를 `zIndex.floated` 토큰으로 교체

## 💡 자세한 설명

화면 위에 겹쳐 표시되는 컴포넌트들이 모두 같은 `zIndex.overlay`(400)를 쓰고 있어서, 서로 다른 포털로 렌더링되는 Dialog, Toast, Snackbar 사이의 위계가 포털 생성 순서에 의존하고 있었습니다. 예를 들어, Dialog가 열린 상태에서 Toast가 뜨면 Toast가 위에 오지만, Toast가 떠 있는 동안 Dialog를 열면 Dialog가 Toast를 덮는 식의 구조였습니다.

논의된 정의에 따라 레이어를 아래와 같이 고정했습니다.

| 컴포넌트 | AS-IS | TO-BE |
| --- | --- | --- |
| `Dialog` (overlay, positioner) | `zIndex.overlay` | `zIndex.overlay` (변경 없음) |
| `Toast` (stackContainer) | `zIndex.overlay` | `zIndex.floated` |
| `Snackbar` (stackContainer) | `zIndex.overlay` | `zIndex.floated` |
| `Tooltip` (content) | `9999` | `zIndex.floated` |

`overlay`(400)는 Dialog 전용이 되고, 나머지 오버레이 계열은 `floated`(300)를 공유합니다. Dialog는 이미 `zIndex.overlay`를 쓰고 있어 수정하지 않았습니다.

### 정리 범위

**vanilla-extract로 마이그레이션된 파일만 대상으로 했습니다.** Emotion 쪽에 남아 있는 하드코딩은 Emotion 제거 시 같이 정리될 부분이라 이번 작업에서 제외했습니다.

Card, Chip, Tabs, Listbox, File, Thumbnail, TextField, focusRing에 있는 `zIndex: 1`은 컴포넌트 내부 stacking context 안에서 형제 요소끼리의 순서를 정하는 값이라 이번 레이어 정의와 층위가 달라 그대로 뒀습니다.

## 📗 참고 자료 (선택)

https://github.com/JECT-Study/JECT-Official-WebSite-Client/pull/547#discussion_r3637937580

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [ ] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #577 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * Toast와 Snackbar가 Dialog 위에 안정적으로 표시되도록 레이어 순서를 조정했습니다.
  * Tooltip이 일관된 디자인 토큰을 사용해 다른 부동 UI와 자연스럽게 표시됩니다.
  * Dialog가 열려 있을 때 관련 컴포넌트가 Dialog 뒤에 배치되도록 동작을 정리했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->