### PR TITLE
refactor: (JDS) Listbox 표현 및 선택 책임 분리

### DIFF
--- a/packages/jds/src/components/Listbox/Listbox.tsx
+++ b/packages/jds/src/components/Listbox/Listbox.tsx
@@ -1,5 +1,5 @@
 import { clsx } from "clsx";
-import { type CSSProperties, forwardRef } from "react";
+import { type CSSProperties, forwardRef, useMemo } from "react";
 
 import { ListboxOption } from "./compound/Option";
 import * as styles from "./listbox.css";
@@ -14,6 +14,8 @@ const InternalListbox = forwardRef<HTMLDivElement, ListboxProps>(
   (
     {
       context,
+      selectionMode,
+      variant,
       children,
       listboxRef,
       listboxProps,
@@ -30,6 +32,11 @@ const InternalListbox = forwardRef<HTMLDivElement, ListboxProps>(
   ) => {
     const { className: listboxClassName, ...restListboxProps } = listboxProps;
 
+    const contextValue = useMemo(
+      () => ({ ...context, selectionMode, variant }),
+      [context, selectionMode, variant],
+    );
+
     const labelId = `${context.listboxId}-label`;
 
     const containerStyle: CSSProperties = { ...style };
@@ -41,7 +48,7 @@ const InternalListbox = forwardRef<HTMLDivElement, ListboxProps>(
     }
 
     return (
-      <ListboxProvider value={context}>
+      <ListboxProvider value={contextValue}>
         <div
           ref={ref}
           className={clsx(styles.selectContainer, className)}
@@ -61,6 +68,7 @@ const InternalListbox = forwardRef<HTMLDivElement, ListboxProps>(
             className={clsx(styles.listbox, listboxClassName)}
             aria-label={label != null ? undefined : ariaLabel}
             aria-labelledby={label != null ? labelId : ariaLabelledby}
+            aria-multiselectable={selectionMode === "multiple" || undefined}
             {...restListboxProps}
           >
             {children}

--- a/packages/jds/src/components/Listbox/Listbox.tsx
+++ b/packages/jds/src/components/Listbox/Listbox.tsx
@@ -1,20 +1,20 @@
 import { clsx } from "clsx";
 import { type CSSProperties, forwardRef } from "react";
 
+import { ListboxOption } from "./compound/Option";
 import * as styles from "./listbox.css";
 import type { ListboxProps, SelectDimension } from "./listbox.types";
 import { ListboxProvider } from "./ListboxContext";
-import { Option } from "./Option";
 
 import { getLabelClassName } from "@/utils/typography";
 
 const resolveDimension = (value: SelectDimension) => (value === "full" ? "100%" : value);
 
-export const Listbox = forwardRef<HTMLDivElement, ListboxProps>(
+const InternalListbox = forwardRef<HTMLDivElement, ListboxProps>(
   (
     {
       context,
-      options,
+      children,
       listboxRef,
       listboxProps,
       label,
@@ -63,17 +63,7 @@ export const Listbox = forwardRef<HTMLDivElement, ListboxProps>(
             aria-labelledby={label != null ? labelId : ariaLabelledby}
             {...restListboxProps}
           >
-            {options.map(({ value, label: optionLabel, caption, suffix, disabled }) => (
-              <Option
-                key={value}
-                value={value}
-                caption={caption}
-                suffix={suffix}
-                disabled={disabled}
-              >
-                {optionLabel}
-              </Option>
-            ))}
+            {children}
           </div>
         </div>
       </ListboxProvider>
@@ -81,4 +71,8 @@ export const Listbox = forwardRef<HTMLDivElement, ListboxProps>(
   },
 );
 
-Listbox.displayName = "Listbox";
+InternalListbox.displayName = "InternalListbox";
+
+export const Listbox = Object.assign(InternalListbox, {
+  Option: ListboxOption,
+});

--- a/packages/jds/src/components/Listbox/ListboxContext.tsx
+++ b/packages/jds/src/components/Listbox/ListboxContext.tsx
@@ -2,15 +2,18 @@ import { createContext, useContext } from "react";
 
 import type { OptionVariant, SelectionMode } from "./listbox.types";
 
-export interface ListboxContextValue {
+export interface ListboxBehaviorContextValue {
   listboxId: string;
   disabled: boolean;
-  variant: OptionVariant;
-  mode: SelectionMode;
   isSelected: (value: string) => boolean;
   activeValue: string | null;
   select: (value: string) => void;
   setActive: (value: string | null) => void;
+}
+
+export interface ListboxContextValue extends ListboxBehaviorContextValue {
+  variant: OptionVariant;
+  selectionMode: SelectionMode;
 }
 
 const ListboxContext = createContext<ListboxContextValue | null>(null);

--- a/packages/jds/src/components/Listbox/compound/Option.tsx
+++ b/packages/jds/src/components/Listbox/compound/Option.tsx
@@ -1,17 +1,23 @@
 import { clsx } from "clsx";
 
-import { CheckboxPrimitive } from "../Checkbox/CheckboxPrimitive";
-import { Icon } from "../Icon";
-import * as styles from "./listbox.css";
-import type { OptionProps } from "./listbox.types";
-import { getOptionId } from "./listbox.utils";
-import { useListboxContext } from "./ListboxContext";
-import { RadioPrimitive } from "../Radio/RadioPrimitive";
+import { CheckboxPrimitive } from "../../Checkbox/CheckboxPrimitive";
+import { Icon } from "../../Icon";
+import { RadioPrimitive } from "../../Radio/RadioPrimitive";
+import * as styles from "../listbox.css";
+import type { ListboxOptionProps } from "../listbox.types";
+import { getOptionId } from "../listbox.utils";
+import { useListboxContext } from "../ListboxContext";
 
 import { getActiveDescendantItemProps } from "@/hooks/useActiveDescendant";
 import { getLabelClassName } from "@/utils/typography";
 
-export const Option = ({ value, disabled = false, caption, suffix, children }: OptionProps) => {
+export const ListboxOption = ({
+  value,
+  disabled = false,
+  caption,
+  suffix,
+  children,
+}: ListboxOptionProps) => {
   const {
     listboxId,
     mode,
@@ -81,4 +87,4 @@ export const Option = ({ value, disabled = false, caption, suffix, children }: O
   );
 };
 
-Option.displayName = "Option";
+ListboxOption.displayName = "Listbox.Option";

--- a/packages/jds/src/components/Listbox/compound/Option.tsx
+++ b/packages/jds/src/components/Listbox/compound/Option.tsx
@@ -20,7 +20,7 @@ export const ListboxOption = ({
 }: ListboxOptionProps) => {
   const {
     listboxId,
-    mode,
+    selectionMode,
     variant,
     disabled: isGroupDisabled,
     isSelected,
@@ -55,7 +55,7 @@ export const ListboxOption = ({
     >
       {variant === "control" && (
         <span className={styles.optionControlSlot}>
-          {mode === "multiple" ? (
+          {selectionMode === "multiple" ? (
             <CheckboxPrimitive.Indicator size='md' state={isItemSelected} disabled={isDisabled} />
           ) : (
             <RadioPrimitive.Indicator size='md' checked={isItemSelected} disabled={isDisabled} />

--- a/packages/jds/src/components/Listbox/index.ts
+++ b/packages/jds/src/components/Listbox/index.ts
@@ -3,6 +3,7 @@ export { useListbox } from "./useListbox";
 
 export type {
   ListboxProps,
+  ListboxOptionProps,
   SelectBaseProps,
   SelectOption,
   SelectionMode,

--- a/packages/jds/src/components/Listbox/index.ts
+++ b/packages/jds/src/components/Listbox/index.ts
@@ -3,7 +3,6 @@ export { useListbox } from "./useListbox";
 
 export type {
   ListboxProps,
-  ListboxOptionProps,
   SelectBaseProps,
   SelectOption,
   SelectionMode,

--- a/packages/jds/src/components/Listbox/index.ts
+++ b/packages/jds/src/components/Listbox/index.ts
@@ -1,5 +1,7 @@
 export { Listbox } from "./Listbox";
 export { useListbox } from "./useListbox";
+export { useSingleSelectState } from "./useSingleSelectState";
+export { useMultiSelectState } from "./useMultiSelectState";
 
 export type {
   ListboxProps,

--- a/packages/jds/src/components/Listbox/listbox.types.ts
+++ b/packages/jds/src/components/Listbox/listbox.types.ts
@@ -24,7 +24,7 @@ export type SelectBaseProps = AriaLabelProps & {
   options: SelectOption[];
 };
 
-export type OptionProps = {
+export type ListboxOptionProps = {
   value: string;
   disabled?: boolean;
   caption?: string;
@@ -34,7 +34,6 @@ export type OptionProps = {
 
 export type ListboxProps = ComponentPropsWithoutRef<"div"> & {
   context: ListboxContextValue;
-  options: SelectOption[];
   listboxRef: Ref<HTMLDivElement>;
   listboxProps: ComponentPropsWithoutRef<"div">;
   label?: string;

--- a/packages/jds/src/components/Listbox/listbox.types.ts
+++ b/packages/jds/src/components/Listbox/listbox.types.ts
@@ -1,7 +1,7 @@
 import type { ComponentPropsWithoutRef, ReactNode, Ref } from "react";
 import type { AriaLabelProps } from "types";
 
-import type { ListboxContextValue } from "./ListboxContext";
+import type { ListboxBehaviorContextValue } from "./ListboxContext";
 
 export type SelectionMode = "single" | "multiple";
 export type OptionVariant = "control" | "label";
@@ -33,7 +33,9 @@ export type ListboxOptionProps = {
 };
 
 export type ListboxProps = ComponentPropsWithoutRef<"div"> & {
-  context: ListboxContextValue;
+  context: ListboxBehaviorContextValue;
+  selectionMode: SelectionMode;
+  variant: OptionVariant;
   listboxRef: Ref<HTMLDivElement>;
   listboxProps: ComponentPropsWithoutRef<"div">;
   label?: string;

--- a/packages/jds/src/components/Listbox/listbox.utils.ts
+++ b/packages/jds/src/components/Listbox/listbox.utils.ts
@@ -1,8 +1,13 @@
+const SELECTED_OPTION_SELECTOR = '[aria-selected="true"]';
+
 export const getOptionId = (listboxId: string, value: string) =>
   `${listboxId}-option-${encodeURIComponent(value)}`;
 
+export const hasSelectedOption = (listboxEl: HTMLElement) =>
+  listboxEl.querySelector(SELECTED_OPTION_SELECTOR) != null;
+
 export const scrollSelectedOptionIntoView = (listboxEl: HTMLElement) => {
-  const selected = listboxEl.querySelector<HTMLElement>('[aria-selected="true"]');
+  const selected = listboxEl.querySelector<HTMLElement>(SELECTED_OPTION_SELECTOR);
   if (selected == null) return;
 
   const listRect = listboxEl.getBoundingClientRect();

--- a/packages/jds/src/components/Listbox/useListbox.ts
+++ b/packages/jds/src/components/Listbox/useListbox.ts
@@ -1,7 +1,7 @@
 import { useCallback, useId, useLayoutEffect, useMemo, useRef, type KeyboardEvent } from "react";
 
 import { SELECTION_KEYS } from "./listbox.constants";
-import { getOptionId, scrollSelectedOptionIntoView } from "./listbox.utils";
+import { getOptionId, hasSelectedOption, scrollSelectedOptionIntoView } from "./listbox.utils";
 import type { ListboxBehaviorContextValue } from "./ListboxContext";
 
 import { useActiveDescendant } from "@/hooks/useActiveDescendant";
@@ -40,16 +40,18 @@ export const useListbox = ({
     scrollSelectedOptionIntoView(el);
   }, [listboxRef]);
 
+  // 선택 항목은 DOM 조회로 확인하므로 별도의 의존성으로 추적할 수 없다.
+  // 의존성 배열을 추가하면 항목이 늦게 렌더되는 시점과 동기화되지 않는다.
   useLayoutEffect(() => {
     if (!autoScrollToSelected || !shouldAutoScrollRef.current) return;
 
     const el = listboxRef.current;
-    if (el == null || el.childElementCount === 0) return;
+    if (el == null || !hasSelectedOption(el)) return;
 
     shouldAutoScrollRef.current = false;
 
     scrollToSelected();
-  }, [listboxRef, scrollToSelected, autoScrollToSelected]);
+  });
 
   const activeId = activeValue != null ? getOptionId(listboxId, activeValue) : undefined;
 

--- a/packages/jds/src/components/Listbox/useListbox.ts
+++ b/packages/jds/src/components/Listbox/useListbox.ts
@@ -132,7 +132,6 @@ export const useListbox = ({
     activateSelected,
     scrollToSelected,
     onKeyDown,
-    onActiveDescendantKeyDown,
     getListboxProps,
     getFocusableListboxProps,
   };

--- a/packages/jds/src/components/Listbox/useListbox.ts
+++ b/packages/jds/src/components/Listbox/useListbox.ts
@@ -1,64 +1,32 @@
-import { useControllableState } from "hooks";
 import { useCallback, useId, useLayoutEffect, useMemo, useRef, type KeyboardEvent } from "react";
 
 import { SELECTION_KEYS } from "./listbox.constants";
-import type { OptionVariant, SelectionMode, SelectOption } from "./listbox.types";
+import type { SelectOption } from "./listbox.types";
 import { getOptionId, scrollSelectedOptionIntoView } from "./listbox.utils";
-import type { ListboxContextValue } from "./ListboxContext";
+import type { ListboxBehaviorContextValue } from "./ListboxContext";
 
 import { useActiveDescendant } from "@/hooks/useActiveDescendant";
 
 interface UseListboxParams {
-  mode: SelectionMode;
-  variant: OptionVariant;
   options: SelectOption[];
-  value?: string | string[] | null;
-  defaultValue?: string | string[];
-  onChange?: (value: string | string[]) => void;
+  selectedValues: string[];
   disabled: boolean;
+  onSelect: (value: string) => void;
   autoScrollToSelected?: boolean;
 }
 
 export const useListbox = ({
-  mode,
-  variant,
   options,
-  value,
-  defaultValue,
-  onChange,
+  selectedValues,
   disabled,
+  onSelect,
   autoScrollToSelected = true,
 }: UseListboxParams) => {
   const shouldAutoScrollRef = useRef(true);
 
   const listboxId = useId();
 
-  const [selection, setSelection] = useControllableState<string | string[] | null | undefined>(
-    value,
-    defaultValue ?? (mode === "multiple" ? [] : undefined),
-    onChange as ((value: string | string[] | null | undefined) => void) | undefined,
-  );
-
-  const selectedValues = useMemo<string[]>(() => {
-    if (selection == null) return [];
-    return Array.isArray(selection) ? selection : [selection];
-  }, [selection]);
-
   const isSelected = useCallback((v: string) => selectedValues.includes(v), [selectedValues]);
-
-  const select = useCallback(
-    (v: string) => {
-      if (mode === "multiple") {
-        setSelection(prev => {
-          const arr = Array.isArray(prev) ? prev : [];
-          return arr.includes(v) ? arr.filter(x => x !== v) : [...arr, v];
-        });
-      } else {
-        setSelection(v);
-      }
-    },
-    [mode, setSelection],
-  );
 
   const {
     containerRef: listboxRef,
@@ -112,9 +80,9 @@ export const useListbox = ({
 
       e.preventDefault();
 
-      if (activeValue != null) select(activeValue);
+      if (activeValue != null) onSelect(activeValue);
     },
-    [activeValue, disabled, onActiveDescendantKeyDown, select],
+    [activeValue, disabled, onActiveDescendantKeyDown, onSelect],
   );
 
   const onFocus = useCallback(() => {
@@ -127,11 +95,10 @@ export const useListbox = ({
     () => ({
       id: listboxId,
       role: "listbox" as const,
-      "aria-multiselectable": mode === "multiple" ? true : undefined,
       "aria-orientation": "vertical" as const,
       "aria-disabled": disabled || undefined,
     }),
-    [listboxId, mode, disabled],
+    [listboxId, disabled],
   );
 
   const getFocusableListboxProps = useCallback(
@@ -145,29 +112,27 @@ export const useListbox = ({
     [getListboxProps, disabled, activeId, onKeyDown, onFocus],
   );
 
-  const contextValue = useMemo<ListboxContextValue>(
+  const contextValue = useMemo<ListboxBehaviorContextValue>(
     () => ({
       listboxId,
       disabled,
-      variant,
-      mode,
       isSelected,
       activeValue,
-      select,
+      select: onSelect,
       setActive: setActiveValue,
     }),
-    [listboxId, disabled, variant, mode, isSelected, activeValue, select, setActiveValue],
+    [listboxId, disabled, isSelected, activeValue, onSelect, setActiveValue],
   );
 
   return {
     listboxRef,
     listboxId,
     contextValue,
-    selectedValues,
     activeId,
     activateSelected,
     scrollToSelected,
     onKeyDown,
+    onActiveDescendantKeyDown,
     getListboxProps,
     getFocusableListboxProps,
   };

--- a/packages/jds/src/components/Listbox/useListbox.ts
+++ b/packages/jds/src/components/Listbox/useListbox.ts
@@ -1,14 +1,12 @@
 import { useCallback, useId, useLayoutEffect, useMemo, useRef, type KeyboardEvent } from "react";
 
 import { SELECTION_KEYS } from "./listbox.constants";
-import type { SelectOption } from "./listbox.types";
 import { getOptionId, scrollSelectedOptionIntoView } from "./listbox.utils";
 import type { ListboxBehaviorContextValue } from "./ListboxContext";
 
 import { useActiveDescendant } from "@/hooks/useActiveDescendant";
 
 interface UseListboxParams {
-  options: SelectOption[];
   selectedValues: string[];
   disabled: boolean;
   onSelect: (value: string) => void;
@@ -16,7 +14,6 @@ interface UseListboxParams {
 }
 
 export const useListbox = ({
-  options,
   selectedValues,
   disabled,
   onSelect,
@@ -30,8 +27,9 @@ export const useListbox = ({
 
   const {
     containerRef: listboxRef,
-    activeValue: rawActiveValue,
+    activeValue,
     setActiveValue,
+    getEnabledValues,
     onKeyDown: onActiveDescendantKeyDown,
   } = useActiveDescendant<HTMLDivElement>({ disabled });
 
@@ -46,29 +44,21 @@ export const useListbox = ({
     if (!autoScrollToSelected || !shouldAutoScrollRef.current) return;
 
     const el = listboxRef.current;
-    if (el == null || options.length === 0) return;
+    if (el == null || el.childElementCount === 0) return;
 
     shouldAutoScrollRef.current = false;
 
     scrollToSelected();
-  }, [listboxRef, options.length, scrollToSelected, autoScrollToSelected]);
-
-  const activeValue = useMemo(() => {
-    if (rawActiveValue == null) return null;
-
-    const option = options.find(o => o.value === rawActiveValue);
-    return option != null && !option.disabled ? rawActiveValue : null;
-  }, [options, rawActiveValue]);
+  }, [listboxRef, scrollToSelected, autoScrollToSelected]);
 
   const activeId = activeValue != null ? getOptionId(listboxId, activeValue) : undefined;
 
   const activateSelected = useCallback(() => {
-    const enabledOptions = options.filter(option => !option.disabled);
-    if (enabledOptions.length === 0) return;
+    const values = getEnabledValues();
+    if (values.length === 0) return;
 
-    const selected = enabledOptions.find(option => selectedValues.includes(option.value));
-    setActiveValue(selected?.value ?? enabledOptions[0].value);
-  }, [options, selectedValues, setActiveValue]);
+    setActiveValue(values.find(value => selectedValues.includes(value)) ?? values[0]);
+  }, [getEnabledValues, selectedValues, setActiveValue]);
 
   const onKeyDown = useCallback(
     (e: KeyboardEvent) => {

--- a/packages/jds/src/components/Listbox/useMultiSelectState.ts
+++ b/packages/jds/src/components/Listbox/useMultiSelectState.ts
@@ -1,0 +1,25 @@
+import { useControllableState } from "hooks";
+import { useCallback } from "react";
+
+export const useMultiSelectState = (
+  value: string[] | undefined,
+  defaultValue: string[] | undefined,
+  onChange?: (value: string[]) => void,
+) => {
+  const [selectedValues, setSelectedValues] = useControllableState<string[]>(
+    value,
+    defaultValue ?? [],
+    onChange,
+  );
+
+  const toggle = useCallback(
+    (next: string) => {
+      setSelectedValues(prev =>
+        prev.includes(next) ? prev.filter(v => v !== next) : [...prev, next],
+      );
+    },
+    [setSelectedValues],
+  );
+
+  return { selectedValues, toggle };
+};

--- a/packages/jds/src/components/Listbox/useSingleSelectState.ts
+++ b/packages/jds/src/components/Listbox/useSingleSelectState.ts
@@ -1,0 +1,23 @@
+import { useControllableState } from "hooks";
+import { useMemo } from "react";
+
+export const useSingleSelectState = (
+  value: string | null | undefined,
+  defaultValue: string | undefined,
+  onChange?: (value: string) => void,
+) => {
+  const [selectedValue, select] = useControllableState<string | null>(
+    value,
+    defaultValue ?? null,
+    next => {
+      if (next != null) onChange?.(next);
+    },
+  );
+
+  const selectedValues = useMemo(
+    () => (selectedValue == null ? [] : [selectedValue]),
+    [selectedValue],
+  );
+
+  return { selectedValue, selectedValues, select };
+};

--- a/packages/jds/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/jds/src/components/MultiSelect/MultiSelect.tsx
@@ -1,4 +1,5 @@
-import { forwardRef } from "react";
+import { useControllableState } from "hooks";
+import { forwardRef, useCallback } from "react";
 
 import type { MultiSelectProps } from "./multiSelect.types";
 import { Listbox, useListbox } from "../Listbox";
@@ -20,20 +21,34 @@ export const MultiSelect = forwardRef<HTMLDivElement, MultiSelectProps>(
     },
     ref,
   ) => {
-    const { listboxRef, contextValue, getFocusableListboxProps } = useListbox({
-      mode: "multiple",
-      variant,
-      options,
+    const [selectedValues, setSelectedValues] = useControllableState<string[]>(
       value,
-      defaultValue,
-      onChange: onChange as ((value: string | string[]) => void) | undefined,
+      defaultValue ?? [],
+      onChange,
+    );
+
+    const toggle = useCallback(
+      (next: string) => {
+        setSelectedValues(prev =>
+          prev.includes(next) ? prev.filter(v => v !== next) : [...prev, next],
+        );
+      },
+      [setSelectedValues],
+    );
+
+    const { listboxRef, contextValue, getFocusableListboxProps } = useListbox({
+      options,
+      selectedValues,
       disabled,
+      onSelect: toggle,
     });
 
     return (
       <Listbox
         ref={ref}
         context={contextValue}
+        selectionMode='multiple'
+        variant={variant}
         label={label}
         width={width}
         height={height}

--- a/packages/jds/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/jds/src/components/MultiSelect/MultiSelect.tsx
@@ -57,15 +57,15 @@ export const MultiSelect = forwardRef<HTMLDivElement, MultiSelectProps>(
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledby}
       >
-        {options.map(({ value: optionValue, label: optionLabel, caption, suffix, disabled }) => (
+        {options.map(option => (
           <Listbox.Option
-            key={optionValue}
-            value={optionValue}
-            caption={caption}
-            suffix={suffix}
-            disabled={disabled}
+            key={option.value}
+            value={option.value}
+            caption={option.caption}
+            suffix={option.suffix}
+            disabled={option.disabled}
           >
-            {optionLabel}
+            {option.label}
           </Listbox.Option>
         ))}
       </Listbox>

--- a/packages/jds/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/jds/src/components/MultiSelect/MultiSelect.tsx
@@ -34,7 +34,6 @@ export const MultiSelect = forwardRef<HTMLDivElement, MultiSelectProps>(
       <Listbox
         ref={ref}
         context={contextValue}
-        options={options}
         label={label}
         width={width}
         height={height}
@@ -42,7 +41,19 @@ export const MultiSelect = forwardRef<HTMLDivElement, MultiSelectProps>(
         listboxProps={getFocusableListboxProps()}
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledby}
-      />
+      >
+        {options.map(({ value: optionValue, label: optionLabel, caption, suffix, disabled }) => (
+          <Listbox.Option
+            key={optionValue}
+            value={optionValue}
+            caption={caption}
+            suffix={suffix}
+            disabled={disabled}
+          >
+            {optionLabel}
+          </Listbox.Option>
+        ))}
+      </Listbox>
     );
   },
 );

--- a/packages/jds/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/jds/src/components/MultiSelect/MultiSelect.tsx
@@ -23,7 +23,6 @@ export const MultiSelect = forwardRef<HTMLDivElement, MultiSelectProps>(
     const { selectedValues, toggle } = useMultiSelectState(value, defaultValue, onChange);
 
     const { listboxRef, contextValue, getFocusableListboxProps } = useListbox({
-      options,
       selectedValues,
       disabled,
       onSelect: toggle,

--- a/packages/jds/src/components/MultiSelect/MultiSelect.tsx
+++ b/packages/jds/src/components/MultiSelect/MultiSelect.tsx
@@ -1,8 +1,7 @@
-import { useControllableState } from "hooks";
-import { forwardRef, useCallback } from "react";
+import { forwardRef } from "react";
 
 import type { MultiSelectProps } from "./multiSelect.types";
-import { Listbox, useListbox } from "../Listbox";
+import { Listbox, useListbox, useMultiSelectState } from "../Listbox";
 
 export const MultiSelect = forwardRef<HTMLDivElement, MultiSelectProps>(
   (
@@ -21,20 +20,7 @@ export const MultiSelect = forwardRef<HTMLDivElement, MultiSelectProps>(
     },
     ref,
   ) => {
-    const [selectedValues, setSelectedValues] = useControllableState<string[]>(
-      value,
-      defaultValue ?? [],
-      onChange,
-    );
-
-    const toggle = useCallback(
-      (next: string) => {
-        setSelectedValues(prev =>
-          prev.includes(next) ? prev.filter(v => v !== next) : [...prev, next],
-        );
-      },
-      [setSelectedValues],
-    );
+    const { selectedValues, toggle } = useMultiSelectState(value, defaultValue, onChange);
 
     const { listboxRef, contextValue, getFocusableListboxProps } = useListbox({
       options,

--- a/packages/jds/src/components/Select/Select.tsx
+++ b/packages/jds/src/components/Select/Select.tsx
@@ -1,8 +1,7 @@
-import { useControllableState } from "hooks";
-import { forwardRef, useCallback, useMemo } from "react";
+import { forwardRef } from "react";
 
 import type { SelectProps } from "./select.types";
-import { Listbox, useListbox } from "../Listbox";
+import { Listbox, useListbox, useSingleSelectState } from "../Listbox";
 
 export const Select = forwardRef<HTMLDivElement, SelectProps>(
   (
@@ -21,29 +20,13 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
     },
     ref,
   ) => {
-    const handleChange = useCallback(
-      (next: string | null) => {
-        if (next != null) onChange?.(next);
-      },
-      [onChange],
-    );
-
-    const [selectedValue, setSelectedValue] = useControllableState<string | null>(
-      value,
-      defaultValue ?? null,
-      handleChange,
-    );
-
-    const selectedValues = useMemo(
-      () => (selectedValue == null ? [] : [selectedValue]),
-      [selectedValue],
-    );
+    const { selectedValues, select } = useSingleSelectState(value, defaultValue, onChange);
 
     const { listboxRef, contextValue, getFocusableListboxProps } = useListbox({
       options,
       selectedValues,
       disabled,
-      onSelect: setSelectedValue,
+      onSelect: select,
     });
 
     return (

--- a/packages/jds/src/components/Select/Select.tsx
+++ b/packages/jds/src/components/Select/Select.tsx
@@ -34,7 +34,6 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
       <Listbox
         ref={ref}
         context={contextValue}
-        options={options}
         label={label}
         width={width}
         height={height}
@@ -42,7 +41,19 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
         listboxProps={getFocusableListboxProps()}
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledby}
-      />
+      >
+        {options.map(({ value: optionValue, label: optionLabel, caption, suffix, disabled }) => (
+          <Listbox.Option
+            key={optionValue}
+            value={optionValue}
+            caption={caption}
+            suffix={suffix}
+            disabled={disabled}
+          >
+            {optionLabel}
+          </Listbox.Option>
+        ))}
+      </Listbox>
     );
   },
 );

--- a/packages/jds/src/components/Select/Select.tsx
+++ b/packages/jds/src/components/Select/Select.tsx
@@ -1,4 +1,5 @@
-import { forwardRef } from "react";
+import { useControllableState } from "hooks";
+import { forwardRef, useCallback, useMemo } from "react";
 
 import type { SelectProps } from "./select.types";
 import { Listbox, useListbox } from "../Listbox";
@@ -20,20 +21,37 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
     },
     ref,
   ) => {
-    const { listboxRef, contextValue, getFocusableListboxProps } = useListbox({
-      mode: "single",
-      variant,
-      options,
+    const handleChange = useCallback(
+      (next: string | null) => {
+        if (next != null) onChange?.(next);
+      },
+      [onChange],
+    );
+
+    const [selectedValue, setSelectedValue] = useControllableState<string | null>(
       value,
-      defaultValue,
-      onChange: onChange as ((value: string | string[]) => void) | undefined,
+      defaultValue ?? null,
+      handleChange,
+    );
+
+    const selectedValues = useMemo(
+      () => (selectedValue == null ? [] : [selectedValue]),
+      [selectedValue],
+    );
+
+    const { listboxRef, contextValue, getFocusableListboxProps } = useListbox({
+      options,
+      selectedValues,
       disabled,
+      onSelect: setSelectedValue,
     });
 
     return (
       <Listbox
         ref={ref}
         context={contextValue}
+        selectionMode='single'
+        variant={variant}
         label={label}
         width={width}
         height={height}

--- a/packages/jds/src/components/Select/Select.tsx
+++ b/packages/jds/src/components/Select/Select.tsx
@@ -23,7 +23,6 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
     const { selectedValues, select } = useSingleSelectState(value, defaultValue, onChange);
 
     const { listboxRef, contextValue, getFocusableListboxProps } = useListbox({
-      options,
       selectedValues,
       disabled,
       onSelect: select,

--- a/packages/jds/src/components/Select/Select.tsx
+++ b/packages/jds/src/components/Select/Select.tsx
@@ -60,15 +60,15 @@ export const Select = forwardRef<HTMLDivElement, SelectProps>(
         aria-label={ariaLabel}
         aria-labelledby={ariaLabelledby}
       >
-        {options.map(({ value: optionValue, label: optionLabel, caption, suffix, disabled }) => (
+        {options.map(option => (
           <Listbox.Option
-            key={optionValue}
-            value={optionValue}
-            caption={caption}
-            suffix={suffix}
-            disabled={disabled}
+            key={option.value}
+            value={option.value}
+            caption={option.caption}
+            suffix={option.suffix}
+            disabled={option.disabled}
           >
-            {optionLabel}
+            {option.label}
           </Listbox.Option>
         ))}
       </Listbox>

--- a/packages/jds/src/components/SelectField/compound/Trigger.tsx
+++ b/packages/jds/src/components/SelectField/compound/Trigger.tsx
@@ -1,7 +1,9 @@
 import { clsx } from "clsx";
+import { useControllableState } from "hooks";
 import { Popover } from "radix-ui";
 import {
   forwardRef,
+  useCallback,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -57,28 +59,42 @@ export const SelectFieldTrigger = forwardRef<HTMLButtonElement, SelectFieldTrigg
     const isDisabled = disabledFromProps ?? isDisabledFromCtx;
     const isInteractive = !isDisabled && !isReadOnly;
 
+    const handleChange = useCallback(
+      (next: string | null) => {
+        if (next != null) onChange?.(next);
+      },
+      [onChange],
+    );
+
+    const [selectedValue, setSelectedValue] = useControllableState<string | null>(
+      value,
+      defaultValue ?? null,
+      handleChange,
+    );
+
+    const selectedValues = useMemo(
+      () => (selectedValue == null ? [] : [selectedValue]),
+      [selectedValue],
+    );
+
     const {
       listboxRef,
       listboxId,
       contextValue,
-      selectedValues,
       activeId,
       activateSelected,
       scrollToSelected,
       onKeyDown: onListboxKeyDown,
       getListboxProps,
     } = useListbox({
-      mode: "single",
-      variant,
       options,
-      value,
-      defaultValue,
-      onChange: onChange as ((value: string | string[]) => void) | undefined,
+      selectedValues,
       disabled: isDisabled,
+      onSelect: setSelectedValue,
       autoScrollToSelected: false,
     });
 
-    const selectedLabel = options.find(option => option.value === selectedValues[0])?.label;
+    const selectedLabel = options.find(option => option.value === selectedValue)?.label;
 
     const activateSelectedRef = useRef(activateSelected);
     activateSelectedRef.current = activateSelected;
@@ -187,6 +203,8 @@ export const SelectFieldTrigger = forwardRef<HTMLButtonElement, SelectFieldTrigg
               role='presentation'
               className={styles.popup}
               context={popupContextValue}
+              selectionMode='single'
+              variant={variant}
               listboxRef={listboxRef}
               listboxProps={{
                 ...getListboxProps(),

--- a/packages/jds/src/components/SelectField/compound/Trigger.tsx
+++ b/packages/jds/src/components/SelectField/compound/Trigger.tsx
@@ -213,19 +213,17 @@ export const SelectFieldTrigger = forwardRef<HTMLButtonElement, SelectFieldTrigg
               }}
               onMouseDown={e => e.preventDefault()}
             >
-              {options.map(
-                ({ value: optionValue, label: optionLabel, caption, suffix, disabled }) => (
-                  <Listbox.Option
-                    key={optionValue}
-                    value={optionValue}
-                    caption={caption}
-                    suffix={suffix}
-                    disabled={disabled}
-                  >
-                    {optionLabel}
-                  </Listbox.Option>
-                ),
-              )}
+              {options.map(option => (
+                <Listbox.Option
+                  key={option.value}
+                  value={option.value}
+                  caption={option.caption}
+                  suffix={option.suffix}
+                  disabled={option.disabled}
+                >
+                  {option.label}
+                </Listbox.Option>
+              ))}
             </Listbox>
           </Popover.Content>
         </Popover.Portal>

--- a/packages/jds/src/components/SelectField/compound/Trigger.tsx
+++ b/packages/jds/src/components/SelectField/compound/Trigger.tsx
@@ -1,9 +1,7 @@
 import { clsx } from "clsx";
-import { useControllableState } from "hooks";
 import { Popover } from "radix-ui";
 import {
   forwardRef,
-  useCallback,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -13,7 +11,7 @@ import {
 
 import { useFieldContext } from "../../Field/Field.context";
 import { Icon } from "../../Icon";
-import { Listbox, useListbox } from "../../Listbox";
+import { Listbox, useListbox, useSingleSelectState } from "../../Listbox";
 import { SELECTION_KEYS } from "../../Listbox/listbox.constants";
 import { useSelectFieldContext } from "../SelectField.context";
 import * as styles from "../selectField.css";
@@ -59,22 +57,10 @@ export const SelectFieldTrigger = forwardRef<HTMLButtonElement, SelectFieldTrigg
     const isDisabled = disabledFromProps ?? isDisabledFromCtx;
     const isInteractive = !isDisabled && !isReadOnly;
 
-    const handleChange = useCallback(
-      (next: string | null) => {
-        if (next != null) onChange?.(next);
-      },
-      [onChange],
-    );
-
-    const [selectedValue, setSelectedValue] = useControllableState<string | null>(
+    const { selectedValue, selectedValues, select } = useSingleSelectState(
       value,
-      defaultValue ?? null,
-      handleChange,
-    );
-
-    const selectedValues = useMemo(
-      () => (selectedValue == null ? [] : [selectedValue]),
-      [selectedValue],
+      defaultValue,
+      onChange,
     );
 
     const {
@@ -90,7 +76,7 @@ export const SelectFieldTrigger = forwardRef<HTMLButtonElement, SelectFieldTrigg
       options,
       selectedValues,
       disabled: isDisabled,
-      onSelect: setSelectedValue,
+      onSelect: select,
       autoScrollToSelected: false,
     });
 

--- a/packages/jds/src/components/SelectField/compound/Trigger.tsx
+++ b/packages/jds/src/components/SelectField/compound/Trigger.tsx
@@ -187,7 +187,6 @@ export const SelectFieldTrigger = forwardRef<HTMLButtonElement, SelectFieldTrigg
               role='presentation'
               className={styles.popup}
               context={popupContextValue}
-              options={options}
               listboxRef={listboxRef}
               listboxProps={{
                 ...getListboxProps(),
@@ -195,7 +194,21 @@ export const SelectFieldTrigger = forwardRef<HTMLButtonElement, SelectFieldTrigg
                 "aria-labelledby": labelId,
               }}
               onMouseDown={e => e.preventDefault()}
-            />
+            >
+              {options.map(
+                ({ value: optionValue, label: optionLabel, caption, suffix, disabled }) => (
+                  <Listbox.Option
+                    key={optionValue}
+                    value={optionValue}
+                    caption={caption}
+                    suffix={suffix}
+                    disabled={disabled}
+                  >
+                    {optionLabel}
+                  </Listbox.Option>
+                ),
+              )}
+            </Listbox>
           </Popover.Content>
         </Popover.Portal>
       </>

--- a/packages/jds/src/components/SelectField/compound/Trigger.tsx
+++ b/packages/jds/src/components/SelectField/compound/Trigger.tsx
@@ -73,7 +73,6 @@ export const SelectFieldTrigger = forwardRef<HTMLButtonElement, SelectFieldTrigg
       onKeyDown: onListboxKeyDown,
       getListboxProps,
     } = useListbox({
-      options,
       selectedValues,
       disabled: isDisabled,
       onSelect: select,
@@ -119,10 +118,11 @@ export const SelectFieldTrigger = forwardRef<HTMLButtonElement, SelectFieldTrigg
     useLayoutEffect(() => {
       if (!isOpen) return;
 
-      activateSelectedRef.current();
-
-      // Radix가 available-height를 반영한 뒤에야 스크롤 영역이 생기므로 다음 프레임에서 실행
-      const frame = requestAnimationFrame(() => scrollToSelected());
+      // Radix가 다음 커밋에서 팝업을 DOM에 추가하므로, 목록이 렌더링된 뒤 활성 항목과 스크롤을 맞춘다
+      const frame = requestAnimationFrame(() => {
+        activateSelectedRef.current();
+        scrollToSelected();
+      });
       return () => cancelAnimationFrame(frame);
     }, [isOpen, scrollToSelected]);
 

--- a/packages/jds/src/hooks/useActiveDescendant.ts
+++ b/packages/jds/src/hooks/useActiveDescendant.ts
@@ -1,4 +1,11 @@
-import { useCallback, useRef, useState, type KeyboardEvent, type RefObject } from "react";
+import {
+  useCallback,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type KeyboardEvent,
+  type RefObject,
+} from "react";
 
 import { VIRTUAL_FOCUS_ATTRIBUTE } from "@/utils/virtualFocus";
 
@@ -26,6 +33,7 @@ interface ActiveDescendantGroup<T extends HTMLElement> {
   containerRef: RefObject<T>;
   activeValue: string | null;
   setActiveValue: (value: string | null) => void;
+  getEnabledValues: () => string[];
   onKeyDown: (e: KeyboardEvent) => void;
 }
 
@@ -126,5 +134,16 @@ export function useActiveDescendant<T extends HTMLElement>({
     [disabled, move],
   );
 
-  return { containerRef, activeValue, setActiveValue, onKeyDown };
+  const getEnabledValues = useCallback(() => getItemValues().values, [getItemValues]);
+
+  // 현재 항목 목록은 DOM 조회로 구성하므로 별도의 의존성으로 추적할 수 없다.
+  // 의존성 배열을 추가하면 항목 추가 및 제거 시점과 동기화되지 않는다.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useLayoutEffect(() => {
+    if (activeValue == null || containerRef.current == null) return;
+
+    if (!getEnabledValues().includes(activeValue)) setActiveValue(null);
+  });
+
+  return { containerRef, activeValue, setActiveValue, getEnabledValues, onKeyDown };
 }


### PR DESCRIPTION
## 💡 작업 내용

- [x] `Listbox`가 옵션 목록을 children으로 받도록 컴파운드 구조로 전환
- [x] `useListbox`에서 선택 상태 관리를 소비처로 이동하고 `mode` 제거
- [x] 단일 / 다중 선택 상태를 전용 훅으로 분리
- [x] 표현 설정을 `Listbox` prop으로 이동
- [x] `useListbox`가 옵션 배열 대신 렌더된 항목을 기준으로 동작하도록 변경

## 💡 자세한 설명

### 1. 개요

`Listbox`(표현)와 `useListbox`(동작)로 레이어를 나눠 두었지만, 실제로는 서로의 책임을 나눠 가지고 있었습니다. [(관련 스레드)](https://github.com/JECT-Study/JECT-Official-WebSite-Client/pull/554#discussion_r3697746770)

`variant`, 마크 종류, `aria-multiselectable`이 훅에 전달되어 컨텍스트로 내려가고 있었고, 반대로 소비처가 결정해야 할 값과 선택 방식까지 훅이 겸하고 있었습니다. `Listbox` 역시 `options` 배열을 행으로 변환하는 방식이 고정되어 있어 옵션 외의 요소를 함께 렌더링할 수 없었습니다.

소비처 / 코어 / 표현 계층이 각각 자기 책임을 갖도록 정리했습니다. 이후 구현할 `MultiSelectField`에서 옵션 목록에 자체 요소를 추가하려면 현재 구조로는 `Listbox`에 별도 분기를 추가해야 하는데, 이번 변경으로 이 제약도 함께 해소할 수 있습니다.

공개 API 변화는 없습니다. `Select`, `MultiSelect`, `SelectField`의 props는 그대로이고, `Listbox`는 `components` 배럴에 포함되지 않는 내부 컴포넌트입니다.

---

### 2. 옵션 목록을 children으로 전환

`Listbox`가 `options`를 받아 내부에서 행으로 매핑하던 것을 `children`으로 바꾸고, `Option`을 `Field`와 동일한 구조로 `compound` 디렉터리에 두어 `Listbox.Option`으로 노출했습니다.

```tsx
<Listbox context={contextValue} selectionMode='single' variant={variant}>
  {options.map(option => (
    <Listbox.Option key={option.value} value={option.value} disabled={option.disabled}>
      {option.label}
    </Listbox.Option>
  ))}
</Listbox>
```

소비처가 항목을 직접 렌더링하므로, 옵션이 아닌 행을 추가할 때 `SelectOption` 타입이나 `Listbox`의 prop을 확장하지 않아도 됩니다.

---

### 3. 선택 상태를 소비처로 이동

`mode`는 세 소비처에서 모두 리터럴로 전달되어 런타임에 달라질 수 없는 값이었지만, 기본값 처리와 `select()`, `aria-multiselectable`, 컨텍스트를 통해 내려가는 `Option`의 마크 선택까지 네 곳에서 분기를 만들고 있었습니다.

단일 선택과 다중 선택을 하나의 훅에서 처리하다 보니 값 타입도 두 형태를 모두 포함하도록 넓어졌고, 이를 다시 좁히기 위한 캐스트가 네 곳에 필요했습니다.

값과 선택 방식을 소비처가 소유하도록 옮기고 `mode`를 제거했습니다. `useListbox`에는 선택 방식과 무관한 동작만 남겼습니다. 선택 상태는 `selectedValues`로 읽기만 하고, 실제 선택은 소비처가 전달하는 `onSelect`에 위임합니다.

---

### 4. 표현 설정을 `Listbox`로 이동

`variant`와 마크 종류, `aria-multiselectable`과 같은 표현 값에 대한 결정이 헤드리스 훅 내부에 있었습니다. 이를 `Listbox`가 `selectionMode`와 `variant`를 받아 훅이 제공하는 동작 컨텍스트에 표현 관련 값을 함께 구성하도록 변경했습니다. 컨텍스트 타입도 동작에 필요한 값과 전체 컨텍스트를 분리했습니다.

선택 모델을 소비처가 소유하게 되면서 `useListbox`는 다중 선택 여부를 알 필요가 없으므로 `aria-multiselectable`은 `getListboxProps()`에서 제거하고, `Listbox`가 `selectionMode`에 따라 직접 부여하도록 옮겼습니다.

---

### 5. 옵션 배열 의존 제거

`Listbox`가 children을 받게 되면서 `useListbox`에 전달하는 배열과 실제로 화면에 그려지는 항목이 서로 달라질 수 있게 됐습니다. 배열에 없는 항목은 활성화되지 않아 키보드로 도달할 수 없게 됩니다.

`useListbox`가 옵션 배열을 받지 않도록 변경하고, 배열을 사용하던 세 곳을 모두 렌더된 항목을 기준으로 동작하도록 변경했습니다. 활성 항목의 유효성 검사는 `useActiveDescendant`로 옮겼고, 첫 활성 대상 선정과 자동 스크롤 여부도 DOM에서 판단하므로 훅은 이제 옵션 데이터의 형태에 의존하지 않습니다.

항목 이동 자체는 기존에도 DOM 순서를 기준으로 하고 있었으므로 이번 변경으로 활성 항목의 유효성 검사도 같은 기준을 사용하게 됩니다.

이 구조는 [`useRovingFocus`](https://github.com/JECT-Study/JECT-Official-WebSite-Client/blob/6135c1c44725d78d405bf3e69ce36cbc223176e2/packages/jds/src/hooks/useRovingFocus.tsx)와 동일합니다. 다만 유효성 검사가 렌더 후로 밀려 한 프레임 늦게 정리되고, 활성 항목 설정도 목록이 DOM에 반영된 뒤에 가능하므로 `SelectField`에서는 이를 기존 스크롤 처리와 같은 프레임으로 옮겼습니다.

## 📗 참고 자료 (선택)

## 📢 리뷰 요구 사항 (선택)

옵션을 항목으로 렌더링하는 코드가 `Select`, `MultiSelect`, `SelectField.Trigger` 세 곳에 중복됩니다. 컴파운드 구조에서 발생하는 중복으로 보고 우선 두었는데, 렌더 헬퍼로 묶는 편이 나을지 의견 주시면 좋겠습니다.

## ✅ 셀프 체크리스트

- [x] 머지할 브랜치 확인했나요?
- [x] 이슈는 close 했나요?
- [x] Reviewers, Labels, Projects를 등록했나요?
- [x] 기능이 잘 동작하나요?
- [x] 불필요한 코드는 제거했나요?

closes #580 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 단일 선택과 다중 선택 상태를 일관되게 관리할 수 있습니다.
  * `Listbox`에서 옵션을 직접 구성하고 `Listbox.Option`으로 사용할 수 있습니다.
  * 선택 상태와 변경 콜백을 외부에서 제어할 수 있습니다.
* **개선 사항**
  * `Select`, `MultiSelect`, `SelectField`의 옵션 렌더링과 선택 동작이 개선되었습니다.
  * 키보드 탐색과 활성 옵션 자동 스크롤이 현재 표시된 옵션을 기준으로 동작합니다.
  * 다중 선택 Listbox에 적절한 접근성 정보가 제공됩니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->